### PR TITLE
Updating helpers for new AMF namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -378,5 +378,6 @@
 * Updating AMF models and tests ([091fa97949b12e773cead36aa087636847c86f06](https://github.com/advanced-rest-client/amf-helper-mixin/commit/091fa97949b12e773cead36aa087636847c86f06))
 * Updating the library to work with new AMF model. ([4bb9664cda4f32bea5907ba007750d8d87ec0f7e](https://github.com/advanced-rest-client/amf-helper-mixin/commit/4bb9664cda4f32bea5907ba007750d8d87ec0f7e))
 
+### Update
 
-
+* Updating namespaces in the AMF model, updating tests ([8d3830b41d43f5d20a2e46e3a4c8c4efcb9589d6](https://github.com/antoniogarrote/amf-helper-mixin/commit/8d3830b41d43f5d20a2e46e3a4c8c4efcb9589d6))

--- a/amf-helper-mixin.js
+++ b/amf-helper-mixin.js
@@ -20,7 +20,9 @@ ns.raml.name = 'http://a.ml/';
 ns.raml.vocabularies = {};
 ns.raml.vocabularies.name = ns.raml.name + 'vocabularies/';
 ns.raml.vocabularies.document = ns.raml.vocabularies.name + 'document#';
-ns.raml.vocabularies.http = ns.raml.vocabularies.name + 'http#';
+ns.raml.vocabularies.core = ns.raml.vocabularies.name + 'core#';
+ns.raml.vocabularies.apiContract = ns.raml.vocabularies.name + 'apiContract#';
+ns.raml.vocabularies.http = ns.raml.vocabularies.apiContract;
 ns.raml.vocabularies.security = ns.raml.vocabularies.name + 'security#';
 ns.raml.vocabularies.shapes = ns.raml.vocabularies.name + 'shapes#';
 ns.raml.vocabularies.data = ns.raml.vocabularies.name + 'data#';
@@ -32,7 +34,7 @@ ns.w3 = {};
 ns.w3.name = 'http://www.w3.org/';
 ns.w3.hydra = {};
 ns.w3.hydra.name = ns.w3.name + 'ns/hydra/';
-ns.w3.hydra.core = ns.w3.hydra.name + 'core#';
+ns.w3.hydra.core = ns.raml.vocabularies.apiContract;
 ns.w3.xmlSchema = ns.w3.name + '2001/XMLSchema#';
 // w3 types
 ns.w3.shacl = {};
@@ -48,17 +50,17 @@ ns.w3.shacl.maxLength = ns.w3.shacl.name + 'maxLength';
 ns.w3.shacl.fileType = ns.w3.shacl.name + 'fileType';
 ns.w3.shacl.shape = ns.w3.shacl.name + 'Shape';
 // Hydra shortcuts
-ns.w3.hydra.supportedOperation = ns.w3.hydra.core + 'supportedOperation';
+ns.w3.hydra.supportedOperation = ns.raml.vocabularies.apiContract + 'supportedOperation';
 // Schema org namespace
 ns.schema = {};
-ns.schema.name = 'http://schema.org/';
+ns.schema.name = ns.raml.vocabularies.core;
 ns.schema.schemaName = ns.schema.name + 'name';
 ns.schema.desc = ns.schema.name + 'description';
 ns.schema.doc = ns.schema.name + 'documentation';
-ns.schema.webApi = ns.schema.name + 'WebAPI';
-ns.schema.creativeWork = ns.schema.name + 'CreativeWork';
-ns.schema.displayName = ns.schema.name + 'displayName';
-ns.schema.title = ns.schema.name + 'title';
+ns.schema.webApi = ns.raml.vocabularies.apiContract + 'WebAPI';
+ns.schema.creativeWork = ns.raml.vocabularies.core + 'CreativeWork';
+ns.schema.displayName = ns.raml.vocabularies.core + 'displayName';
+ns.schema.title = ns.raml.vocabularies.core + 'title';
 
 Object.freeze(ns.raml);
 Object.freeze(ns.raml.vocabularies);
@@ -332,15 +334,15 @@ export const AmfHelperMixin = dedupingMixin((base) => {
     }
 
     _computeHeaders(shape) {
-      return this._computePropertyArray(shape, ns.raml.vocabularies.http + 'header');
+      return this._computePropertyArray(shape, ns.raml.vocabularies.apiContract + 'header');
     }
 
     _computeQueryParameters(shape) {
-      return this._computePropertyArray(shape, ns.raml.vocabularies.http + 'parameter');
+      return this._computePropertyArray(shape, ns.raml.vocabularies.apiContract + 'parameter');
     }
 
     _computeResponses(shape) {
-      return this._computePropertyArray(shape, ns.w3.hydra.core + 'response');
+      return this._computePropertyArray(shape, ns.raml.vocabularies.apiContract + 'response');
     }
     /**
      * Computes value for `serverVariables` property.
@@ -349,7 +351,7 @@ export const AmfHelperMixin = dedupingMixin((base) => {
      * @return {Array<Object>|undefined} Variables if defined.
      */
     _computeServerVariables(server) {
-      return this._computePropertyArray(server, ns.raml.vocabularies.http + 'variable');
+      return this._computePropertyArray(server, ns.raml.vocabularies.apiContract + 'variable');
     }
     /**
      * Computes value for `endpointVariables` property.
@@ -367,7 +369,7 @@ export const AmfHelperMixin = dedupingMixin((base) => {
      * @return {Array<Object>|undefined} Payload model if defined.
      */
     _computePayload(expects) {
-      return this._computePropertyArray(expects, ns.raml.vocabularies.http + 'payload');
+      return this._computePropertyArray(expects, ns.raml.vocabularies.apiContract + 'payload');
     }
     /**
      * Computes value for `returns` property
@@ -376,7 +378,7 @@ export const AmfHelperMixin = dedupingMixin((base) => {
      * @return {Array<Object>|undefined}
      */
     _computeReturns(method) {
-      return this._computePropertyArray(method, ns.w3.hydra.core + 'returns');
+      return this._computePropertyArray(method, ns.raml.vocabularies.apiContract + 'returns');
     }
     /**
      * Computes value for `security` property
@@ -407,7 +409,7 @@ export const AmfHelperMixin = dedupingMixin((base) => {
       if (!api) {
         return;
       }
-      return this._getValue(api, ns.schema.name + 'version');
+      return this._getValue(api, ns.raml.vocabularies.core + 'version');
     }
     /**
      * Computes model's `encodes` property.
@@ -494,7 +496,7 @@ export const AmfHelperMixin = dedupingMixin((base) => {
       if (!api) {
         return;
       }
-      const key = this._getAmfKey(ns.raml.vocabularies.http + 'server');
+      const key = this._getAmfKey(ns.raml.vocabularies.apiContract + 'server');
       const srv = this._ensureArray(api[key]);
       return srv ? srv[0] : undefined;
     }
@@ -513,7 +515,7 @@ export const AmfHelperMixin = dedupingMixin((base) => {
         base = base.substr(0, base.length - 1);
       }
       base = this._ensureUrlScheme(base);
-      const path = this._getValue(endpoint, ns.raml.vocabularies.http + 'path');
+      const path = this._getValue(endpoint, ns.raml.vocabularies.apiContract + 'path');
       let result = base + (path || '');
       if (version && result) {
         result = result.replace('{version}', version);
@@ -551,7 +553,7 @@ export const AmfHelperMixin = dedupingMixin((base) => {
      * @return {String|undefined} Base uri value if exists.
      */
     _getAmfBaseUri(server, protocols) {
-      let value = this._getValue(server, ns.raml.vocabularies.http + 'url');
+      let value = this._getValue(server, ns.raml.vocabularies.apiContract + 'url');
       value = this._ensureUrlScheme(value, protocols);
       return value;
     }
@@ -592,7 +594,7 @@ export const AmfHelperMixin = dedupingMixin((base) => {
       if (!api) {
         return;
       }
-      return this._getValueArray(api, ns.raml.vocabularies.http + 'scheme');
+      return this._getValueArray(api, ns.raml.vocabularies.apiContract + 'scheme');
     }
     /**
      * Computes value for the `expects` property.
@@ -617,7 +619,7 @@ export const AmfHelperMixin = dedupingMixin((base) => {
      * @return {String|undefined}
      */
     _computePropertyValue(item) {
-      const skey = this._getAmfKey(ns.raml.vocabularies.http + 'schema');
+      const skey = this._getAmfKey(ns.raml.vocabularies.apiContract + 'schema');
       let schema = item && item[skey];
       if (!schema) {
         return;
@@ -627,7 +629,7 @@ export const AmfHelperMixin = dedupingMixin((base) => {
       }
       let value = this._getValue(schema, ns.w3.shacl.name + 'defaultValue');
       if (!value) {
-        const examplesKey = this._getAmfKey(ns.raml.vocabularies.document + 'examples');
+        const examplesKey = this._getAmfKey(ns.raml.vocabularies.apiContract + 'examples');
         let example = schema[examplesKey];
         if (example) {
           if (example instanceof Array) {
@@ -647,7 +649,7 @@ export const AmfHelperMixin = dedupingMixin((base) => {
       if (!webApi) {
         return [];
       }
-      const key = this._getAmfKey(ns.raml.vocabularies.http + 'endpoint');
+      const key = this._getAmfKey(ns.raml.vocabularies.apiContract + 'endpoint');
       return this._ensureArray(webApi[key]);
     }
     /**
@@ -680,7 +682,7 @@ export const AmfHelperMixin = dedupingMixin((base) => {
         return;
       }
       for (let i = 0; i < endpoints.length; i++) {
-        const ePath = this._getValue(endpoints[i], this.ns.raml.vocabularies.http + 'path');
+        const ePath = this._getValue(endpoints[i], this.ns.raml.vocabularies.apiContract + 'path');
         if (ePath === path) {
           return endpoints[i];
         }
@@ -711,7 +713,7 @@ export const AmfHelperMixin = dedupingMixin((base) => {
       if (!endpoint) {
         return [];
       }
-      const opKey = this._getAmfKey(ns.w3.hydra.supportedOperation);
+      const opKey = this._getAmfKey(ns.raml.vocabularies.apiContract + 'supportedOperation');
       return this._ensureArray(endpoint[opKey]);
     }
     /**
@@ -728,7 +730,7 @@ export const AmfHelperMixin = dedupingMixin((base) => {
       if (!endpoints) {
         return;
       }
-      const opKey = this._getAmfKey(ns.w3.hydra.supportedOperation);
+      const opKey = this._getAmfKey(ns.raml.vocabularies.apiContract + 'supportedOperation');
       for (let i = 0, len = endpoints.length; i < len; i++) {
         const endpoint = endpoints[i];
         let methods = endpoint[opKey];
@@ -758,7 +760,7 @@ export const AmfHelperMixin = dedupingMixin((base) => {
       if (!endpoint) {
         return;
       }
-      const opKey = this._getAmfKey(ns.w3.hydra.supportedOperation);
+      const opKey = this._getAmfKey(ns.raml.vocabularies.apiContract + 'supportedOperation');
       return this._ensureArray(endpoint[opKey]);
     }
     /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,109 @@
         "@babel/highlight": "^7.0.0"
       }
     },
+    "@babel/core": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.4.3.tgz",
+      "integrity": "sha512-oDpASqKFlbspQfzAE7yaeTmdljSH2ADIvBlb0RwbStltTuWa0+7CCI1fYVINNv9saHPa1W7oaKeuNuKj+RQCvA==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/generator": "^7.4.0",
+        "@babel/helpers": "^7.4.3",
+        "@babel/parser": "^7.4.3",
+        "@babel/template": "^7.4.0",
+        "@babel/traverse": "^7.4.3",
+        "@babel/types": "^7.4.0",
+        "convert-source-map": "^1.1.0",
+        "debug": "^4.1.0",
+        "json5": "^2.1.0",
+        "lodash": "^4.17.11",
+        "resolve": "^1.3.2",
+        "semver": "^5.4.1",
+        "source-map": "^0.5.0"
+      },
+      "dependencies": {
+        "@babel/generator": {
+          "version": "7.4.0",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.0.tgz",
+          "integrity": "sha512-/v5I+a1jhGSKLgZDcmAUZ4K/VePi43eRkUs3yePW1HB1iANOD5tqJXwGSG4BZhSksP8J9ejSlwGeTiiOFZOrXQ==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.4.0",
+            "jsesc": "^2.5.1",
+            "lodash": "^4.17.11",
+            "source-map": "^0.5.0",
+            "trim-right": "^1.0.1"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.4.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.0.tgz",
+          "integrity": "sha512-7Cuc6JZiYShaZnybDmfwhY4UYHzI6rlqhWjaIqbsJGsIqPimEYy5uh3akSRLMg65LSdSEnJ8a8/bWQN6u2oMGw==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.4.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.4.3",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.3.tgz",
+          "integrity": "sha512-gxpEUhTS1sGA63EGQGuA+WESPR/6tz6ng7tSHFCmaTJK/cGK8y37cBTspX+U2xCAue2IQVvF6Z0oigmjwD8YGQ==",
+          "dev": true
+        },
+        "@babel/template": {
+          "version": "7.4.0",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.0.tgz",
+          "integrity": "sha512-SOWwxxClTTh5NdbbYZ0BmaBVzxzTh2tO/TeLTbF6MO6EzVhHTnff8CdBXx3mEtazFBoysmEM6GU/wF+SuSx4Fw==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@babel/parser": "^7.4.0",
+            "@babel/types": "^7.4.0"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.4.3",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.3.tgz",
+          "integrity": "sha512-HmA01qrtaCwwJWpSKpA948cBvU5BrmviAief/b3AVw936DtcdsTexlbyzNuDnthwhOQ37xshn7hvQaEQk7ISYQ==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@babel/generator": "^7.4.0",
+            "@babel/helper-function-name": "^7.1.0",
+            "@babel/helper-split-export-declaration": "^7.4.0",
+            "@babel/parser": "^7.4.3",
+            "@babel/types": "^7.4.0",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0",
+            "lodash": "^4.17.11"
+          }
+        },
+        "@babel/types": {
+          "version": "7.4.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.0.tgz",
+          "integrity": "sha512-aPvkXyU2SPOnztlgo8n9cEiXW755mgyvueUPcpStqdzoSPm0fjO0vQBjLkt3JKJW7ufikfcnMTTPsN1xaTsBPA==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.11",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
     "@babel/generator": {
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.3.2.tgz",
@@ -41,6 +144,134 @@
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         }
+      }
+    },
+    "@babel/helper-annotate-as-pure": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0.tgz",
+      "integrity": "sha512-3UYcJUj9kvSLbLbUIfQTqzcy5VX7GRZ/CCDrnOaZorFFM01aXp1+GJwuFGV4NDDoAS+mOUyHcO6UD/RfqOks3Q==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-builder-binary-assignment-operator-visitor": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.1.0.tgz",
+      "integrity": "sha512-qNSR4jrmJ8M1VMM9tibvyRAHXQs2PmaksQF7c1CGJNipfe3D8p+wgNwgso/P2A2r2mdgBWAXljNWR0QRZAMW8w==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-explode-assignable-expression": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-call-delegate": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.4.0.tgz",
+      "integrity": "sha512-SdqDfbVdNQCBp3WhK2mNdDvHd3BD6qbmIc43CAyjnsfCmgHMeqgDcM3BzY2lchi7HBJGJ2CVdynLWbezaE4mmQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-hoist-variables": "^7.4.0",
+        "@babel/traverse": "^7.4.0",
+        "@babel/types": "^7.4.0"
+      },
+      "dependencies": {
+        "@babel/generator": {
+          "version": "7.4.0",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.0.tgz",
+          "integrity": "sha512-/v5I+a1jhGSKLgZDcmAUZ4K/VePi43eRkUs3yePW1HB1iANOD5tqJXwGSG4BZhSksP8J9ejSlwGeTiiOFZOrXQ==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.4.0",
+            "jsesc": "^2.5.1",
+            "lodash": "^4.17.11",
+            "source-map": "^0.5.0",
+            "trim-right": "^1.0.1"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.4.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.0.tgz",
+          "integrity": "sha512-7Cuc6JZiYShaZnybDmfwhY4UYHzI6rlqhWjaIqbsJGsIqPimEYy5uh3akSRLMg65LSdSEnJ8a8/bWQN6u2oMGw==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.4.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.4.3",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.3.tgz",
+          "integrity": "sha512-gxpEUhTS1sGA63EGQGuA+WESPR/6tz6ng7tSHFCmaTJK/cGK8y37cBTspX+U2xCAue2IQVvF6Z0oigmjwD8YGQ==",
+          "dev": true
+        },
+        "@babel/traverse": {
+          "version": "7.4.3",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.3.tgz",
+          "integrity": "sha512-HmA01qrtaCwwJWpSKpA948cBvU5BrmviAief/b3AVw936DtcdsTexlbyzNuDnthwhOQ37xshn7hvQaEQk7ISYQ==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@babel/generator": "^7.4.0",
+            "@babel/helper-function-name": "^7.1.0",
+            "@babel/helper-split-export-declaration": "^7.4.0",
+            "@babel/parser": "^7.4.3",
+            "@babel/types": "^7.4.0",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0",
+            "lodash": "^4.17.11"
+          }
+        },
+        "@babel/types": {
+          "version": "7.4.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.0.tgz",
+          "integrity": "sha512-aPvkXyU2SPOnztlgo8n9cEiXW755mgyvueUPcpStqdzoSPm0fjO0vQBjLkt3JKJW7ufikfcnMTTPsN1xaTsBPA==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.11",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
+    "@babel/helper-define-map": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.4.0.tgz",
+      "integrity": "sha512-wAhQ9HdnLIywERVcSvX40CEJwKdAa1ID4neI9NXQPDOHwwA+57DqwLiPEVy2AIyWzAk0CQ8qx4awO0VUURwLtA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/types": "^7.4.0",
+        "lodash": "^4.17.11"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.4.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.0.tgz",
+          "integrity": "sha512-aPvkXyU2SPOnztlgo8n9cEiXW755mgyvueUPcpStqdzoSPm0fjO0vQBjLkt3JKJW7ufikfcnMTTPsN1xaTsBPA==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.11",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
+      }
+    },
+    "@babel/helper-explode-assignable-expression": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.1.0.tgz",
+      "integrity": "sha512-NRQpfHrJ1msCHtKjbzs9YcMmJZOg6mQMmGRB+hbamEdG5PNpaSm95275VD92DvJKuyl0s2sFiDmMZ+EnnvufqA==",
+      "dev": true,
+      "requires": {
+        "@babel/traverse": "^7.1.0",
+        "@babel/types": "^7.0.0"
       }
     },
     "@babel/helper-function-name": {
@@ -63,6 +294,183 @@
         "@babel/types": "^7.0.0"
       }
     },
+    "@babel/helper-hoist-variables": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.4.0.tgz",
+      "integrity": "sha512-/NErCuoe/et17IlAQFKWM24qtyYYie7sFIrW/tIQXpck6vAu2hhtYYsKLBWQV+BQZMbcIYPU/QMYuTufrY4aQw==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.4.0"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.4.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.0.tgz",
+          "integrity": "sha512-aPvkXyU2SPOnztlgo8n9cEiXW755mgyvueUPcpStqdzoSPm0fjO0vQBjLkt3JKJW7ufikfcnMTTPsN1xaTsBPA==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.11",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
+      }
+    },
+    "@babel/helper-member-expression-to-functions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.0.0.tgz",
+      "integrity": "sha512-avo+lm/QmZlv27Zsi0xEor2fKcqWG56D5ae9dzklpIaY7cQMK5N8VSpaNVPPagiqmy7LrEjK1IWdGMOqPu5csg==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-module-imports": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0.tgz",
+      "integrity": "sha512-aP/hlLq01DWNEiDg4Jn23i+CXxW/owM4WpDLFUbpjxe4NS3BhLVZQ5i7E0ZrxuQ/vwekIeciyamgB1UIYxxM6A==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-module-transforms": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.4.3.tgz",
+      "integrity": "sha512-H88T9IySZW25anu5uqyaC1DaQre7ofM+joZtAaO2F8NBdFfupH0SZ4gKjgSFVcvtx/aAirqA9L9Clio2heYbZA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/helper-simple-access": "^7.1.0",
+        "@babel/helper-split-export-declaration": "^7.0.0",
+        "@babel/template": "^7.2.2",
+        "@babel/types": "^7.2.2",
+        "lodash": "^4.17.11"
+      }
+    },
+    "@babel/helper-optimise-call-expression": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0.tgz",
+      "integrity": "sha512-u8nd9NQePYNQV8iPWu/pLLYBqZBa4ZaY1YWRFMuxrid94wKI1QNt67NEZ7GAe5Kc/0LLScbim05xZFWkAdrj9g==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-plugin-utils": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
+      "integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA==",
+      "dev": true
+    },
+    "@babel/helper-regex": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.4.3.tgz",
+      "integrity": "sha512-hnoq5u96pLCfgjXuj8ZLX3QQ+6nAulS+zSgi6HulUwFbEruRAKwbGLU5OvXkE14L8XW6XsQEKsIDfgthKLRAyA==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.11"
+      }
+    },
+    "@babel/helper-remap-async-to-generator": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.1.0.tgz",
+      "integrity": "sha512-3fOK0L+Fdlg8S5al8u/hWE6vhufGSn0bN09xm2LXMy//REAF8kDCrYoOBKYmA8m5Nom+sV9LyLCwrFynA8/slg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.0.0",
+        "@babel/helper-wrap-function": "^7.1.0",
+        "@babel/template": "^7.1.0",
+        "@babel/traverse": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-replace-supers": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.4.0.tgz",
+      "integrity": "sha512-PVwCVnWWAgnal+kJ+ZSAphzyl58XrFeSKSAJRiqg5QToTsjL+Xu1f9+RJ+d+Q0aPhPfBGaYfkox66k86thxNSg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-member-expression-to-functions": "^7.0.0",
+        "@babel/helper-optimise-call-expression": "^7.0.0",
+        "@babel/traverse": "^7.4.0",
+        "@babel/types": "^7.4.0"
+      },
+      "dependencies": {
+        "@babel/generator": {
+          "version": "7.4.0",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.0.tgz",
+          "integrity": "sha512-/v5I+a1jhGSKLgZDcmAUZ4K/VePi43eRkUs3yePW1HB1iANOD5tqJXwGSG4BZhSksP8J9ejSlwGeTiiOFZOrXQ==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.4.0",
+            "jsesc": "^2.5.1",
+            "lodash": "^4.17.11",
+            "source-map": "^0.5.0",
+            "trim-right": "^1.0.1"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.4.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.0.tgz",
+          "integrity": "sha512-7Cuc6JZiYShaZnybDmfwhY4UYHzI6rlqhWjaIqbsJGsIqPimEYy5uh3akSRLMg65LSdSEnJ8a8/bWQN6u2oMGw==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.4.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.4.3",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.3.tgz",
+          "integrity": "sha512-gxpEUhTS1sGA63EGQGuA+WESPR/6tz6ng7tSHFCmaTJK/cGK8y37cBTspX+U2xCAue2IQVvF6Z0oigmjwD8YGQ==",
+          "dev": true
+        },
+        "@babel/traverse": {
+          "version": "7.4.3",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.3.tgz",
+          "integrity": "sha512-HmA01qrtaCwwJWpSKpA948cBvU5BrmviAief/b3AVw936DtcdsTexlbyzNuDnthwhOQ37xshn7hvQaEQk7ISYQ==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@babel/generator": "^7.4.0",
+            "@babel/helper-function-name": "^7.1.0",
+            "@babel/helper-split-export-declaration": "^7.4.0",
+            "@babel/parser": "^7.4.3",
+            "@babel/types": "^7.4.0",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0",
+            "lodash": "^4.17.11"
+          }
+        },
+        "@babel/types": {
+          "version": "7.4.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.0.tgz",
+          "integrity": "sha512-aPvkXyU2SPOnztlgo8n9cEiXW755mgyvueUPcpStqdzoSPm0fjO0vQBjLkt3JKJW7ufikfcnMTTPsN1xaTsBPA==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.11",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
+    "@babel/helper-simple-access": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.1.0.tgz",
+      "integrity": "sha512-Vk+78hNjRbsiu49zAPALxTb+JUQCz1aolpd8osOF16BGnLtseD21nbHgLPGUwrXEurZgiCOUmvs3ExTu4F5x6w==",
+      "dev": true,
+      "requires": {
+        "@babel/template": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
     "@babel/helper-split-export-declaration": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0.tgz",
@@ -70,6 +478,104 @@
       "dev": true,
       "requires": {
         "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-wrap-function": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.2.0.tgz",
+      "integrity": "sha512-o9fP1BZLLSrYlxYEYyl2aS+Flun5gtjTIG8iln+XuEzQTs0PLagAGSXUcqruJwD5fM48jzIEggCKpIfWTcR7pQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/template": "^7.1.0",
+        "@babel/traverse": "^7.1.0",
+        "@babel/types": "^7.2.0"
+      }
+    },
+    "@babel/helpers": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.4.3.tgz",
+      "integrity": "sha512-BMh7X0oZqb36CfyhvtbSmcWc3GXocfxv3yNsAEuM0l+fAqSO22rQrUpijr3oE/10jCTrB6/0b9kzmG4VetCj8Q==",
+      "dev": true,
+      "requires": {
+        "@babel/template": "^7.4.0",
+        "@babel/traverse": "^7.4.3",
+        "@babel/types": "^7.4.0"
+      },
+      "dependencies": {
+        "@babel/generator": {
+          "version": "7.4.0",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.0.tgz",
+          "integrity": "sha512-/v5I+a1jhGSKLgZDcmAUZ4K/VePi43eRkUs3yePW1HB1iANOD5tqJXwGSG4BZhSksP8J9ejSlwGeTiiOFZOrXQ==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.4.0",
+            "jsesc": "^2.5.1",
+            "lodash": "^4.17.11",
+            "source-map": "^0.5.0",
+            "trim-right": "^1.0.1"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.4.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.0.tgz",
+          "integrity": "sha512-7Cuc6JZiYShaZnybDmfwhY4UYHzI6rlqhWjaIqbsJGsIqPimEYy5uh3akSRLMg65LSdSEnJ8a8/bWQN6u2oMGw==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.4.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.4.3",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.3.tgz",
+          "integrity": "sha512-gxpEUhTS1sGA63EGQGuA+WESPR/6tz6ng7tSHFCmaTJK/cGK8y37cBTspX+U2xCAue2IQVvF6Z0oigmjwD8YGQ==",
+          "dev": true
+        },
+        "@babel/template": {
+          "version": "7.4.0",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.0.tgz",
+          "integrity": "sha512-SOWwxxClTTh5NdbbYZ0BmaBVzxzTh2tO/TeLTbF6MO6EzVhHTnff8CdBXx3mEtazFBoysmEM6GU/wF+SuSx4Fw==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@babel/parser": "^7.4.0",
+            "@babel/types": "^7.4.0"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.4.3",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.3.tgz",
+          "integrity": "sha512-HmA01qrtaCwwJWpSKpA948cBvU5BrmviAief/b3AVw936DtcdsTexlbyzNuDnthwhOQ37xshn7hvQaEQk7ISYQ==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@babel/generator": "^7.4.0",
+            "@babel/helper-function-name": "^7.1.0",
+            "@babel/helper-split-export-declaration": "^7.4.0",
+            "@babel/parser": "^7.4.3",
+            "@babel/types": "^7.4.0",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0",
+            "lodash": "^4.17.11"
+          }
+        },
+        "@babel/types": {
+          "version": "7.4.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.0.tgz",
+          "integrity": "sha512-aPvkXyU2SPOnztlgo8n9cEiXW755mgyvueUPcpStqdzoSPm0fjO0vQBjLkt3JKJW7ufikfcnMTTPsN1xaTsBPA==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.11",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
       }
     },
     "@babel/highlight": {
@@ -88,6 +594,321 @@
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.3.2.tgz",
       "integrity": "sha512-QzNUC2RO1gadg+fs21fi0Uu0OuGNzRKEmgCxoLNzbCdoprLwjfmZwzUrpUNfJPaVRwBpDY47A17yYEGWyRelnQ==",
       "dev": true
+    },
+    "@babel/plugin-external-helpers": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-external-helpers/-/plugin-external-helpers-7.2.0.tgz",
+      "integrity": "sha512-QFmtcCShFkyAsNtdCM3lJPmRe1iB+vPZymlB4LnDIKEBj2yKQLQKtoxXxJ8ePT5fwMl4QGg303p4mB0UsSI2/g==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-proposal-async-generator-functions": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.2.0.tgz",
+      "integrity": "sha512-+Dfo/SCQqrwx48ptLVGLdE39YtWRuKc/Y9I5Fy0P1DDBB9lsAHpjcEJQt+4IifuSOSTLBKJObJqMvaO1pIE8LQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-remap-async-to-generator": "^7.1.0",
+        "@babel/plugin-syntax-async-generators": "^7.2.0"
+      }
+    },
+    "@babel/plugin-proposal-object-rest-spread": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.4.3.tgz",
+      "integrity": "sha512-xC//6DNSSHVjq8O2ge0dyYlhshsH4T7XdCVoxbi5HzLYWfsC5ooFlJjrXk8RcAT+hjHAK9UjBXdylzSoDK3t4g==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-object-rest-spread": "^7.2.0"
+      }
+    },
+    "@babel/plugin-syntax-async-generators": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.2.0.tgz",
+      "integrity": "sha512-1ZrIRBv2t0GSlcwVoQ6VgSLpLgiN/FVQUzt9znxo7v2Ov4jJrs8RY8tv0wvDmFN3qIdMKWrmMMW6yZ0G19MfGg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-syntax-dynamic-import": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.2.0.tgz",
+      "integrity": "sha512-mVxuJ0YroI/h/tbFTPGZR8cv6ai+STMKNBq0f8hFxsxWjl94qqhsb+wXbpNMDPU3cfR1TIsVFzU3nXyZMqyK4w==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-syntax-import-meta": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.2.0.tgz",
+      "integrity": "sha512-Hq6kFSZD7+PHkmBN8bCpHR6J8QEoCuEV/B38AIQscYjgMZkGlXB7cHNFzP5jR4RCh5545yP1ujHdmO7hAgKtBA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-syntax-object-rest-spread": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.2.0.tgz",
+      "integrity": "sha512-t0JKGgqk2We+9may3t0xDdmneaXmyxq0xieYcKHxIsrJO64n1OiMWNUtc5gQK1PA0NpdCRrtZp4z+IUaKugrSA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-arrow-functions": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.2.0.tgz",
+      "integrity": "sha512-ER77Cax1+8/8jCB9fo4Ud161OZzWN5qawi4GusDuRLcDbDG+bIGYY20zb2dfAFdTRGzrfq2xZPvF0R64EHnimg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-async-to-generator": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.4.0.tgz",
+      "integrity": "sha512-EeaFdCeUULM+GPFEsf7pFcNSxM7hYjoj5fiYbyuiXobW4JhFnjAv9OWzNwHyHcKoPNpAfeRDuW6VyaXEDUBa7g==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-remap-async-to-generator": "^7.1.0"
+      }
+    },
+    "@babel/plugin-transform-block-scoped-functions": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.2.0.tgz",
+      "integrity": "sha512-ntQPR6q1/NKuphly49+QiQiTN0O63uOwjdD6dhIjSWBI5xlrbUFh720TIpzBhpnrLfv2tNH/BXvLIab1+BAI0w==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-block-scoping": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.4.0.tgz",
+      "integrity": "sha512-AWyt3k+fBXQqt2qb9r97tn3iBwFpiv9xdAiG+Gr2HpAZpuayvbL55yWrsV3MyHvXk/4vmSiedhDRl1YI2Iy5nQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "lodash": "^4.17.11"
+      }
+    },
+    "@babel/plugin-transform-classes": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.4.3.tgz",
+      "integrity": "sha512-PUaIKyFUDtG6jF5DUJOfkBdwAS/kFFV3XFk7Nn0a6vR7ZT8jYw5cGtIlat77wcnd0C6ViGqo/wyNf4ZHytF/nQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.0.0",
+        "@babel/helper-define-map": "^7.4.0",
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/helper-optimise-call-expression": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-replace-supers": "^7.4.0",
+        "@babel/helper-split-export-declaration": "^7.4.0",
+        "globals": "^11.1.0"
+      },
+      "dependencies": {
+        "@babel/helper-split-export-declaration": {
+          "version": "7.4.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.0.tgz",
+          "integrity": "sha512-7Cuc6JZiYShaZnybDmfwhY4UYHzI6rlqhWjaIqbsJGsIqPimEYy5uh3akSRLMg65LSdSEnJ8a8/bWQN6u2oMGw==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.4.0"
+          }
+        },
+        "@babel/types": {
+          "version": "7.4.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.0.tgz",
+          "integrity": "sha512-aPvkXyU2SPOnztlgo8n9cEiXW755mgyvueUPcpStqdzoSPm0fjO0vQBjLkt3JKJW7ufikfcnMTTPsN1xaTsBPA==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.11",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
+      }
+    },
+    "@babel/plugin-transform-computed-properties": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.2.0.tgz",
+      "integrity": "sha512-kP/drqTxY6Xt3NNpKiMomfgkNn4o7+vKxK2DDKcBG9sHj51vHqMBGy8wbDS/J4lMxnqs153/T3+DmCEAkC5cpA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-destructuring": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.4.3.tgz",
+      "integrity": "sha512-rVTLLZpydDFDyN4qnXdzwoVpk1oaXHIvPEOkOLyr88o7oHxVc/LyrnDx+amuBWGOwUb7D1s/uLsKBNTx08htZg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-duplicate-keys": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.2.0.tgz",
+      "integrity": "sha512-q+yuxW4DsTjNceUiTzK0L+AfQ0zD9rWaTLiUqHA8p0gxx7lu1EylenfzjeIWNkPy6e/0VG/Wjw9uf9LueQwLOw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-exponentiation-operator": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.2.0.tgz",
+      "integrity": "sha512-umh4hR6N7mu4Elq9GG8TOu9M0bakvlsREEC+ialrQN6ABS4oDQ69qJv1VtR3uxlKMCQMCvzk7vr17RHKcjx68A==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-builder-binary-assignment-operator-visitor": "^7.1.0",
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-for-of": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.4.3.tgz",
+      "integrity": "sha512-UselcZPwVWNSURnqcfpnxtMehrb8wjXYOimlYQPBnup/Zld426YzIhNEvuRsEWVHfESIECGrxoI6L5QqzuLH5Q==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-function-name": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.4.3.tgz",
+      "integrity": "sha512-uT5J/3qI/8vACBR9I1GlAuU/JqBtWdfCrynuOkrWG6nCDieZd5przB1vfP59FRHBZQ9DC2IUfqr/xKqzOD5x0A==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-instanceof": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-instanceof/-/plugin-transform-instanceof-7.2.0.tgz",
+      "integrity": "sha512-tw2fb96tpcd5XaJXns19tGKo/SeIUS0exAteHJ/7EP27Bke7RmV/gAftHCf1WKZgKeZOUfzOL7nrXH2HIH9auA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-literals": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.2.0.tgz",
+      "integrity": "sha512-2ThDhm4lI4oV7fVQ6pNNK+sx+c/GM5/SaML0w/r4ZB7sAneD/piDJtwdKlNckXeyGK7wlwg2E2w33C/Hh+VFCg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-modules-amd": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.2.0.tgz",
+      "integrity": "sha512-mK2A8ucqz1qhrdqjS9VMIDfIvvT2thrEsIQzbaTdc5QFzhDjQv2CkJJ5f6BXIkgbmaoax3zBr2RyvV/8zeoUZw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-transforms": "^7.1.0",
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-object-super": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.2.0.tgz",
+      "integrity": "sha512-VMyhPYZISFZAqAPVkiYb7dUe2AsVi2/wCT5+wZdsNO31FojQJa9ns40hzZ6U9f50Jlq4w6qwzdBB2uwqZ00ebg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-replace-supers": "^7.1.0"
+      }
+    },
+    "@babel/plugin-transform-parameters": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.4.3.tgz",
+      "integrity": "sha512-ULJYC2Vnw96/zdotCZkMGr2QVfKpIT/4/K+xWWY0MbOJyMZuk660BGkr3bEKWQrrciwz6xpmft39nA4BF7hJuA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-call-delegate": "^7.4.0",
+        "@babel/helper-get-function-arity": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-regenerator": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.4.3.tgz",
+      "integrity": "sha512-kEzotPuOpv6/iSlHroCDydPkKYw7tiJGKlmYp6iJn4a6C/+b2FdttlJsLKYxolYHgotTJ5G5UY5h0qey5ka3+A==",
+      "dev": true,
+      "requires": {
+        "regenerator-transform": "^0.13.4"
+      }
+    },
+    "@babel/plugin-transform-shorthand-properties": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.2.0.tgz",
+      "integrity": "sha512-QP4eUM83ha9zmYtpbnyjTLAGKQritA5XW/iG9cjtuOI8s1RuL/3V6a3DeSHfKutJQ+ayUfeZJPcnCYEQzaPQqg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-spread": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.2.2.tgz",
+      "integrity": "sha512-KWfky/58vubwtS0hLqEnrWJjsMGaOeSBn90Ezn5Jeg9Z8KKHmELbP1yGylMlm5N6TPKeY9A2+UaSYLdxahg01w==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-sticky-regex": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.2.0.tgz",
+      "integrity": "sha512-KKYCoGaRAf+ckH8gEL3JHUaFVyNHKe3ASNsZ+AlktgHevvxGigoIttrEJb8iKN03Q7Eazlv1s6cx2B2cQ3Jabw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-regex": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-template-literals": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.2.0.tgz",
+      "integrity": "sha512-FkPix00J9A/XWXv4VoKJBMeSkyY9x/TqIh76wzcdfl57RJJcf8CehQ08uwfhCDNtRQYtHQKBTwKZDEyjE13Lwg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-typeof-symbol": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.2.0.tgz",
+      "integrity": "sha512-2LNhETWYxiYysBtrBTqL8+La0jIoQQnIScUJc74OYvUGRmkskNY4EzLCnjHBzdmb38wqtTaixpo1NctEcvMDZw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-unicode-regex": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.4.3.tgz",
+      "integrity": "sha512-lnSNgkVjL8EMtnE8eSS7t2ku8qvKH3eqNf/IwIfnSPUqzgqYmRwzdsQWv4mNQAN9Nuo6Gz1Y0a4CSmdpu1Pp6g==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-regex": "^7.4.3",
+        "regexpu-core": "^4.5.4"
+      }
     },
     "@babel/template": {
       "version": "7.2.2",
@@ -140,6 +961,12 @@
         "@polymer/iron-scroll-target-behavior": "^3.0.0-pre.26",
         "@polymer/polymer": "^3.0.0"
       }
+    },
+    "@polymer/esm-amd-loader": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@polymer/esm-amd-loader/-/esm-amd-loader-1.0.4.tgz",
+      "integrity": "sha512-h+hqYkL+tQV/y2ESD5gFXMl5z4cC+XY1jTlBeGSBaTcj3VbB5OBEScbvRXm63NcEbBneQQYbHfBAXAkF9i9wIA==",
+      "dev": true
     },
     "@polymer/font-roboto": {
       "version": "3.0.2",
@@ -484,6 +1311,12 @@
         "prismjs": "^1.11.0"
       }
     },
+    "@polymer/sinonjs": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@polymer/sinonjs/-/sinonjs-1.17.1.tgz",
+      "integrity": "sha512-/U8F/cOTrbF2iVVYgINYmvKbtbexs+89Q3v8AaHADRYabTg7aOZGOb0RyWpOI+sUJt04kj63U4FwMhzW5r4wZA==",
+      "dev": true
+    },
     "@polymer/test-fixture": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@polymer/test-fixture/-/test-fixture-4.0.2.tgz",
@@ -552,6 +1385,22 @@
         "@types/babel-types": "*"
       }
     },
+    "@types/bluebird": {
+      "version": "3.5.26",
+      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.26.tgz",
+      "integrity": "sha512-aj2mrBLn5ky0GmAg6IPXrQjnN0iB/ulozuJ+oZdrHRAzRbXjGmu4UXsNCjFvPbSaaPZmniocdOzsM392qLOlmQ==",
+      "dev": true
+    },
+    "@types/body-parser": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.17.0.tgz",
+      "integrity": "sha512-a2+YeUjPkztKJu5aIF2yArYFQQp8d51wZ7DavSHjFuY1mqVgidGyzEQ41JIVNy82fXj8yPgy2vJmfIywgESW6w==",
+      "dev": true,
+      "requires": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
     "@types/chai": {
       "version": "4.1.7",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.1.7.tgz",
@@ -573,6 +1422,15 @@
       "integrity": "sha1-ox10JBprHtu5c8822XooloNKUfk=",
       "dev": true
     },
+    "@types/clean-css": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@types/clean-css/-/clean-css-4.2.1.tgz",
+      "integrity": "sha512-A1HQhQ0hkvqqByJMgg+Wiv9p9XdoYEzuwm11SVo1mX2/4PSdhjcrUlilJQoqLscIheC51t1D5g+EFWCXZ2VTQQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/clone": {
       "version": "0.1.30",
       "resolved": "https://registry.npmjs.org/@types/clone/-/clone-0.1.30.tgz",
@@ -591,6 +1449,30 @@
       "integrity": "sha512-/xUgezxxYePeXhg5S04hUjxG9JZi+rJTs1+4NwpYPfSaS7BeDa6tVJkH6lN9Cb6rl8d24Fi2uX0s0Ngg2JT6gg==",
       "dev": true
     },
+    "@types/compression": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/@types/compression/-/compression-0.0.33.tgz",
+      "integrity": "sha1-ldxzOiM5qoRjgdfxN3eS0lU9wn0=",
+      "dev": true,
+      "requires": {
+        "@types/express": "*"
+      }
+    },
+    "@types/connect": {
+      "version": "3.4.32",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.32.tgz",
+      "integrity": "sha512-4r8qa0quOvh7lGD0pre62CAb1oni1OO6ecJLGCezTmhQ8Fz50Arx9RUszryR8KlgK6avuSXvviL6yWyViQABOg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/content-type": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@types/content-type/-/content-type-1.1.3.tgz",
+      "integrity": "sha512-pv8VcFrZ3fN93L4rTNIbbUzdkzjEyVMp5mPVjsFfOYTDOZMZiZ8P1dhu+kEv3faYyKzZgLlSvnyQNFg+p/v5ug==",
+      "dev": true
+    },
     "@types/cssbeautify": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/@types/cssbeautify/-/cssbeautify-0.3.1.tgz",
@@ -603,11 +1485,51 @@
       "integrity": "sha1-6JLSk8ksnB0/mvcsFaVU+8fgiVo=",
       "dev": true
     },
+    "@types/escape-html": {
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/@types/escape-html/-/escape-html-0.0.20.tgz",
+      "integrity": "sha512-6dhZJLbA7aOwkYB2GDGdIqJ20wmHnkDzaxV9PJXe7O02I2dSFTERzRB6JrX6cWKaS+VqhhY7cQUMCbO5kloFUw==",
+      "dev": true
+    },
+    "@types/estree": {
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+      "dev": true
+    },
     "@types/events": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
       "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
       "dev": true
+    },
+    "@types/express": {
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.16.1.tgz",
+      "integrity": "sha512-V0clmJow23WeyblmACoxbHBu2JKlE5TiIme6Lem14FnPW9gsttyHtk6wq7njcdIWH1njAaFgR8gW09lgY98gQg==",
+      "dev": true,
+      "requires": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "@types/express-serve-static-core": {
+      "version": "4.16.2",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.16.2.tgz",
+      "integrity": "sha512-qgc8tjnDrc789rAQed8NoiFLV5VGcItA4yWNFphqGU0RcuuQngD00g3LHhWIK3HQ2XeDgVCmlNPDlqi3fWBHnQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "@types/range-parser": "*"
+      }
+    },
+    "@types/freeport": {
+      "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/@types/freeport/-/freeport-1.0.21.tgz",
+      "integrity": "sha1-c/ZUPtZ9PKP/+XuYVZFZi3CSBm8=",
+      "dev": true,
+      "optional": true
     },
     "@types/fs-extra": {
       "version": "5.0.4",
@@ -629,10 +1551,54 @@
         "@types/node": "*"
       }
     },
+    "@types/glob-stream": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@types/glob-stream/-/glob-stream-6.1.0.tgz",
+      "integrity": "sha512-RHv6ZQjcTncXo3thYZrsbAVwoy4vSKosSWhuhuQxLOTv74OJuFQxXkmUuZCr3q9uNBEVCvIzmZL/FeRNbHZGUg==",
+      "dev": true,
+      "requires": {
+        "@types/glob": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/gulp-if": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/@types/gulp-if/-/gulp-if-0.0.33.tgz",
+      "integrity": "sha512-J5lzff21X7r1x/4hSzn02GgIUEyjCqYIXZ9GgGBLhbsD3RiBdqwnkFWgF16/0jO5rcVZ52Zp+6MQMQdvIsWuKg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "@types/vinyl": "*"
+      }
+    },
+    "@types/html-minifier": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/@types/html-minifier/-/html-minifier-3.5.3.tgz",
+      "integrity": "sha512-j1P/4PcWVVCPEy5lofcHnQ6BtXz9tHGiFPWzqm7TtGuWZEfCHEP446HlkSNc9fQgNJaJZ6ewPtp2aaFla/Uerg==",
+      "dev": true,
+      "requires": {
+        "@types/clean-css": "*",
+        "@types/relateurl": "*",
+        "@types/uglify-js": "*"
+      }
+    },
     "@types/is-windows": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@types/is-windows/-/is-windows-0.2.0.tgz",
       "integrity": "sha1-byTuSHMdMRaOpRBhDW3RXl/Jxv8=",
+      "dev": true
+    },
+    "@types/launchpad": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@types/launchpad/-/launchpad-0.6.0.tgz",
+      "integrity": "sha1-NylhCbfyd/bmxf1+DAcGvJGPu1E=",
+      "dev": true,
+      "optional": true
+    },
+    "@types/mime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.1.tgz",
+      "integrity": "sha512-FwI9gX75FgVBJ7ywgnq/P7tw+/o1GUbtP0KzbtusLigAOgIgNISRK0ZPl4qertvXSIE8YbsVJueQ90cDt9YYyw==",
       "dev": true
     },
     "@types/minimatch": {
@@ -641,11 +1607,29 @@
       "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
       "dev": true
     },
+    "@types/mz": {
+      "version": "0.0.31",
+      "resolved": "https://registry.npmjs.org/@types/mz/-/mz-0.0.31.tgz",
+      "integrity": "sha1-pNgMCC/v5x5Ap8DwfR5lVbu8e1I=",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/node": {
       "version": "10.12.21",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.21.tgz",
       "integrity": "sha512-CBgLNk4o3XMnqMc0rhb6lc77IwShMEglz05deDcn2lQxyXEZivfwgYJu7SMha9V5XcrP6qZuevTHV/QrN2vjKQ==",
       "dev": true
+    },
+    "@types/opn": {
+      "version": "3.0.28",
+      "resolved": "https://registry.npmjs.org/@types/opn/-/opn-3.0.28.tgz",
+      "integrity": "sha1-CX0NHJtXSVc6XZbfEyOHu20CEYo=",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/parse5": {
       "version": "2.2.34",
@@ -662,6 +1646,27 @@
       "integrity": "sha512-hfnXRGugz+McgX2jxyy5qz9sB21LRzlGn24zlwN2KEgoPtEvjzNRrLtUkOOebPDPZl3Rq7ywKxYvylVcEZDnEw==",
       "dev": true
     },
+    "@types/pem": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/@types/pem/-/pem-1.9.5.tgz",
+      "integrity": "sha512-C0txxEw8B7DCoD85Ko7SEvzUogNd5VDJ5/YBG8XUcacsOGqxr5Oo4g3OUAfdEDUbhXanwUoVh/ZkMFw77FGPQQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/range-parser": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz",
+      "integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==",
+      "dev": true
+    },
+    "@types/relateurl": {
+      "version": "0.2.28",
+      "resolved": "https://registry.npmjs.org/@types/relateurl/-/relateurl-0.2.28.tgz",
+      "integrity": "sha1-a9p9uGU/piZD9e5p6facEaOS46Y=",
+      "dev": true
+    },
     "@types/resolve": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-0.0.6.tgz",
@@ -669,6 +1674,69 @@
       "dev": true,
       "requires": {
         "@types/node": "*"
+      }
+    },
+    "@types/serve-static": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.2.tgz",
+      "integrity": "sha512-/BZ4QRLpH/bNYgZgwhKEh+5AsboDBcUdlBYgzoLX0fpj3Y2gp6EApyOlM3bK53wQS/OE1SrdSYBAbux2D1528Q==",
+      "dev": true,
+      "requires": {
+        "@types/express-serve-static-core": "*",
+        "@types/mime": "*"
+      }
+    },
+    "@types/spdy": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@types/spdy/-/spdy-3.4.4.tgz",
+      "integrity": "sha512-N9LBlbVRRYq6HgYpPkqQc3a9HJ/iEtVZToW6xlTtJiMhmRJ7jJdV7TaZQJw/Ve/1ePUsQiCTDc4JMuzzag94GA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/ua-parser-js": {
+      "version": "0.7.33",
+      "resolved": "https://registry.npmjs.org/@types/ua-parser-js/-/ua-parser-js-0.7.33.tgz",
+      "integrity": "sha512-ngUKcHnytUodUCL7C6EZ+lVXUjTMQb+9p/e1JjV5tN9TVzS98lHozWEFRPY1QcCdwFeMsmVWfZ3DPPT/udCyIw==",
+      "dev": true
+    },
+    "@types/uglify-js": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.0.4.tgz",
+      "integrity": "sha512-SudIN9TRJ+v8g5pTG8RRCqfqTMNqgWCKKd3vtynhGzkIIjxaicNAMuY5TRadJ6tzDu3Dotf3ngaMILtmOdmWEQ==",
+      "dev": true,
+      "requires": {
+        "source-map": "^0.6.1"
+      }
+    },
+    "@types/uuid": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.4.tgz",
+      "integrity": "sha512-tPIgT0GUmdJQNSHxp0X2jnpQfBSTfGxUMc/2CXBU2mnyTFVYVa2ojpoQ74w0U2yn2vw3jnC640+77lkFFpdVDw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/vinyl": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/vinyl/-/vinyl-2.0.3.tgz",
+      "integrity": "sha512-hrT6xg16CWSmndZqOTJ6BGIn2abKyTw0B58bI+7ioUoj3Sma6u8ftZ1DTI2yCaJamOVGLOnQWiPH3a74+EaqTA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/vinyl-fs": {
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/@types/vinyl-fs/-/vinyl-fs-2.4.11.tgz",
+      "integrity": "sha512-2OzQSfIr9CqqWMGqmcERE6Hnd2KY3eBVtFaulVo3sJghplUcaeMdL9ZjEiljcQQeHjheWY9RlNmumjIAvsBNaA==",
+      "dev": true,
+      "requires": {
+        "@types/glob-stream": "*",
+        "@types/node": "*",
+        "@types/vinyl": "*"
       }
     },
     "@types/whatwg-url": {
@@ -679,6 +1747,13 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@types/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-ZrJDWpvg75LTGX4XwuneY9s6bF3OeZcGTpoGh3zDV9ytzcHMFsRrMIaLBRJZQMBoGyKs6unBQfVdrLZiYfb1zQ==",
+      "dev": true,
+      "optional": true
     },
     "@webcomponents/shadycss": {
       "version": "1.9.0",
@@ -691,6 +1766,86 @@
       "integrity": "sha512-kPPjzV+5kpoWpTniyvBSPcXS33f3j/C6HvNOJ3YecF3pvz3XwVeU4ammbxtVy/osF3z7hr1DYNptIf4oPEvXZA==",
       "dev": true
     },
+    "abbrev": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
+      "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
+      "dev": true
+    },
+    "accepts": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
+      "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
+      "dev": true,
+      "requires": {
+        "mime-types": "~2.1.18",
+        "negotiator": "0.6.1"
+      }
+    },
+    "accessibility-developer-tools": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/accessibility-developer-tools/-/accessibility-developer-tools-2.12.0.tgz",
+      "integrity": "sha1-PaDM6dbsY3OWS4TzXbfPw996tRQ=",
+      "dev": true
+    },
+    "acorn": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+      "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+      "dev": true
+    },
+    "acorn-jsx": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+      "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+      "dev": true,
+      "requires": {
+        "acorn": "^3.0.4"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+          "dev": true
+        }
+      }
+    },
+    "adm-zip": {
+      "version": "0.4.13",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.13.tgz",
+      "integrity": "sha512-fERNJX8sOXfel6qCBCMPvZLzENBEhZTzKqg6vrOW5pvoEaQuJhRU4ndTAh6lHOxn1I6jnz2NHra56ZODM751uw==",
+      "dev": true,
+      "optional": true
+    },
+    "after": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
+      "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8=",
+      "dev": true
+    },
+    "agent-base": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
+      "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "es6-promisify": "^5.0.0"
+      },
+      "dependencies": {
+        "es6-promisify": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+          "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "es6-promise": "^4.0.3"
+          }
+        }
+      }
+    },
     "ajv": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.2.tgz",
@@ -702,6 +1857,13 @@
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.1"
       }
+    },
+    "amdefine": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+      "dev": true,
+      "optional": true
     },
     "amf-client-js": {
       "version": "3.1.6",
@@ -719,6 +1881,15 @@
       "integrity": "sha512-CoW08R+Y5VluBhC0IT11yJMJqVfuYVa8JHKopL4sXXCgTjtKikn1dyfOmY/b/u0WVKmx787JVDb/HnTzOEVoiA==",
       "dev": true
     },
+    "ansi-align": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
+      "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
+      "dev": true,
+      "requires": {
+        "string-width": "^2.0.0"
+      }
+    },
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
@@ -734,6 +1905,93 @@
         "color-convert": "^1.9.0"
       }
     },
+    "any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8=",
+      "dev": true
+    },
+    "append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha1-HjRA6RXwsSA9I3SOeO3XubW0PlY=",
+      "dev": true
+    },
+    "append-transform": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-1.0.0.tgz",
+      "integrity": "sha512-P009oYkeHyU742iSZJzZZywj4QRJdnTWffaKuJQLablCZ1uz6/cW4yaRgcDaoQ+uwOxxnt0gRUcwfsNP2ri0gw==",
+      "dev": true,
+      "requires": {
+        "default-require-extensions": "^2.0.0"
+      }
+    },
+    "archiver": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-2.1.1.tgz",
+      "integrity": "sha1-/2YrSnggFJSj7lRNOjP+dJZQnrw=",
+      "dev": true,
+      "requires": {
+        "archiver-utils": "^1.3.0",
+        "async": "^2.0.0",
+        "buffer-crc32": "^0.2.1",
+        "glob": "^7.0.0",
+        "lodash": "^4.8.0",
+        "readable-stream": "^2.0.0",
+        "tar-stream": "^1.5.0",
+        "zip-stream": "^1.2.0"
+      },
+      "dependencies": {
+        "bl": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+          "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
+          "dev": true,
+          "requires": {
+            "readable-stream": "^2.3.5",
+            "safe-buffer": "^5.1.1"
+          }
+        },
+        "tar-stream": {
+          "version": "1.6.2",
+          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
+          "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
+          "dev": true,
+          "requires": {
+            "bl": "^1.0.0",
+            "buffer-alloc": "^1.2.0",
+            "end-of-stream": "^1.0.0",
+            "fs-constants": "^1.0.0",
+            "readable-stream": "^2.3.0",
+            "to-buffer": "^1.1.1",
+            "xtend": "^4.0.0"
+          }
+        }
+      }
+    },
+    "archiver-utils": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-1.3.0.tgz",
+      "integrity": "sha1-5QtMCccL89aA4y/xt5lOn52JUXQ=",
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.0",
+        "graceful-fs": "^4.1.0",
+        "lazystream": "^1.0.0",
+        "lodash": "^4.8.0",
+        "normalize-path": "^2.0.0",
+        "readable-stream": "^2.0.0"
+      }
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
     "argv-tools": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/argv-tools/-/argv-tools-0.1.1.tgz",
@@ -744,6 +2002,27 @@
         "find-replace": "^2.0.1"
       }
     },
+    "arr-diff": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+      "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+      "dev": true,
+      "requires": {
+        "arr-flatten": "^1.0.1"
+      }
+    },
+    "arr-flatten": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+      "dev": true
+    },
+    "arr-union": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+      "dev": true
+    },
     "array-back": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
@@ -753,10 +2032,49 @@
         "typical": "^2.6.1"
       }
     },
+    "array-find-index": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+      "dev": true
+    },
+    "array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
+      "dev": true
+    },
     "array-from": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
       "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
+      "dev": true
+    },
+    "array-unique": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+      "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+      "dev": true
+    },
+    "arraybuffer.slice": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz",
+      "integrity": "sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog==",
+      "dev": true
+    },
+    "asn1": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
       "dev": true
     },
     "assertion-error": {
@@ -765,10 +2083,457 @@
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true
     },
+    "assign-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+      "dev": true
+    },
+    "async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
+      "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.11"
+      }
+    },
+    "async-limiter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
+      "dev": true
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
+    },
+    "atob": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "dev": true
+    },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+      "dev": true
+    },
+    "aws4": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
+      "dev": true
+    },
+    "babel-code-frame": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "js-tokens": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
+    },
+    "babel-generator": {
+      "version": "6.26.1",
+      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
+      "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
+      "dev": true,
+      "requires": {
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "detect-indent": "^4.0.0",
+        "jsesc": "^1.3.0",
+        "lodash": "^4.17.4",
+        "source-map": "^0.5.7",
+        "trim-right": "^1.0.1"
+      },
+      "dependencies": {
+        "jsesc": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+          "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
+    "babel-helper-evaluate-path": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-evaluate-path/-/babel-helper-evaluate-path-0.5.0.tgz",
+      "integrity": "sha512-mUh0UhS607bGh5wUMAQfOpt2JX2ThXMtppHRdRU1kL7ZLRWIXxoV2UIV1r2cAeeNeU1M5SB5/RSUgUxrK8yOkA==",
+      "dev": true
+    },
+    "babel-helper-flip-expressions": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/babel-helper-flip-expressions/-/babel-helper-flip-expressions-0.4.3.tgz",
+      "integrity": "sha1-NpZzahKKwYvCUlS19AoizrPB0/0=",
+      "dev": true
+    },
+    "babel-helper-is-nodes-equiv": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-is-nodes-equiv/-/babel-helper-is-nodes-equiv-0.0.1.tgz",
+      "integrity": "sha1-NOmzALFHnd2Y7HfqC76TQt/jloQ=",
+      "dev": true
+    },
+    "babel-helper-is-void-0": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/babel-helper-is-void-0/-/babel-helper-is-void-0-0.4.3.tgz",
+      "integrity": "sha1-fZwBtFYee5Xb2g9u7kj1tg5nMT4=",
+      "dev": true
+    },
+    "babel-helper-mark-eval-scopes": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/babel-helper-mark-eval-scopes/-/babel-helper-mark-eval-scopes-0.4.3.tgz",
+      "integrity": "sha1-0kSjvvmESHJgP/tG4izorN9VFWI=",
+      "dev": true
+    },
+    "babel-helper-remove-or-void": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/babel-helper-remove-or-void/-/babel-helper-remove-or-void-0.4.3.tgz",
+      "integrity": "sha1-pPA7QAd6D/6I5F0HAQ3uJB/1rmA=",
+      "dev": true
+    },
+    "babel-helper-to-multiple-sequence-expressions": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-to-multiple-sequence-expressions/-/babel-helper-to-multiple-sequence-expressions-0.5.0.tgz",
+      "integrity": "sha512-m2CvfDW4+1qfDdsrtf4dwOslQC3yhbgyBFptncp4wvtdrDHqueW7slsYv4gArie056phvQFhT2nRcGS4bnm6mA==",
+      "dev": true
+    },
+    "babel-messages": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+      "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-minify-builtins": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-builtins/-/babel-plugin-minify-builtins-0.5.0.tgz",
+      "integrity": "sha512-wpqbN7Ov5hsNwGdzuzvFcjgRlzbIeVv1gMIlICbPj0xkexnfoIDe7q+AZHMkQmAE/F9R5jkrB6TLfTegImlXag==",
+      "dev": true
+    },
+    "babel-plugin-minify-constant-folding": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-constant-folding/-/babel-plugin-minify-constant-folding-0.5.0.tgz",
+      "integrity": "sha512-Vj97CTn/lE9hR1D+jKUeHfNy+m1baNiJ1wJvoGyOBUx7F7kJqDZxr9nCHjO/Ad+irbR3HzR6jABpSSA29QsrXQ==",
+      "dev": true,
+      "requires": {
+        "babel-helper-evaluate-path": "^0.5.0"
+      }
+    },
+    "babel-plugin-minify-dead-code-elimination": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-dead-code-elimination/-/babel-plugin-minify-dead-code-elimination-0.5.0.tgz",
+      "integrity": "sha512-XQteBGXlgEoAKc/BhO6oafUdT4LBa7ARi55mxoyhLHNuA+RlzRmeMAfc31pb/UqU01wBzRc36YqHQzopnkd/6Q==",
+      "dev": true,
+      "requires": {
+        "babel-helper-evaluate-path": "^0.5.0",
+        "babel-helper-mark-eval-scopes": "^0.4.3",
+        "babel-helper-remove-or-void": "^0.4.3",
+        "lodash.some": "^4.6.0"
+      }
+    },
+    "babel-plugin-minify-flip-comparisons": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-flip-comparisons/-/babel-plugin-minify-flip-comparisons-0.4.3.tgz",
+      "integrity": "sha1-AMqHDLjxO0XAOLPB68DyJyk8llo=",
+      "dev": true,
+      "requires": {
+        "babel-helper-is-void-0": "^0.4.3"
+      }
+    },
+    "babel-plugin-minify-guarded-expressions": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-guarded-expressions/-/babel-plugin-minify-guarded-expressions-0.4.3.tgz",
+      "integrity": "sha1-zHCbRFP9IbHzAod0RMifiEJ845c=",
+      "dev": true,
+      "requires": {
+        "babel-helper-flip-expressions": "^0.4.3"
+      }
+    },
+    "babel-plugin-minify-infinity": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-infinity/-/babel-plugin-minify-infinity-0.4.3.tgz",
+      "integrity": "sha1-37h2obCKBldjhO8/kuZTumB7Oco=",
+      "dev": true
+    },
+    "babel-plugin-minify-mangle-names": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-mangle-names/-/babel-plugin-minify-mangle-names-0.5.0.tgz",
+      "integrity": "sha512-3jdNv6hCAw6fsX1p2wBGPfWuK69sfOjfd3zjUXkbq8McbohWy23tpXfy5RnToYWggvqzuMOwlId1PhyHOfgnGw==",
+      "dev": true,
+      "requires": {
+        "babel-helper-mark-eval-scopes": "^0.4.3"
+      }
+    },
+    "babel-plugin-minify-numeric-literals": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-numeric-literals/-/babel-plugin-minify-numeric-literals-0.4.3.tgz",
+      "integrity": "sha1-jk/VYcefeAEob/YOjF/Z3u6TwLw=",
+      "dev": true
+    },
+    "babel-plugin-minify-replace": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-replace/-/babel-plugin-minify-replace-0.5.0.tgz",
+      "integrity": "sha512-aXZiaqWDNUbyNNNpWs/8NyST+oU7QTpK7J9zFEFSA0eOmtUNMU3fczlTTTlnCxHmq/jYNFEmkkSG3DDBtW3Y4Q==",
+      "dev": true
+    },
+    "babel-plugin-minify-simplify": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-simplify/-/babel-plugin-minify-simplify-0.5.0.tgz",
+      "integrity": "sha512-TM01J/YcKZ8XIQd1Z3nF2AdWHoDsarjtZ5fWPDksYZNsoOjQ2UO2EWm824Ym6sp127m44gPlLFiO5KFxU8pA5Q==",
+      "dev": true,
+      "requires": {
+        "babel-helper-flip-expressions": "^0.4.3",
+        "babel-helper-is-nodes-equiv": "^0.0.1",
+        "babel-helper-to-multiple-sequence-expressions": "^0.5.0"
+      }
+    },
+    "babel-plugin-minify-type-constructors": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-type-constructors/-/babel-plugin-minify-type-constructors-0.4.3.tgz",
+      "integrity": "sha1-G8bxW4f3qxCF1CszC3F2V6IVZQA=",
+      "dev": true,
+      "requires": {
+        "babel-helper-is-void-0": "^0.4.3"
+      }
+    },
+    "babel-plugin-transform-inline-consecutive-adds": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-inline-consecutive-adds/-/babel-plugin-transform-inline-consecutive-adds-0.4.3.tgz",
+      "integrity": "sha1-Mj1Ho+pjqDp6w8gRro5pQfrysNE=",
+      "dev": true
+    },
+    "babel-plugin-transform-member-expression-literals": {
+      "version": "6.9.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-member-expression-literals/-/babel-plugin-transform-member-expression-literals-6.9.4.tgz",
+      "integrity": "sha1-NwOcmgwzE6OUlfqsL/OmtbnQOL8=",
+      "dev": true
+    },
+    "babel-plugin-transform-merge-sibling-variables": {
+      "version": "6.9.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-merge-sibling-variables/-/babel-plugin-transform-merge-sibling-variables-6.9.4.tgz",
+      "integrity": "sha1-hbQi/DN3tEnJ0c3kQIcgNTJAHa4=",
+      "dev": true
+    },
+    "babel-plugin-transform-minify-booleans": {
+      "version": "6.9.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-minify-booleans/-/babel-plugin-transform-minify-booleans-6.9.4.tgz",
+      "integrity": "sha1-rLs+VqNVXdI5KOS1gtKFFi3SsZg=",
+      "dev": true
+    },
+    "babel-plugin-transform-property-literals": {
+      "version": "6.9.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-property-literals/-/babel-plugin-transform-property-literals-6.9.4.tgz",
+      "integrity": "sha1-mMHSHiVXNlc/k+zlRFn2ziSYXTk=",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2"
+      }
+    },
+    "babel-plugin-transform-regexp-constructors": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-regexp-constructors/-/babel-plugin-transform-regexp-constructors-0.4.3.tgz",
+      "integrity": "sha1-WLd3W2OvzzMyj66aX4j71PsLSWU=",
+      "dev": true
+    },
+    "babel-plugin-transform-remove-console": {
+      "version": "6.9.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-console/-/babel-plugin-transform-remove-console-6.9.4.tgz",
+      "integrity": "sha1-uYA2DAZzhOJLNXpYjYB9PINSd4A=",
+      "dev": true
+    },
+    "babel-plugin-transform-remove-debugger": {
+      "version": "6.9.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-debugger/-/babel-plugin-transform-remove-debugger-6.9.4.tgz",
+      "integrity": "sha1-QrcnYxyXl44estGZp67IShgznvI=",
+      "dev": true
+    },
+    "babel-plugin-transform-remove-undefined": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-undefined/-/babel-plugin-transform-remove-undefined-0.5.0.tgz",
+      "integrity": "sha512-+M7fJYFaEE/M9CXa0/IRkDbiV3wRELzA1kKQFCJ4ifhrzLKn/9VCCgj9OFmYWwBd8IB48YdgPkHYtbYq+4vtHQ==",
+      "dev": true,
+      "requires": {
+        "babel-helper-evaluate-path": "^0.5.0"
+      }
+    },
+    "babel-plugin-transform-simplify-comparison-operators": {
+      "version": "6.9.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-simplify-comparison-operators/-/babel-plugin-transform-simplify-comparison-operators-6.9.4.tgz",
+      "integrity": "sha1-9ir+CWyrDh9ootdT/fKDiIRxzrk=",
+      "dev": true
+    },
+    "babel-plugin-transform-undefined-to-void": {
+      "version": "6.9.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-undefined-to-void/-/babel-plugin-transform-undefined-to-void-6.9.4.tgz",
+      "integrity": "sha1-viQcqBQEAwZ4t0hxcyK4nQyP4oA=",
+      "dev": true
+    },
+    "babel-preset-minify": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-minify/-/babel-preset-minify-0.5.0.tgz",
+      "integrity": "sha512-xj1s9Mon+RFubH569vrGCayA9Fm2GMsCgDRm1Jb8SgctOB7KFcrVc2o8K3YHUyMz+SWP8aea75BoS8YfsXXuiA==",
+      "dev": true,
+      "requires": {
+        "babel-plugin-minify-builtins": "^0.5.0",
+        "babel-plugin-minify-constant-folding": "^0.5.0",
+        "babel-plugin-minify-dead-code-elimination": "^0.5.0",
+        "babel-plugin-minify-flip-comparisons": "^0.4.3",
+        "babel-plugin-minify-guarded-expressions": "^0.4.3",
+        "babel-plugin-minify-infinity": "^0.4.3",
+        "babel-plugin-minify-mangle-names": "^0.5.0",
+        "babel-plugin-minify-numeric-literals": "^0.4.3",
+        "babel-plugin-minify-replace": "^0.5.0",
+        "babel-plugin-minify-simplify": "^0.5.0",
+        "babel-plugin-minify-type-constructors": "^0.4.3",
+        "babel-plugin-transform-inline-consecutive-adds": "^0.4.3",
+        "babel-plugin-transform-member-expression-literals": "^6.9.4",
+        "babel-plugin-transform-merge-sibling-variables": "^6.9.4",
+        "babel-plugin-transform-minify-booleans": "^6.9.4",
+        "babel-plugin-transform-property-literals": "^6.9.4",
+        "babel-plugin-transform-regexp-constructors": "^0.4.3",
+        "babel-plugin-transform-remove-console": "^6.9.4",
+        "babel-plugin-transform-remove-debugger": "^6.9.4",
+        "babel-plugin-transform-remove-undefined": "^0.5.0",
+        "babel-plugin-transform-simplify-comparison-operators": "^6.9.4",
+        "babel-plugin-transform-undefined-to-void": "^6.9.4",
+        "lodash.isplainobject": "^4.0.6"
+      }
+    },
+    "babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "dev": true,
+      "requires": {
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
+      }
+    },
+    "babel-traverse": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+      "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "^6.26.0",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "debug": "^2.6.8",
+        "globals": "^9.18.0",
+        "invariant": "^2.2.2",
+        "lodash": "^4.17.4"
+      },
+      "dependencies": {
+        "babylon": {
+          "version": "6.18.0",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+          "dev": true
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "globals": {
+          "version": "9.18.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
+    "babel-types": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+      "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.4",
+        "to-fast-properties": "^1.0.3"
+      },
+      "dependencies": {
+        "to-fast-properties": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+          "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+          "dev": true
+        }
+      }
+    },
     "babylon": {
       "version": "7.0.0-beta.47",
       "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.47.tgz",
       "integrity": "sha512-+rq2cr4GDhtToEzKFD6KZZMDBXhjFAr9JjPw9pAppZACeEWqNM294j+NdBzkSHYXwzzBmVjZ3nEVJlOhbR2gOQ==",
+      "dev": true
+    },
+    "backo2": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
+      "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc=",
       "dev": true
     },
     "balanced-match": {
@@ -776,6 +2541,197 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
+    },
+    "base": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+      "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+      "dev": true,
+      "requires": {
+        "cache-base": "^1.0.1",
+        "class-utils": "^0.3.5",
+        "component-emitter": "^1.2.1",
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.1",
+        "mixin-deep": "^1.2.0",
+        "pascalcase": "^0.1.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
+        }
+      }
+    },
+    "base64-arraybuffer": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
+      "integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg=",
+      "dev": true
+    },
+    "base64-js": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.0.tgz",
+      "integrity": "sha1-o5mS1yNYSBGYK+XikLtqU9hnAPE=",
+      "dev": true
+    },
+    "base64id": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/base64id/-/base64id-1.0.0.tgz",
+      "integrity": "sha1-R2iMuZu2gE8OBtPnY7HDLlfY5rY=",
+      "dev": true
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "dev": true,
+      "requires": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
+    "better-assert": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
+      "integrity": "sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=",
+      "dev": true,
+      "requires": {
+        "callsite": "1.0.0"
+      }
+    },
+    "bl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.0.tgz",
+      "integrity": "sha512-wbgvOpqopSr7uq6fJrLH8EsvYMJf9gzfo2jCsL2eTy75qXPukA4pCgHamOQkZtY5vmfVtjB+P3LNlMHW5CEZXA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "readable-stream": "^2.3.5",
+        "safe-buffer": "^5.1.1"
+      }
+    },
+    "blob": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.5.tgz",
+      "integrity": "sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig==",
+      "dev": true
+    },
+    "body-parser": {
+      "version": "1.18.3",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
+      "integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
+      "dev": true,
+      "requires": {
+        "bytes": "3.0.0",
+        "content-type": "~1.0.4",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "http-errors": "~1.6.3",
+        "iconv-lite": "0.4.23",
+        "on-finished": "~2.3.0",
+        "qs": "6.5.2",
+        "raw-body": "2.3.3",
+        "type-is": "~1.6.16"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
+    "bower-config": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/bower-config/-/bower-config-1.4.1.tgz",
+      "integrity": "sha1-hf2d82fCuNu9DKpMXyutQM2Ewsw=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.3",
+        "mout": "^1.0.0",
+        "optimist": "^0.6.1",
+        "osenv": "^0.1.3",
+        "untildify": "^2.1.0"
+      }
+    },
+    "boxen": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
+      "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
+      "dev": true,
+      "requires": {
+        "ansi-align": "^2.0.0",
+        "camelcase": "^4.0.0",
+        "chalk": "^2.0.1",
+        "cli-boxes": "^1.0.0",
+        "string-width": "^2.0.0",
+        "term-size": "^1.2.0",
+        "widest-line": "^2.0.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true
+        }
+      }
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -787,10 +2743,79 @@
         "concat-map": "0.0.1"
       }
     },
+    "braces": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+      "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+      "dev": true,
+      "requires": {
+        "expand-range": "^1.8.1",
+        "preserve": "^0.2.0",
+        "repeat-element": "^1.1.2"
+      }
+    },
+    "browser-capabilities": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/browser-capabilities/-/browser-capabilities-1.1.3.tgz",
+      "integrity": "sha512-mdpQfV436YU8kzFtvvlVGnSJNSoUIzQZRIlYOfjB0y/M/b0R9Hc8os0XIPXdluimJRUIIn3YePtYJjHGFXC24Q==",
+      "dev": true,
+      "requires": {
+        "@types/ua-parser-js": "^0.7.31",
+        "ua-parser-js": "^0.7.15"
+      }
+    },
     "browser-stdout": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
+    },
+    "browserstack": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/browserstack/-/browserstack-1.5.2.tgz",
+      "integrity": "sha512-+6AFt9HzhKykcPF79W6yjEUJcdvZOV0lIXdkORXMJftGrDl0OKWqRF4GHqpDNkxiceDT/uB7Fb/aDwktvXX7dg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "https-proxy-agent": "^2.2.1"
+      }
+    },
+    "buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",
+      "integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
+      "dev": true,
+      "requires": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
+      }
+    },
+    "buffer-alloc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
+      "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
+      "dev": true,
+      "requires": {
+        "buffer-alloc-unsafe": "^1.1.0",
+        "buffer-fill": "^1.0.0"
+      }
+    },
+    "buffer-alloc-unsafe": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
+      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
+      "dev": true
+    },
+    "buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+      "dev": true
+    },
+    "buffer-fill": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
+      "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
       "dev": true
     },
     "buffer-from": {
@@ -798,6 +2823,99 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
       "dev": true
+    },
+    "busboy": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-0.2.14.tgz",
+      "integrity": "sha1-bCpiLvz0fFe7vh4qnDetNseSVFM=",
+      "dev": true,
+      "requires": {
+        "dicer": "0.2.5",
+        "readable-stream": "1.1.x"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        }
+      }
+    },
+    "bytes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
+      "dev": true
+    },
+    "cache-base": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+      "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+      "dev": true,
+      "requires": {
+        "collection-visit": "^1.0.0",
+        "component-emitter": "^1.2.1",
+        "get-value": "^2.0.6",
+        "has-value": "^1.0.0",
+        "isobject": "^3.0.1",
+        "set-value": "^2.0.0",
+        "to-object-path": "^0.3.0",
+        "union-value": "^1.0.0",
+        "unset-value": "^1.0.0"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
+      }
+    },
+    "callsite": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
+      "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA=",
+      "dev": true
+    },
+    "camel-case": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
+      "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
+      "dev": true,
+      "requires": {
+        "no-case": "^2.2.0",
+        "upper-case": "^1.1.1"
+      }
+    },
+    "camelcase": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+      "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+      "dev": true
+    },
+    "camelcase-keys": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
+      "dev": true,
+      "requires": {
+        "camelcase": "^2.0.0",
+        "map-obj": "^1.0.0"
+      }
     },
     "cancel-token": {
       "version": "0.1.1",
@@ -815,6 +2933,18 @@
           "dev": true
         }
       }
+    },
+    "capture-stack-trace": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz",
+      "integrity": "sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw==",
+      "dev": true
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+      "dev": true
     },
     "chai": {
       "version": "4.2.0",
@@ -841,10 +2971,72 @@
         "supports-color": "^5.3.0"
       }
     },
+    "charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=",
+      "dev": true
+    },
     "check-error": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
       "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "dev": true
+    },
+    "ci-info": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
+      "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
+      "dev": true
+    },
+    "class-utils": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+      "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+      "dev": true,
+      "requires": {
+        "arr-union": "^3.1.0",
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "static-extend": "^0.1.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
+      }
+    },
+    "clean-css": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.1.tgz",
+      "integrity": "sha512-4ZxI6dy4lrY6FHzfiy1aEOXgu4LIsW2MhwG0VBKdcoGoH/XLFgaHSdLTGr4O8Be6A8r3MOphEiI8Gc1n0ecf3g==",
+      "dev": true,
+      "requires": {
+        "source-map": "~0.6.0"
+      }
+    },
+    "cleankill": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/cleankill/-/cleankill-2.0.0.tgz",
+      "integrity": "sha1-WYMN/ItBHVPccq0J1Fp46jMWGpE=",
+      "dev": true
+    },
+    "cli-boxes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
+      "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
       "dev": true
     },
     "clipboard": {
@@ -865,6 +3057,32 @@
       "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
       "dev": true
     },
+    "clone-stats": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+      "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
+      "dev": true
+    },
+    "collection-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+      "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+      "dev": true,
+      "requires": {
+        "map-visit": "^1.0.0",
+        "object-visit": "^1.0.0"
+      }
+    },
+    "color": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.0.0.tgz",
+      "integrity": "sha512-jCpd5+s0s0t7p3pHQKpnJ0TpQKKdleP71LWcA0aqiljpiuAkOSUFN/dyH8ZwF0hRmFlrIuRhufds1QyEP9EB+w==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^1.9.1",
+        "color-string": "^1.5.2"
+      }
+    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -879,6 +3097,47 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
+    },
+    "color-string": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.3.tgz",
+      "integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
+      "dev": true,
+      "requires": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "colornames": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/colornames/-/colornames-1.1.1.tgz",
+      "integrity": "sha1-+IiQMGhcfE/54qVZ9Qd+t2qBb5Y=",
+      "dev": true
+    },
+    "colors": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
+      "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==",
+      "dev": true
+    },
+    "colorspace": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.1.tgz",
+      "integrity": "sha512-pI3btWyiuz7Ken0BWh9Elzsmv2bM9AhA7psXib4anUXy/orfZ/E0MbQwhSOG/9L8hLlalqrU0UhOuqxW1YjmVw==",
+      "dev": true,
+      "requires": {
+        "color": "3.0.x",
+        "text-hex": "1.0.x"
+      }
+    },
+    "combined-stream": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
+      "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
+      "dev": true,
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
     },
     "command-line-args": {
       "version": "5.0.2",
@@ -911,17 +3170,280 @@
       "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
       "dev": true
     },
+    "compare-versions": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.4.0.tgz",
+      "integrity": "sha512-tK69D7oNXXqUW3ZNo/z7NXTEz22TCF0pTE+YF9cxvaAM9XnkLo1fV621xCLrRR6aevJlKxExkss0vWqUCUpqdg==",
+      "dev": true
+    },
+    "component-bind": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
+      "integrity": "sha1-AMYIq33Nk4l8AAllGx06jh5zu9E=",
+      "dev": true
+    },
+    "component-emitter": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
+      "dev": true
+    },
+    "component-inherit": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
+      "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM=",
+      "dev": true
+    },
+    "compress-commons": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-1.2.2.tgz",
+      "integrity": "sha1-UkqfEJA/OoEzibAiXSfEi7dRiQ8=",
+      "dev": true,
+      "requires": {
+        "buffer-crc32": "^0.2.1",
+        "crc32-stream": "^2.0.0",
+        "normalize-path": "^2.0.0",
+        "readable-stream": "^2.0.0"
+      }
+    },
+    "compressible": {
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.16.tgz",
+      "integrity": "sha512-JQfEOdnI7dASwCuSPWIeVYwc/zMsu/+tRhoUvEfXz2gxOA2DNjmG5vhtFdBlhWPPGo+RdT9S3tgc/uH5qgDiiA==",
+      "dev": true,
+      "requires": {
+        "mime-db": ">= 1.38.0 < 2"
+      }
+    },
+    "compression": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.4.tgz",
+      "integrity": "sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==",
+      "dev": true,
+      "requires": {
+        "accepts": "~1.3.5",
+        "bytes": "3.0.0",
+        "compressible": "~2.0.16",
+        "debug": "2.6.9",
+        "on-headers": "~1.0.2",
+        "safe-buffer": "5.1.2",
+        "vary": "~1.1.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
+    "concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "configstore": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
+      "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
+      "dev": true,
+      "requires": {
+        "dot-prop": "^4.1.0",
+        "graceful-fs": "^4.1.2",
+        "make-dir": "^1.0.0",
+        "unique-string": "^1.0.0",
+        "write-file-atomic": "^2.0.0",
+        "xdg-basedir": "^3.0.0"
+      },
+      "dependencies": {
+        "make-dir": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+          "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+          "dev": true,
+          "requires": {
+            "pify": "^3.0.0"
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        }
+      }
+    },
+    "content-disposition": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+      "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ=",
+      "dev": true
+    },
+    "content-type": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+      "dev": true
+    },
+    "convert-source-map": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
+      "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.1"
+      }
+    },
+    "cookie": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
+      "dev": true
+    },
+    "cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
+      "dev": true
+    },
+    "copy-descriptor": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+      "dev": true
+    },
+    "core-js": {
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
+      "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==",
+      "dev": true
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
+    "cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "dev": true,
+      "requires": {
+        "object-assign": "^4",
+        "vary": "^1"
+      }
+    },
+    "crc": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
+      "integrity": "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==",
+      "dev": true,
+      "requires": {
+        "buffer": "^5.1.0"
+      }
+    },
+    "crc32-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-2.0.0.tgz",
+      "integrity": "sha1-483TtN8xaN10494/u8t7KX/pCPQ=",
+      "dev": true,
+      "requires": {
+        "crc": "^3.4.4",
+        "readable-stream": "^2.0.0"
+      }
+    },
+    "create-error-class": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
+      "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
+      "dev": true,
+      "requires": {
+        "capture-stack-trace": "^1.0.0"
+      }
+    },
+    "cross-spawn": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^4.0.1",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      }
+    },
+    "crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=",
+      "dev": true
+    },
+    "crypto-random-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
+      "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
+      "dev": true
+    },
+    "css-slam": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/css-slam/-/css-slam-2.1.2.tgz",
+      "integrity": "sha512-cObrY+mhFEmepWpua6EpMrgRNTQ0eeym+kvR0lukI6hDEzK7F8himEDS4cJ9+fPHCoArTzVrrR0d+oAUbTR1NA==",
+      "dev": true,
+      "requires": {
+        "command-line-args": "^5.0.2",
+        "command-line-usage": "^5.0.5",
+        "dom5": "^3.0.0",
+        "parse5": "^4.0.0",
+        "shady-css-parser": "^0.1.0"
+      }
+    },
     "cssbeautify": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/cssbeautify/-/cssbeautify-0.3.1.tgz",
       "integrity": "sha1-Et0fc0A1wub6ymfcvc73TkKBE5c=",
       "dev": true
+    },
+    "currently-unhandled": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+      "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+      "dev": true,
+      "requires": {
+        "array-find-index": "^1.0.1"
+      }
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
     },
     "debug": {
       "version": "4.1.1",
@@ -931,6 +3453,18 @@
       "requires": {
         "ms": "^2.1.1"
       }
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
+    },
+    "decode-uri-component": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "dev": true
     },
     "deep-eql": {
       "version": "3.0.1",
@@ -953,12 +3487,154 @@
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
+    "default-require-extensions": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-2.0.0.tgz",
+      "integrity": "sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=",
+      "dev": true,
+      "requires": {
+        "strip-bom": "^3.0.0"
+      }
+    },
+    "define-property": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+      "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+      "dev": true,
+      "requires": {
+        "is-descriptor": "^1.0.2",
+        "isobject": "^3.0.1"
+      },
+      "dependencies": {
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
+        }
+      }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
+    },
     "delegate": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
       "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
       "dev": true,
       "optional": true
+    },
+    "depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+      "dev": true
+    },
+    "destroy": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
+      "dev": true
+    },
+    "detect-file": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
+      "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
+      "dev": true
+    },
+    "detect-indent": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+      "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+      "dev": true,
+      "requires": {
+        "repeating": "^2.0.0"
+      }
+    },
+    "detect-node": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.4.tgz",
+      "integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw==",
+      "dev": true
+    },
+    "diagnostics": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/diagnostics/-/diagnostics-1.1.1.tgz",
+      "integrity": "sha512-8wn1PmdunLJ9Tqbx+Fx/ZEuHfJf4NKSN2ZBj7SJC/OWRWha843+WsTjqMe1B5E3p28jqBlp+mJ2fPVxPyNgYKQ==",
+      "dev": true,
+      "requires": {
+        "colorspace": "1.1.x",
+        "enabled": "1.0.x",
+        "kuler": "1.0.x"
+      }
+    },
+    "dicer": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.2.5.tgz",
+      "integrity": "sha1-WZbAhrszIYyBLAkL3cCc0S+stw8=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "1.1.x",
+        "streamsearch": "0.1.2"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        }
+      }
     },
     "diff": {
       "version": "3.5.0",
@@ -975,6 +3651,15 @@
         "esutils": "^2.0.2"
       }
     },
+    "dom-urls": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/dom-urls/-/dom-urls-1.1.0.tgz",
+      "integrity": "sha1-AB3fgWKM0ecGElxxdvU8zsVdkY4=",
+      "dev": true,
+      "requires": {
+        "urijs": "^1.16.1"
+      }
+    },
     "dom5": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dom5/-/dom5-3.0.1.tgz",
@@ -985,6 +3670,215 @@
         "clone": "^2.1.0",
         "parse5": "^4.0.0"
       }
+    },
+    "dot-prop": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
+      "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+      "dev": true,
+      "requires": {
+        "is-obj": "^1.0.0"
+      }
+    },
+    "duplexer2": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "duplexer3": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
+      "dev": true
+    },
+    "duplexify": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
+      "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "^1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
+      }
+    },
+    "ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "dev": true,
+      "requires": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
+    "ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+      "dev": true
+    },
+    "emitter-component": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/emitter-component/-/emitter-component-1.1.1.tgz",
+      "integrity": "sha1-Bl4tvtaVm/RwZ57avq95gdEAOrY=",
+      "dev": true
+    },
+    "enabled": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-1.0.2.tgz",
+      "integrity": "sha1-ll9lE9LC0cX0ZStkouM5ZGf8L5M=",
+      "dev": true,
+      "requires": {
+        "env-variable": "0.0.x"
+      }
+    },
+    "encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
+      "dev": true
+    },
+    "end-of-stream": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "dev": true,
+      "requires": {
+        "once": "^1.4.0"
+      }
+    },
+    "engine.io": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.3.2.tgz",
+      "integrity": "sha512-AsaA9KG7cWPXWHp5FvHdDWY3AMWeZ8x+2pUVLcn71qE5AtAzgGbxuclOytygskw8XGmiQafTmnI9Bix3uihu2w==",
+      "dev": true,
+      "requires": {
+        "accepts": "~1.3.4",
+        "base64id": "1.0.0",
+        "cookie": "0.3.1",
+        "debug": "~3.1.0",
+        "engine.io-parser": "~2.1.0",
+        "ws": "~6.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
+    "engine.io-client": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.3.2.tgz",
+      "integrity": "sha512-y0CPINnhMvPuwtqXfsGuWE8BB66+B6wTtCofQDRecMQPYX3MYUZXFNKDhdrSe3EVjgOu4V3rxdeqN/Tr91IgbQ==",
+      "dev": true,
+      "requires": {
+        "component-emitter": "1.2.1",
+        "component-inherit": "0.0.3",
+        "debug": "~3.1.0",
+        "engine.io-parser": "~2.1.1",
+        "has-cors": "1.1.0",
+        "indexof": "0.0.1",
+        "parseqs": "0.0.5",
+        "parseuri": "0.0.5",
+        "ws": "~6.1.0",
+        "xmlhttprequest-ssl": "~1.5.4",
+        "yeast": "0.1.2"
+      },
+      "dependencies": {
+        "component-emitter": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+          "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+          "dev": true
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
+    "engine.io-parser": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.1.3.tgz",
+      "integrity": "sha512-6HXPre2O4Houl7c4g7Ic/XzPnHBvaEmN90vtRO9uLmwtRqQmTOw0QMevL1TOfL2Cpu1VzsaTmMotQgMdkzGkVA==",
+      "dev": true,
+      "requires": {
+        "after": "0.8.2",
+        "arraybuffer.slice": "~0.0.7",
+        "base64-arraybuffer": "0.1.5",
+        "blob": "0.0.5",
+        "has-binary2": "~1.0.2"
+      }
+    },
+    "env-variable": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/env-variable/-/env-variable-0.0.5.tgz",
+      "integrity": "sha512-zoB603vQReOFvTg5xMl9I1P2PnHsHQQKTEowsKKD7nseUfJq6UWzK+4YtlWUO1nhiQUxe6XMkk+JleSZD1NZFA==",
+      "dev": true
+    },
+    "error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "^0.2.1"
+      },
+      "dependencies": {
+        "is-arrayish": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+          "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+          "dev": true
+        }
+      }
+    },
+    "es6-promise": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.6.tgz",
+      "integrity": "sha512-aRVgGdnmW2OiySVPUC9e6m+plolMAJKjZnQlCwNSuK5yQ0JN61DZSO1X1Ufd1foqWRAlig0rhduTCHe7sVtK5Q==",
+      "dev": true
+    },
+    "es6-promisify": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-6.0.1.tgz",
+      "integrity": "sha512-J3ZkwbEnnO+fGAKrjVpeUAnZshAdfZvbhQpqfIH9kSAspReRC4nJnu8ewm55b4y9ElyeuhCTzJD0XiH8Tsbhlw==",
+      "dev": true
+    },
+    "escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+      "dev": true
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -1005,6 +3899,16 @@
         "source-map": "~0.6.1"
       }
     },
+    "espree": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+      "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+      "dev": true,
+      "requires": {
+        "acorn": "^5.5.0",
+        "acorn-jsx": "^3.0.0"
+      }
+    },
     "esprima": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
@@ -1021,6 +3925,159 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "dev": true
+    },
+    "etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+      "dev": true
+    },
+    "eventemitter3": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.0.tgz",
+      "integrity": "sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA==",
+      "dev": true
+    },
+    "execa": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+      "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^5.0.1",
+        "get-stream": "^3.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
+      }
+    },
+    "expand-brackets": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+      "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+      "dev": true,
+      "requires": {
+        "is-posix-bracket": "^0.1.0"
+      }
+    },
+    "expand-range": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+      "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+      "dev": true,
+      "requires": {
+        "fill-range": "^2.1.0"
+      }
+    },
+    "expand-tilde": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+      "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
+      "dev": true,
+      "requires": {
+        "homedir-polyfill": "^1.0.1"
+      }
+    },
+    "express": {
+      "version": "4.16.4",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.16.4.tgz",
+      "integrity": "sha512-j12Uuyb4FMrd/qQAm6uCHAkPtO8FDTRJZBDd5D2KOL2eLaz1yUNdUB/NOIyq0iU4q4cFarsUCrnFDPBcnksuOg==",
+      "dev": true,
+      "requires": {
+        "accepts": "~1.3.5",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.18.3",
+        "content-disposition": "0.5.2",
+        "content-type": "~1.0.4",
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "1.1.1",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~2.0.4",
+        "qs": "6.5.2",
+        "range-parser": "~1.2.0",
+        "safe-buffer": "5.1.2",
+        "send": "0.16.2",
+        "serve-static": "1.13.2",
+        "setprototypeof": "1.1.0",
+        "statuses": "~1.4.0",
+        "type-is": "~1.6.16",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
+        "path-to-regexp": {
+          "version": "0.1.7",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+          "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
+          "dev": true
+        }
+      }
+    },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true
+    },
+    "extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "dev": true,
+      "requires": {
+        "is-extendable": "^0.1.0"
+      }
+    },
+    "extglob": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+      "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^1.0.0"
+      },
+      "dependencies": {
+        "is-extglob": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+          "dev": true
+        }
+      }
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
       "dev": true
     },
     "fast-deep-equal": {
@@ -1041,6 +4098,106 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fast-safe-stringify": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.6.tgz",
+      "integrity": "sha512-q8BZ89jjc+mz08rSxROs8VsrBBcn1SIw1kq9NjolL509tkABRk9io01RAjSaEv1Xb2uFLt8VtRiZbGp5H8iDtg==",
+      "dev": true
+    },
+    "fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "pend": "~1.2.0"
+      }
+    },
+    "fecha": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-2.3.3.tgz",
+      "integrity": "sha512-lUGBnIamTAwk4znq5BcqsDaxSmZ9nDVJaij6NvRt/Tg4R69gERA+otPKbS86ROw9nxVMw2/mp1fnaiWqbs6Sdg==",
+      "dev": true
+    },
+    "filename-regex": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+      "dev": true
+    },
+    "fileset": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/fileset/-/fileset-2.0.3.tgz",
+      "integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.3",
+        "minimatch": "^3.0.3"
+      }
+    },
+    "fill-range": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
+      "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
+      "dev": true,
+      "requires": {
+        "is-number": "^2.1.0",
+        "isobject": "^2.0.0",
+        "randomatic": "^3.0.0",
+        "repeat-element": "^1.1.2",
+        "repeat-string": "^1.5.2"
+      }
+    },
+    "finalhandler": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+      "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
+        "statuses": "~1.4.0",
+        "unpipe": "~1.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
+    "find-port": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/find-port/-/find-port-1.0.1.tgz",
+      "integrity": "sha1-2whKbL+ZVk2Zhprnn73s9m6KGFw=",
+      "dev": true,
+      "requires": {
+        "async": "~0.2.9"
+      },
+      "dependencies": {
+        "async": {
+          "version": "0.2.10",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
+          "dev": true
+        }
+      }
+    },
     "find-replace": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-2.0.1.tgz",
@@ -1050,6 +4207,447 @@
         "array-back": "^2.0.0",
         "test-value": "^3.0.0"
       }
+    },
+    "find-up": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+      "dev": true,
+      "requires": {
+        "path-exists": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
+      }
+    },
+    "findup-sync": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
+      "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
+      "dev": true,
+      "requires": {
+        "detect-file": "^1.0.0",
+        "is-glob": "^3.1.0",
+        "micromatch": "^3.0.4",
+        "resolve-dir": "^1.0.1"
+      },
+      "dependencies": {
+        "arr-diff": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+          "dev": true
+        },
+        "array-unique": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+          "dev": true
+        },
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "expand-brackets": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+          "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+          "dev": true,
+          "requires": {
+            "debug": "^2.3.3",
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "posix-character-classes": "^0.1.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+              "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+              "dev": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "dev": true,
+                  "requires": {
+                    "is-buffer": "^1.1.5"
+                  }
+                }
+              }
+            },
+            "is-data-descriptor": {
+              "version": "0.1.4",
+              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+              "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+              "dev": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "dev": true,
+                  "requires": {
+                    "is-buffer": "^1.1.5"
+                  }
+                }
+              }
+            },
+            "is-descriptor": {
+              "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+              "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+              "dev": true,
+              "requires": {
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
+              }
+            },
+            "kind-of": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+              "dev": true
+            }
+          }
+        },
+        "extend-shallow": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+          "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+          "dev": true,
+          "requires": {
+            "assign-symbols": "^1.0.0",
+            "is-extendable": "^1.0.1"
+          },
+          "dependencies": {
+            "is-extendable": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+              "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+              "dev": true,
+              "requires": {
+                "is-plain-object": "^2.0.4"
+              }
+            }
+          }
+        },
+        "extglob": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+          "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+          "dev": true,
+          "requires": {
+            "array-unique": "^0.3.2",
+            "define-property": "^1.0.0",
+            "expand-brackets": "^2.1.4",
+            "extend-shallow": "^2.0.1",
+            "fragment-cache": "^0.2.1",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "^1.0.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
+        },
+        "micromatch": {
+          "version": "3.1.10",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+          "dev": true,
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
+    "first-chunk-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
+      "integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04=",
+      "dev": true
+    },
+    "follow-redirects": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.7.0.tgz",
+      "integrity": "sha512-m/pZQy4Gj287eNy94nivy5wchN3Kp+Q5WgUPNy5lJSZ3sgkVKSYV/ZChMAQVIgx1SqfZ2zBZtPA2YlXIWxxJOQ==",
+      "dev": true,
+      "requires": {
+        "debug": "^3.2.6"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
+    },
+    "for-in": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+      "dev": true
+    },
+    "for-own": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+      "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+      "dev": true,
+      "requires": {
+        "for-in": "^1.0.1"
+      }
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true
+    },
+    "fork-stream": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/fork-stream/-/fork-stream-0.0.4.tgz",
+      "integrity": "sha1-24Sfznf2cIpfjzhq5TOgkHtUrnA=",
+      "dev": true
+    },
+    "form-data": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "dev": true,
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      }
+    },
+    "formatio": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
+      "integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
+      "dev": true,
+      "requires": {
+        "samsam": "1.x"
+      }
+    },
+    "forwarded": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
+      "dev": true
+    },
+    "fragment-cache": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+      "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+      "dev": true,
+      "requires": {
+        "map-cache": "^0.2.2"
+      }
+    },
+    "freeport": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/freeport/-/freeport-1.0.5.tgz",
+      "integrity": "sha1-JV6KuEFwwzuoXZkOghrl9KGpvF0=",
+      "dev": true,
+      "optional": true
+    },
+    "fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+      "dev": true
+    },
+    "fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true
     },
     "fs-extra": {
       "version": "6.0.1",
@@ -1074,6 +4672,33 @@
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
     },
+    "get-stdin": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+      "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+      "dev": true
+    },
+    "get-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+      "dev": true
+    },
+    "get-value": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+      "dev": true
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
     "glob": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
@@ -1086,6 +4711,144 @@
         "minimatch": "^3.0.4",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
+      }
+    },
+    "glob-base": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+      "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+      "dev": true,
+      "requires": {
+        "glob-parent": "^2.0.0",
+        "is-glob": "^2.0.0"
+      },
+      "dependencies": {
+        "glob-parent": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+          "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+          "dev": true,
+          "requires": {
+            "is-glob": "^2.0.0"
+          }
+        },
+        "is-extglob": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^1.0.0"
+          }
+        }
+      }
+    },
+    "glob-parent": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+      "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+      "dev": true,
+      "requires": {
+        "is-glob": "^3.1.0",
+        "path-dirname": "^1.0.0"
+      }
+    },
+    "glob-stream": {
+      "version": "5.3.5",
+      "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz",
+      "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
+      "dev": true,
+      "requires": {
+        "extend": "^3.0.0",
+        "glob": "^5.0.3",
+        "glob-parent": "^3.0.0",
+        "micromatch": "^2.3.7",
+        "ordered-read-streams": "^0.3.0",
+        "through2": "^0.6.0",
+        "to-absolute-glob": "^0.1.1",
+        "unique-stream": "^2.0.2"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "5.0.15",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+          "dev": true,
+          "requires": {
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        },
+        "through2": {
+          "version": "0.6.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+          "dev": true,
+          "requires": {
+            "readable-stream": ">=1.0.33-1 <1.1.0-0",
+            "xtend": ">=4.0.0 <4.1.0-0"
+          }
+        }
+      }
+    },
+    "global-dirs": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
+      "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
+      "dev": true,
+      "requires": {
+        "ini": "^1.3.4"
+      }
+    },
+    "global-modules": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
+      "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
+      "dev": true,
+      "requires": {
+        "global-prefix": "^1.0.1",
+        "is-windows": "^1.0.1",
+        "resolve-dir": "^1.0.0"
+      }
+    },
+    "global-prefix": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
+      "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
+      "dev": true,
+      "requires": {
+        "expand-tilde": "^2.0.2",
+        "homedir-polyfill": "^1.0.1",
+        "ini": "^1.3.4",
+        "is-windows": "^1.0.1",
+        "which": "^1.2.14"
       }
     },
     "globals": {
@@ -1104,6 +4867,25 @@
         "delegate": "^3.1.2"
       }
     },
+    "got": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+      "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
+      "dev": true,
+      "requires": {
+        "create-error-class": "^3.0.0",
+        "duplexer3": "^0.1.4",
+        "get-stream": "^3.0.0",
+        "is-redirect": "^1.0.0",
+        "is-retry-allowed": "^1.0.0",
+        "is-stream": "^1.0.0",
+        "lowercase-keys": "^1.0.0",
+        "safe-buffer": "^5.0.1",
+        "timed-out": "^4.0.0",
+        "unzip-response": "^2.0.1",
+        "url-parse-lax": "^1.0.0"
+      }
+    },
     "graceful-fs": {
       "version": "4.1.15",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
@@ -1116,6 +4898,98 @@
       "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
       "dev": true
     },
+    "gulp-if": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/gulp-if/-/gulp-if-2.0.2.tgz",
+      "integrity": "sha1-pJe351cwBQQcqivIt92jyARE1ik=",
+      "dev": true,
+      "requires": {
+        "gulp-match": "^1.0.3",
+        "ternary-stream": "^2.0.1",
+        "through2": "^2.0.1"
+      }
+    },
+    "gulp-match": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/gulp-match/-/gulp-match-1.0.3.tgz",
+      "integrity": "sha1-kcfA1/Kb7NZgbVfYCn+Hdqh6uo4=",
+      "dev": true,
+      "requires": {
+        "minimatch": "^3.0.3"
+      }
+    },
+    "gulp-sourcemaps": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
+      "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
+      "dev": true,
+      "requires": {
+        "convert-source-map": "^1.1.1",
+        "graceful-fs": "^4.1.2",
+        "strip-bom": "^2.0.0",
+        "through2": "^2.0.0",
+        "vinyl": "^1.0.0"
+      },
+      "dependencies": {
+        "strip-bom": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "dev": true,
+          "requires": {
+            "is-utf8": "^0.2.0"
+          }
+        }
+      }
+    },
+    "handle-thing": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-1.2.5.tgz",
+      "integrity": "sha1-/Xqtcmvxpf0W38KbL3pmAdJxOcQ=",
+      "dev": true
+    },
+    "handlebars": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
+      "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
+      "dev": true,
+      "requires": {
+        "neo-async": "^2.6.0",
+        "optimist": "^0.6.1",
+        "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4"
+      }
+    },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "dev": true
+    },
+    "har-validator": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.5.5",
+        "har-schema": "^2.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.10.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
+          "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^2.0.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        }
+      }
+    },
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
@@ -1125,11 +4999,100 @@
         "ansi-regex": "^2.0.0"
       }
     },
+    "has-binary2": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-binary2/-/has-binary2-1.0.3.tgz",
+      "integrity": "sha512-G1LWKhDSvhGeAQ8mPVQlqNcOB2sJdwATtZKl2pDKKHfpf/rYj24lkinxf69blJbnsvtqqNU+L3SL50vzZhXOnw==",
+      "dev": true,
+      "requires": {
+        "isarray": "2.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
+          "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=",
+          "dev": true
+        }
+      }
+    },
+    "has-color": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
+      "integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8=",
+      "dev": true
+    },
+    "has-cors": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
+      "integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk=",
+      "dev": true
+    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
+    },
+    "has-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+      "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+      "dev": true,
+      "requires": {
+        "get-value": "^2.0.6",
+        "has-values": "^1.0.0",
+        "isobject": "^3.0.0"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
+      }
+    },
+    "has-values": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+      "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+      "dev": true,
+      "requires": {
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "kind-of": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
     },
     "he": {
       "version": "1.1.1",
@@ -1137,10 +5100,210 @@
       "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
       "dev": true
     },
+    "homedir-polyfill": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
+      "integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
+      "dev": true,
+      "requires": {
+        "parse-passwd": "^1.0.0"
+      }
+    },
+    "hosted-git-info": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
+      "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
+      "dev": true
+    },
+    "hpack.js": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
+      "integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.1",
+        "obuf": "^1.0.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.1.0"
+      }
+    },
+    "html-minifier": {
+      "version": "3.5.21",
+      "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.21.tgz",
+      "integrity": "sha512-LKUKwuJDhxNa3uf/LPR/KVjm/l3rBqtYeCOAekvG8F1vItxMUpueGd94i/asDDr8/1u7InxzFA5EeGjhhG5mMA==",
+      "dev": true,
+      "requires": {
+        "camel-case": "3.0.x",
+        "clean-css": "4.2.x",
+        "commander": "2.17.x",
+        "he": "1.2.x",
+        "param-case": "2.1.x",
+        "relateurl": "0.2.x",
+        "uglify-js": "3.4.x"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.17.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
+          "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
+          "dev": true
+        },
+        "he": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+          "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+          "dev": true
+        },
+        "uglify-js": {
+          "version": "3.4.10",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.10.tgz",
+          "integrity": "sha512-Y2VsbPVs0FIshJztycsO2SfPk7/KAF/T72qzv9u5EpQ4kB2hQoHlhNQTsNyy6ul7lQtqJN/AoWeS23OzEiEFxw==",
+          "dev": true,
+          "requires": {
+            "commander": "~2.19.0",
+            "source-map": "~0.6.1"
+          },
+          "dependencies": {
+            "commander": {
+              "version": "2.19.0",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
+              "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
+              "dev": true
+            }
+          }
+        }
+      }
+    },
+    "html-script-hook": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/html-script-hook/-/html-script-hook-0.10.0.tgz",
+      "integrity": "sha1-AhInn7JHOXl7UNGOhhUqT5z/N8w=",
+      "dev": true,
+      "requires": {
+        "pegjs": "^0.9.0"
+      }
+    },
+    "http-deceiver": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
+      "integrity": "sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc=",
+      "dev": true
+    },
+    "http-errors": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+      "dev": true,
+      "requires": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.1.0",
+        "statuses": ">= 1.4.0 < 2"
+      }
+    },
+    "http-proxy": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.17.0.tgz",
+      "integrity": "sha512-Taqn+3nNvYRfJ3bGvKfBSRwy1v6eePlm3oc/aWVxZp57DQr5Eq3xhKJi7Z4hZpS8PC3H4qI+Yly5EmFacGuA/g==",
+      "dev": true,
+      "requires": {
+        "eventemitter3": "^3.0.0",
+        "follow-redirects": "^1.0.0",
+        "requires-port": "^1.0.0"
+      }
+    },
+    "http-proxy-middleware": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.17.4.tgz",
+      "integrity": "sha1-ZC6ISIUdZvCdTxJJEoRtuutBuDM=",
+      "dev": true,
+      "requires": {
+        "http-proxy": "^1.16.2",
+        "is-glob": "^3.1.0",
+        "lodash": "^4.17.2",
+        "micromatch": "^2.3.11"
+      }
+    },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+      }
+    },
+    "https-proxy-agent": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
+      "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "agent-base": "^4.1.0",
+        "debug": "^3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
+    },
+    "iconv-lite": {
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+      "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "ieee754": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
+      "dev": true
+    },
+    "import-lazy": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
+      "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
+      "dev": true
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
+    },
     "indent": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/indent/-/indent-0.0.2.tgz",
       "integrity": "sha1-jHnwgBkFWbaHA0uEx676l9WpEdk=",
+      "dev": true
+    },
+    "indent-string": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+      "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+      "dev": true,
+      "requires": {
+        "repeating": "^2.0.0"
+      }
+    },
+    "indexof": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+      "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
       "dev": true
     },
     "inflight": {
@@ -1159,6 +5322,241 @@
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "dev": true
     },
+    "ini": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "dev": true
+    },
+    "invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.0.0"
+      }
+    },
+    "ipaddr.js": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
+      "integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA==",
+      "dev": true
+    },
+    "is-accessor-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      }
+    },
+    "is-arrayish": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
+      "dev": true
+    },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true
+    },
+    "is-ci": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
+      "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
+      "dev": true,
+      "requires": {
+        "ci-info": "^1.5.0"
+      }
+    },
+    "is-data-descriptor": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      }
+    },
+    "is-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+      "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+      "dev": true,
+      "requires": {
+        "is-accessor-descriptor": "^0.1.6",
+        "is-data-descriptor": "^0.1.4",
+        "kind-of": "^5.0.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
+        }
+      }
+    },
+    "is-dotfile": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
+      "dev": true
+    },
+    "is-equal-shallow": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+      "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+      "dev": true,
+      "requires": {
+        "is-primitive": "^2.0.0"
+      }
+    },
+    "is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+      "dev": true
+    },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true
+    },
+    "is-finite": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+      "dev": true,
+      "requires": {
+        "number-is-nan": "^1.0.0"
+      }
+    },
+    "is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true
+    },
+    "is-glob": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+      "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^2.1.0"
+      }
+    },
+    "is-installed-globally": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
+      "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
+      "dev": true,
+      "requires": {
+        "global-dirs": "^0.1.0",
+        "is-path-inside": "^1.0.0"
+      }
+    },
+    "is-npm": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
+      "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
+      "dev": true
+    },
+    "is-number": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+      "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      }
+    },
+    "is-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+      "dev": true
+    },
+    "is-path-inside": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+      "dev": true,
+      "requires": {
+        "path-is-inside": "^1.0.1"
+      }
+    },
+    "is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.1"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
+      }
+    },
+    "is-posix-bracket": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+      "dev": true
+    },
+    "is-primitive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+      "dev": true
+    },
+    "is-redirect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
+      "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
+      "dev": true
+    },
+    "is-retry-allowed": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
+      "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
+      "dev": true
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
+    },
+    "is-utf8": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+      "dev": true
+    },
+    "is-valid-glob": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz",
+      "integrity": "sha1-1LVcafUYhvm2XHDWwmItN+KfSP4=",
+      "dev": true
+    },
     "is-windows": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
@@ -1171,10 +5569,306 @@
       "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
       "dev": true
     },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "isobject": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+      "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+      "dev": true,
+      "requires": {
+        "isarray": "1.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        }
+      }
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
+    },
+    "istanbub": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/istanbub/-/istanbub-0.4.6.tgz",
+      "integrity": "sha512-gdFOkD0tkO/jO4Kxenrg5XlRCduu99RfXwdh2PwAo9JMFM7WMpLhVUnTNvN+mkg3MXOiV51Poy0q+6NOItl8ug==",
+      "dev": true,
+      "requires": {
+        "abbrev": "1.0.x",
+        "async": "1.x",
+        "escodegen": "1.8.x",
+        "esprima": "4.0.x",
+        "glob": "^5.0.15",
+        "handlebars": "^4.0.1",
+        "js-yaml": "3.x",
+        "mkdirp": "0.5.x",
+        "nopt": "3.x",
+        "once": "1.x",
+        "resolve": "1.1.x",
+        "supports-color": "^3.1.0",
+        "which": "^1.1.1",
+        "wordwrap": "^1.0.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+          "dev": true
+        },
+        "escodegen": {
+          "version": "1.8.1",
+          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
+          "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
+          "dev": true,
+          "requires": {
+            "esprima": "^2.7.1",
+            "estraverse": "^1.9.1",
+            "esutils": "^2.0.2",
+            "optionator": "^0.8.1",
+            "source-map": "~0.2.0"
+          },
+          "dependencies": {
+            "esprima": {
+              "version": "2.7.3",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+              "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+              "dev": true
+            }
+          }
+        },
+        "esprima": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+          "dev": true
+        },
+        "estraverse": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
+          "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=",
+          "dev": true
+        },
+        "glob": {
+          "version": "5.0.15",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+          "dev": true,
+          "requires": {
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+          "dev": true
+        },
+        "resolve": {
+          "version": "1.1.7",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+          "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+          "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "amdefine": ">=0.0.4"
+          }
+        },
+        "supports-color": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^1.0.0"
+          }
+        }
+      }
+    },
+    "istanbul-api": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-2.1.5.tgz",
+      "integrity": "sha512-meYk1BwDp59Pfse1TvPrkKYgVqAufbdBLEVoqvu/hLLKSaQ054ZTksbNepyc223tMnWdm6AdK2URIJJRqdP87g==",
+      "dev": true,
+      "requires": {
+        "async": "^2.6.1",
+        "compare-versions": "^3.2.1",
+        "fileset": "^2.0.3",
+        "istanbul-lib-coverage": "^2.0.4",
+        "istanbul-lib-hook": "^2.0.6",
+        "istanbul-lib-instrument": "^3.2.0",
+        "istanbul-lib-report": "^2.0.7",
+        "istanbul-lib-source-maps": "^3.0.5",
+        "istanbul-reports": "^2.2.3",
+        "js-yaml": "^3.13.0",
+        "make-dir": "^2.1.0",
+        "minimatch": "^3.0.4",
+        "once": "^1.4.0"
+      },
+      "dependencies": {
+        "istanbul-lib-source-maps": {
+          "version": "3.0.5",
+          "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.5.tgz",
+          "integrity": "sha512-eDhZ7r6r1d1zQPVZehLc3D0K14vRba/eBYkz3rw16DLOrrTzve9RmnkcwrrkWVgO1FL3EK5knujVe5S8QHE9xw==",
+          "dev": true,
+          "requires": {
+            "debug": "^4.1.1",
+            "istanbul-lib-coverage": "^2.0.4",
+            "make-dir": "^2.1.0",
+            "rimraf": "^2.6.2",
+            "source-map": "^0.6.1"
+          }
+        }
+      }
+    },
+    "istanbul-lib-coverage": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz",
+      "integrity": "sha512-LXTBICkMARVgo579kWDm8SqfB6nvSDKNqIOBEjmJRnL04JvoMHCYGWaMddQnseJYtkEuEvO/sIcOxPLk9gERug==",
+      "dev": true
+    },
+    "istanbul-lib-hook": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-2.0.6.tgz",
+      "integrity": "sha512-829DKONApZ7UCiPXcOYWSgkFXa4+vNYoNOt3F+4uDJLKL1OotAoVwvThoEj1i8jmOj7odbYcR3rnaHu+QroaXg==",
+      "dev": true,
+      "requires": {
+        "append-transform": "^1.0.0"
+      }
+    },
+    "istanbul-lib-instrument": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.2.0.tgz",
+      "integrity": "sha512-06IM3xShbNW4NgZv5AP4QH0oHqf1/ivFo8eFys0ZjPXHGldHJQWb3riYOKXqmOqfxXBfxu4B+g/iuhOPZH0RJg==",
+      "dev": true,
+      "requires": {
+        "@babel/generator": "^7.0.0",
+        "@babel/parser": "^7.0.0",
+        "@babel/template": "^7.0.0",
+        "@babel/traverse": "^7.0.0",
+        "@babel/types": "^7.0.0",
+        "istanbul-lib-coverage": "^2.0.4",
+        "semver": "^6.0.0"
+      }
+    },
+    "istanbul-lib-report": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-2.0.7.tgz",
+      "integrity": "sha512-wLH6beJBFbRBLiTlMOBxmb85cnVM1Vyl36N48e4e/aTKSM3WbOx7zbVIH1SQ537fhhsPbX0/C5JB4qsmyRXXyA==",
+      "dev": true,
+      "requires": {
+        "istanbul-lib-coverage": "^2.0.4",
+        "make-dir": "^2.1.0",
+        "supports-color": "^6.0.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "istanbul-lib-source-maps": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-2.0.1.tgz",
+      "integrity": "sha512-30l40ySg+gvBLcxTrLzR4Z2XTRj3HgRCA/p2rnbs/3OiTaoj054gAbuP5DcLOtwqmy4XW8qXBHzrmP2/bQ9i3A==",
+      "dev": true,
+      "requires": {
+        "debug": "^3.1.0",
+        "istanbul-lib-coverage": "^2.0.1",
+        "make-dir": "^1.3.0",
+        "rimraf": "^2.6.2",
+        "source-map": "^0.6.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "make-dir": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+          "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+          "dev": true,
+          "requires": {
+            "pify": "^3.0.0"
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        }
+      }
+    },
+    "istanbul-reports": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.3.tgz",
+      "integrity": "sha512-T6EbPuc8Cb620LWAYyZ4D8SSn06dY9i1+IgUX2lTH8gbwflMc9Obd33zHTyNX653ybjpamAHS9toKS3E6cGhTw==",
+      "dev": true,
+      "requires": {
+        "handlebars": "^4.1.0"
+      }
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+          "dev": true
+        }
+      }
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "dev": true
     },
     "jsesc": {
@@ -1183,11 +5877,46 @@
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
       "dev": true
     },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "dev": true
+    },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
+    },
+    "json5": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
+      "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
     },
     "jsonfile": {
       "version": "4.0.0",
@@ -1204,11 +5933,100 @@
       "integrity": "sha512-lz1nOH69GbsVHeVgEdvyavc/33oymY1AZwtePMiMj4HZPMbP5OIKK3zT9INMWjwua/V4Z4yq7wSlBbSG+g4AEw==",
       "dev": true
     },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      }
+    },
     "just-extend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.0.2.tgz",
       "integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==",
       "dev": true
+    },
+    "kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "dev": true,
+      "requires": {
+        "is-buffer": "^1.1.5"
+      }
+    },
+    "kuler": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-1.0.1.tgz",
+      "integrity": "sha512-J9nVUucG1p/skKul6DU3PUZrhs0LPulNaeUOox0IyXDi8S4CztTHs1gQphhuZmzXG7VOQSf6NJfKuzteQLv9gQ==",
+      "dev": true,
+      "requires": {
+        "colornames": "^1.1.1"
+      }
+    },
+    "latest-version": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
+      "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
+      "dev": true,
+      "requires": {
+        "package-json": "^4.0.0"
+      }
+    },
+    "launchpad": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/launchpad/-/launchpad-0.7.2.tgz",
+      "integrity": "sha512-nmfx8QWqCvAmukHPticyO3+frnUKp0tDKXz3Au570XHBE0G1lNyN+KSODHgTqIIEuCIAlAgpbWjI36Vjk1mDKA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "async": "^2.0.1",
+        "browserstack": "^1.2.0",
+        "debug": "^2.2.0",
+        "plist": "^2.0.1",
+        "q": "^1.4.1",
+        "underscore": "^1.8.3"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true,
+          "optional": true
+        },
+        "underscore": {
+          "version": "1.9.1",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
+          "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "lazystream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
+      "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "^2.0.5"
+      }
     },
     "levn": {
       "version": "0.3.0",
@@ -1220,10 +6038,46 @@
         "type-check": "~0.3.2"
       }
     },
+    "load-json-file": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "strip-bom": "^2.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "dev": true,
+          "requires": {
+            "is-utf8": "^0.2.0"
+          }
+        }
+      }
+    },
     "lodash": {
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
       "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "dev": true
+    },
+    "lodash._reinterpolate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+      "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
       "dev": true
     },
     "lodash.camelcase": {
@@ -1232,10 +6086,34 @@
       "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
       "dev": true
     },
+    "lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=",
+      "dev": true
+    },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
+      "dev": true
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
+      "dev": true
+    },
     "lodash.padend": {
       "version": "4.6.1",
       "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz",
       "integrity": "sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4=",
+      "dev": true
+    },
+    "lodash.some": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz",
+      "integrity": "sha1-G7nzFO9ri63tE7VJFpsqlF62jk0=",
       "dev": true
     },
     "lodash.sortby": {
@@ -1244,16 +6122,290 @@
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
       "dev": true
     },
+    "lodash.template": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
+      "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
+      "dev": true,
+      "requires": {
+        "lodash._reinterpolate": "~3.0.0",
+        "lodash.templatesettings": "^4.0.0"
+      }
+    },
+    "lodash.templatesettings": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
+      "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
+      "dev": true,
+      "requires": {
+        "lodash._reinterpolate": "~3.0.0"
+      }
+    },
+    "logform": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-1.10.0.tgz",
+      "integrity": "sha512-em5ojIhU18fIMOw/333mD+ZLE2fis0EzXl1ZwHx4iQzmpQi6odNiY/t+ITNr33JZhT9/KEaH+UPIipr6a9EjWg==",
+      "dev": true,
+      "requires": {
+        "colors": "^1.2.1",
+        "fast-safe-stringify": "^2.0.4",
+        "fecha": "^2.3.3",
+        "ms": "^2.1.1",
+        "triple-beam": "^1.2.0"
+      }
+    },
     "lolex": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lolex/-/lolex-3.1.0.tgz",
       "integrity": "sha512-zFo5MgCJ0rZ7gQg69S4pqBsLURbFw11X68C18OcJjJQbqaXm2NoTrGl1IMM3TIz0/BnN1tIs2tzmmqvCsOMMjw==",
       "dev": true
     },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      }
+    },
+    "loud-rejection": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+      "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+      "dev": true,
+      "requires": {
+        "currently-unhandled": "^0.4.1",
+        "signal-exit": "^3.0.0"
+      }
+    },
+    "lower-case": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
+      "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw=",
+      "dev": true
+    },
+    "lowercase-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
+      "dev": true
+    },
+    "lru-cache": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+      "dev": true,
+      "requires": {
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
+      }
+    },
+    "magic-string": {
+      "version": "0.22.5",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.22.5.tgz",
+      "integrity": "sha512-oreip9rJZkzvA8Qzk9HFs8fZGF/u7H/gtrE8EN6RjKJ9kh2HlC+yQ2QezifqTZfGyiuAV0dRv5a+y/8gBb1m9w==",
+      "dev": true,
+      "requires": {
+        "vlq": "^0.2.2"
+      }
+    },
+    "make-dir": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+      "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+      "dev": true,
+      "requires": {
+        "pify": "^4.0.1",
+        "semver": "^5.6.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "dev": true
+        }
+      }
+    },
+    "map-cache": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+      "dev": true
+    },
+    "map-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+      "dev": true
+    },
+    "map-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+      "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+      "dev": true,
+      "requires": {
+        "object-visit": "^1.0.0"
+      }
+    },
     "marked": {
       "version": "0.3.19",
       "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
       "integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg==",
+      "dev": true
+    },
+    "matcher": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/matcher/-/matcher-1.1.1.tgz",
+      "integrity": "sha512-+BmqxWIubKTRKNWx/ahnCkk3mG8m7OturVlqq6HiojGJTd5hVYbgZm6WzcYPCoB+KBT4Vd6R7WSRG2OADNaCjg==",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.4"
+      }
+    },
+    "math-random": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.4.tgz",
+      "integrity": "sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A==",
+      "dev": true
+    },
+    "md5": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
+      "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
+      "dev": true,
+      "requires": {
+        "charenc": "~0.0.1",
+        "crypt": "~0.0.1",
+        "is-buffer": "~1.1.1"
+      }
+    },
+    "media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
+      "dev": true
+    },
+    "meow": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+      "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
+      "dev": true,
+      "requires": {
+        "camelcase-keys": "^2.0.0",
+        "decamelize": "^1.1.2",
+        "loud-rejection": "^1.0.0",
+        "map-obj": "^1.0.1",
+        "minimist": "^1.1.3",
+        "normalize-package-data": "^2.3.4",
+        "object-assign": "^4.0.1",
+        "read-pkg-up": "^1.0.1",
+        "redent": "^1.0.0",
+        "trim-newlines": "^1.0.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
+    "merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+      "dev": true
+    },
+    "merge-source-map": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.1.0.tgz",
+      "integrity": "sha512-Qkcp7P2ygktpMPh2mCQZaf3jhN6D3Z/qVZHSdWvQ+2Ef5HgRAPBO57A77+ENm0CPx2+1Ce/MYKi3ymqdfuqibw==",
+      "dev": true,
+      "requires": {
+        "source-map": "^0.6.1"
+      }
+    },
+    "merge-stream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+      "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "^2.0.1"
+      }
+    },
+    "methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
+      "dev": true
+    },
+    "micromatch": {
+      "version": "2.3.11",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+      "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+      "dev": true,
+      "requires": {
+        "arr-diff": "^2.0.0",
+        "array-unique": "^0.2.1",
+        "braces": "^1.8.2",
+        "expand-brackets": "^0.1.4",
+        "extglob": "^0.3.1",
+        "filename-regex": "^2.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.1",
+        "kind-of": "^3.0.2",
+        "normalize-path": "^2.0.1",
+        "object.omit": "^2.0.0",
+        "parse-glob": "^3.0.4",
+        "regex-cache": "^0.4.2"
+      },
+      "dependencies": {
+        "is-extglob": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^1.0.0"
+          }
+        }
+      }
+    },
+    "mime": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+      "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
+      "dev": true
+    },
+    "mime-db": {
+      "version": "1.39.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.39.0.tgz",
+      "integrity": "sha512-DTsrw/iWVvwHH+9Otxccdyy0Tgiil6TWK/xhfARJZF/QFhwOgZgOIvA2/VIGpM8U7Q8z5nDmdDWC6tuVMJNibw==",
+      "dev": true
+    },
+    "mime-types": {
+      "version": "2.1.23",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.23.tgz",
+      "integrity": "sha512-ROk/m+gMVSrRxTkMlaQOvFmFmYDc7sZgrjjM76abqmd2Cc5fCV7jAMA5XUccEtJ3cYiYdgixUVI+fApc2LkXlw==",
+      "dev": true,
+      "requires": {
+        "mime-db": "~1.39.0"
+      }
+    },
+    "minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
       "dev": true
     },
     "minimatch": {
@@ -1265,11 +6417,41 @@
         "brace-expansion": "^1.1.7"
       }
     },
+    "minimatch-all": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/minimatch-all/-/minimatch-all-1.1.0.tgz",
+      "integrity": "sha1-QMSWonouEo0Zv3WOdrsBoMcUV4c=",
+      "dev": true,
+      "requires": {
+        "minimatch": "^3.0.2"
+      }
+    },
     "minimist": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
+    },
+    "mixin-deep": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
+      "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+      "dev": true,
+      "requires": {
+        "for-in": "^1.0.2",
+        "is-extendable": "^1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
+        }
+      }
     },
     "mkdirp": {
       "version": "0.5.1",
@@ -1339,11 +6521,137 @@
         }
       }
     },
+    "mout": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/mout/-/mout-1.1.0.tgz",
+      "integrity": "sha512-XsP0vf4As6BfqglxZqbqQ8SR6KQot2AgxvR0gG+WtUkf90vUXchMOZQtPf/Hml1rEffJupqL/tIrU6EYhsUQjw==",
+      "dev": true
+    },
     "ms": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
       "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
       "dev": true
+    },
+    "multer": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-1.4.1.tgz",
+      "integrity": "sha512-zzOLNRxzszwd+61JFuAo0fxdQfvku12aNJgnla0AQ+hHxFmfc/B7jBVuPr5Rmvu46Jze/iJrFpSOsD7afO8SDw==",
+      "dev": true,
+      "requires": {
+        "append-field": "^1.0.0",
+        "busboy": "^0.2.11",
+        "concat-stream": "^1.5.2",
+        "mkdirp": "^0.5.1",
+        "object-assign": "^4.1.1",
+        "on-finished": "^2.3.0",
+        "type-is": "^1.6.4",
+        "xtend": "^4.0.0"
+      }
+    },
+    "multipipe": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-1.0.2.tgz",
+      "integrity": "sha1-zBPv2DPJzamfIk+GhGG44aP9k50=",
+      "dev": true,
+      "requires": {
+        "duplexer2": "^0.1.2",
+        "object-assign": "^4.1.0"
+      }
+    },
+    "mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "requires": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
+    "nanomatch": {
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
+      "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+      "dev": true,
+      "requires": {
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "fragment-cache": "^0.2.1",
+        "is-windows": "^1.0.2",
+        "kind-of": "^6.0.2",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "arr-diff": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+          "dev": true
+        },
+        "array-unique": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+          "dev": true
+        },
+        "extend-shallow": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+          "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+          "dev": true,
+          "requires": {
+            "assign-symbols": "^1.0.0",
+            "is-extendable": "^1.0.1"
+          }
+        },
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
+        },
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
+        }
+      }
+    },
+    "native-promise-only": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
+      "integrity": "sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE=",
+      "dev": true
+    },
+    "negotiator": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+      "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
+      "dev": true
+    },
+    "neo-async": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.0.tgz",
+      "integrity": "sha512-MFh0d/Wa7vkKO3Y3LlacqAEeHK0mckVqzDieUKTT+KGxi+zIpeVsFxymkIiRpbpDziHc290Xr9A1O4Om7otoRA==",
+      "dev": true
+    },
+    "nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "dev": true,
+      "optional": true
     },
     "nise": {
       "version": "1.4.8",
@@ -1366,6 +6674,208 @@
         }
       }
     },
+    "no-case": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
+      "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
+      "dev": true,
+      "requires": {
+        "lower-case": "^1.1.1"
+      }
+    },
+    "nomnom": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
+      "integrity": "sha1-IVH3Ikcrp55Qp2/BJbuMjy5Nwqc=",
+      "dev": true,
+      "requires": {
+        "chalk": "~0.4.0",
+        "underscore": "~1.6.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
+          "integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+          "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "~1.0.0",
+            "has-color": "~0.1.0",
+            "strip-ansi": "~0.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
+          "integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE=",
+          "dev": true
+        }
+      }
+    },
+    "nopt": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+      "dev": true,
+      "requires": {
+        "abbrev": "1"
+      }
+    },
+    "normalize-package-data": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "dev": true
+        }
+      }
+    },
+    "normalize-path": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+      "dev": true,
+      "requires": {
+        "remove-trailing-separator": "^1.0.1"
+      }
+    },
+    "npm-run-path": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+      "dev": true,
+      "requires": {
+        "path-key": "^2.0.0"
+      }
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
+    },
+    "oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+      "dev": true
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
+    },
+    "object-component": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
+      "integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE=",
+      "dev": true
+    },
+    "object-copy": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+      "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+      "dev": true,
+      "requires": {
+        "copy-descriptor": "^0.1.0",
+        "define-property": "^0.2.5",
+        "kind-of": "^3.0.3"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        }
+      }
+    },
+    "object-visit": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+      "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.0"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
+      }
+    },
+    "object.omit": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+      "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+      "dev": true,
+      "requires": {
+        "for-own": "^0.1.4",
+        "is-extendable": "^0.1.1"
+      }
+    },
+    "object.pick": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+      "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.1"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
+      }
+    },
+    "obuf": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
+      "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
+      "dev": true
+    },
+    "on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "dev": true,
+      "requires": {
+        "ee-first": "1.1.1"
+      }
+    },
+    "on-headers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+      "dev": true
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -1373,6 +6883,39 @@
       "dev": true,
       "requires": {
         "wrappy": "1"
+      }
+    },
+    "one-time": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/one-time/-/one-time-0.0.4.tgz",
+      "integrity": "sha1-+M33eISCb+Tf+T46nMN7HkSAdC4=",
+      "dev": true
+    },
+    "opn": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/opn/-/opn-3.0.3.tgz",
+      "integrity": "sha1-ttmec5n3jWXDuq/+8fsojpuFJDo=",
+      "dev": true,
+      "requires": {
+        "object-assign": "^4.0.1"
+      }
+    },
+    "optimist": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "dev": true,
+      "requires": {
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
+      },
+      "dependencies": {
+        "wordwrap": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+          "dev": true
+        }
       }
     },
     "optionator": {
@@ -1389,11 +6932,167 @@
         "wordwrap": "~1.0.0"
       }
     },
+    "ordered-read-streams": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
+      "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
+      "dev": true,
+      "requires": {
+        "is-stream": "^1.0.1",
+        "readable-stream": "^2.0.1"
+      }
+    },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "dev": true
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
+    },
+    "osenv": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+      "dev": true,
+      "requires": {
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.0"
+      }
+    },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+      "dev": true
+    },
+    "package-json": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
+      "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
+      "dev": true,
+      "requires": {
+        "got": "^6.7.1",
+        "registry-auth-token": "^3.0.1",
+        "registry-url": "^3.0.3",
+        "semver": "^5.1.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "dev": true
+        }
+      }
+    },
+    "param-case": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
+      "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
+      "dev": true,
+      "requires": {
+        "no-case": "^2.2.0"
+      }
+    },
+    "parse-glob": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+      "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+      "dev": true,
+      "requires": {
+        "glob-base": "^0.3.0",
+        "is-dotfile": "^1.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.0"
+      },
+      "dependencies": {
+        "is-extglob": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^1.0.0"
+          }
+        }
+      }
+    },
+    "parse-json": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "dev": true,
+      "requires": {
+        "error-ex": "^1.2.0"
+      }
+    },
+    "parse-passwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+      "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
+      "dev": true
+    },
     "parse5": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
       "integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
       "dev": true
+    },
+    "parseqs": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
+      "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
+      "dev": true,
+      "requires": {
+        "better-assert": "~1.0.0"
+      }
+    },
+    "parseuri": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
+      "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
+      "dev": true,
+      "requires": {
+        "better-assert": "~1.0.0"
+      }
+    },
+    "parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "dev": true
+    },
+    "pascalcase": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+      "dev": true
+    },
+    "path-dirname": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+      "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
+      "dev": true
+    },
+    "path-exists": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+      "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+      "dev": true,
+      "requires": {
+        "pinkie-promise": "^2.0.0"
+      }
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -1405,6 +7104,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
       "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "dev": true
+    },
+    "path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
       "dev": true
     },
     "path-parse": {
@@ -1422,11 +7127,105 @@
         "isarray": "0.0.1"
       }
     },
+    "path-type": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        }
+      }
+    },
     "pathval": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
       "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
       "dev": true
+    },
+    "pegjs": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/pegjs/-/pegjs-0.9.0.tgz",
+      "integrity": "sha1-9q76LjzlYWkgjlIXnf5B+JFBo2k=",
+      "dev": true
+    },
+    "pem": {
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/pem/-/pem-1.14.2.tgz",
+      "integrity": "sha512-TOnPtq3ZFnCniOZ+rka4pk8UIze9xG1qI+wNE7EmkiR/cg+53uVvk5QbkWZ7M6RsuOxzz62FW1hlAobJr/lTOA==",
+      "dev": true,
+      "requires": {
+        "es6-promisify": "^6.0.0",
+        "md5": "^2.2.1",
+        "os-tmpdir": "^1.0.1",
+        "which": "^1.3.1"
+      }
+    },
+    "pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
+      "dev": true,
+      "optional": true
+    },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true
+    },
+    "pify": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+      "dev": true
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dev": true,
+      "requires": {
+        "pinkie": "^2.0.0"
+      }
+    },
+    "plist": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/plist/-/plist-2.1.0.tgz",
+      "integrity": "sha1-V8zbeggh3yGDEhejytVOPhRqECU=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "base64-js": "1.2.0",
+        "xmlbuilder": "8.2.2",
+        "xmldom": "0.1.x"
+      }
+    },
+    "plylog": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/plylog/-/plylog-1.1.0.tgz",
+      "integrity": "sha512-/QnY5aSVaP54va6hruzNtAj02HpsLlAt7V5EndMrtq6ZUTZJKUja43rgiUtGXqm95yrSJjbZoPW0yQQQwLpoJA==",
+      "dev": true,
+      "requires": {
+        "logform": "^1.9.1",
+        "winston": "^3.0.0",
+        "winston-transport": "^4.2.0"
+      }
     },
     "polymer-analyzer": {
       "version": "3.2.2",
@@ -1506,10 +7305,225 @@
         }
       }
     },
+    "polymer-build": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/polymer-build/-/polymer-build-3.1.3.tgz",
+      "integrity": "sha512-OI1Wl18Zz9kZ3zo4OuhaW0rXu4NUsA4Xtw6R/nHfsE7KqeKtuoNWYrQXzCNI3DBamQnxRjDR2s0A/cmNwQNO9Q==",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.0.0",
+        "@babel/plugin-external-helpers": "^7.0.0",
+        "@babel/plugin-proposal-async-generator-functions": "^7.0.0",
+        "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
+        "@babel/plugin-syntax-async-generators": "^7.0.0",
+        "@babel/plugin-syntax-dynamic-import": "^7.0.0",
+        "@babel/plugin-syntax-import-meta": "^7.0.0",
+        "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
+        "@babel/plugin-transform-arrow-functions": "^7.0.0",
+        "@babel/plugin-transform-async-to-generator": "^7.0.0",
+        "@babel/plugin-transform-block-scoped-functions": "^7.0.0",
+        "@babel/plugin-transform-block-scoping": "^7.0.0",
+        "@babel/plugin-transform-classes": "^7.0.0",
+        "@babel/plugin-transform-computed-properties": "^7.0.0",
+        "@babel/plugin-transform-destructuring": "^7.0.0",
+        "@babel/plugin-transform-duplicate-keys": "^7.0.0",
+        "@babel/plugin-transform-exponentiation-operator": "^7.0.0",
+        "@babel/plugin-transform-for-of": "^7.0.0",
+        "@babel/plugin-transform-function-name": "^7.0.0",
+        "@babel/plugin-transform-instanceof": "^7.0.0",
+        "@babel/plugin-transform-literals": "^7.0.0",
+        "@babel/plugin-transform-modules-amd": "^7.0.0",
+        "@babel/plugin-transform-object-super": "^7.0.0",
+        "@babel/plugin-transform-parameters": "^7.0.0",
+        "@babel/plugin-transform-regenerator": "^7.0.0",
+        "@babel/plugin-transform-shorthand-properties": "^7.0.0",
+        "@babel/plugin-transform-spread": "^7.0.0",
+        "@babel/plugin-transform-sticky-regex": "^7.0.0",
+        "@babel/plugin-transform-template-literals": "^7.0.0",
+        "@babel/plugin-transform-typeof-symbol": "^7.0.0",
+        "@babel/plugin-transform-unicode-regex": "^7.0.0",
+        "@babel/traverse": "^7.0.0",
+        "@polymer/esm-amd-loader": "^1.0.0",
+        "@types/babel-types": "^6.25.1",
+        "@types/babylon": "^6.16.2",
+        "@types/gulp-if": "0.0.33",
+        "@types/html-minifier": "^3.5.1",
+        "@types/is-windows": "^0.2.0",
+        "@types/mz": "0.0.31",
+        "@types/parse5": "^2.2.34",
+        "@types/resolve": "0.0.7",
+        "@types/uuid": "^3.4.3",
+        "@types/vinyl": "^2.0.0",
+        "@types/vinyl-fs": "^2.4.8",
+        "babel-plugin-minify-guarded-expressions": "^0.4.3",
+        "babel-preset-minify": "^0.5.0",
+        "babylon": "^7.0.0-beta.42",
+        "css-slam": "^2.1.2",
+        "dom5": "^3.0.0",
+        "gulp-if": "^2.0.2",
+        "html-minifier": "^3.5.10",
+        "matcher": "^1.1.0",
+        "multipipe": "^1.0.2",
+        "mz": "^2.6.0",
+        "parse5": "^4.0.0",
+        "plylog": "^1.0.0",
+        "polymer-analyzer": "^3.1.3",
+        "polymer-bundler": "^4.0.9",
+        "polymer-project-config": "^4.0.3",
+        "regenerator-runtime": "^0.11.1",
+        "stream": "0.0.2",
+        "sw-precache": "^5.1.1",
+        "uuid": "^3.2.1",
+        "vinyl": "^1.2.0",
+        "vinyl-fs": "^2.4.4"
+      },
+      "dependencies": {
+        "@types/resolve": {
+          "version": "0.0.7",
+          "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-0.0.7.tgz",
+          "integrity": "sha512-GPewdjkb0Q76o459qgp6pBLzJj/bD3oveS2kfLhIkZ9U3t3AFKtl5DlFB6lGTw0iZmcmxoGC8lpLW3NNJKrN9A==",
+          "dev": true,
+          "requires": {
+            "@types/node": "*"
+          }
+        }
+      }
+    },
+    "polymer-bundler": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/polymer-bundler/-/polymer-bundler-4.0.9.tgz",
+      "integrity": "sha512-6r6O0D9Yd7fyf9K+HBfkwnj54zPU9W2/PXeIIsw6N75334dhdDwvFfDRTKhEwOVYElJcUO0MQLsIEbMCZCHY1w==",
+      "dev": true,
+      "requires": {
+        "@types/babel-generator": "^6.25.1",
+        "@types/babel-traverse": "^6.25.3",
+        "babel-generator": "^6.26.1",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "clone": "^2.1.0",
+        "command-line-args": "^5.0.2",
+        "command-line-usage": "^5.0.5",
+        "dom5": "^3.0.0",
+        "espree": "^3.5.2",
+        "magic-string": "^0.22.4",
+        "mkdirp": "^0.5.1",
+        "parse5": "^4.0.0",
+        "polymer-analyzer": "^3.2.2",
+        "rollup": "^1.3.0",
+        "source-map": "^0.5.6",
+        "vscode-uri": "^1.0.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
+    "polymer-project-config": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/polymer-project-config/-/polymer-project-config-4.0.3.tgz",
+      "integrity": "sha512-Drr+Imq+znhBC8XSt9pMlmPixoGnIOmleV5SD6mto1zOGC5oCDbSNsQL2v89DWOk+9aSUO79vnWwOmEPDSvYfw==",
+      "dev": true,
+      "requires": {
+        "@types/parse5": "^2.2.34",
+        "browser-capabilities": "^1.0.0",
+        "jsonschema": "^1.1.1",
+        "minimatch-all": "^1.1.0",
+        "plylog": "^1.0.0",
+        "winston": "^3.0.0"
+      }
+    },
+    "polyserve": {
+      "version": "0.27.15",
+      "resolved": "https://registry.npmjs.org/polyserve/-/polyserve-0.27.15.tgz",
+      "integrity": "sha512-AaFgANt+tUUVgHLw+BnaVYcn649JiwL1ru0TOZUKj1gGGn/Bq2S16gxql+1muGpRaAsgFu13Zu7k5XkwatwwSg==",
+      "dev": true,
+      "requires": {
+        "@types/compression": "^0.0.33",
+        "@types/content-type": "^1.1.0",
+        "@types/escape-html": "0.0.20",
+        "@types/express": "^4.0.36",
+        "@types/mime": "^2.0.0",
+        "@types/mz": "0.0.29",
+        "@types/opn": "^3.0.28",
+        "@types/parse5": "^2.2.34",
+        "@types/pem": "^1.8.1",
+        "@types/resolve": "0.0.6",
+        "@types/serve-static": "^1.7.31",
+        "@types/spdy": "^3.4.1",
+        "bower-config": "^1.4.1",
+        "browser-capabilities": "^1.0.0",
+        "command-line-args": "^5.0.2",
+        "command-line-usage": "^5.0.5",
+        "compression": "^1.6.2",
+        "content-type": "^1.0.2",
+        "cors": "^2.8.4",
+        "escape-html": "^1.0.3",
+        "express": "^4.8.5",
+        "find-port": "^1.0.1",
+        "http-proxy-middleware": "^0.17.2",
+        "lru-cache": "^4.0.2",
+        "mime": "^2.3.1",
+        "mz": "^2.4.0",
+        "opn": "^3.0.2",
+        "pem": "^1.8.3",
+        "polymer-build": "^3.1.0",
+        "polymer-project-config": "^4.0.0",
+        "requirejs": "^2.3.4",
+        "resolve": "^1.5.0",
+        "send": "^0.16.2",
+        "spdy": "^3.3.3"
+      },
+      "dependencies": {
+        "@types/mz": {
+          "version": "0.0.29",
+          "resolved": "https://registry.npmjs.org/@types/mz/-/mz-0.0.29.tgz",
+          "integrity": "sha1-vCRyjGSZc/HHhR6QM/nOUlZowns=",
+          "dev": true,
+          "requires": {
+            "@types/bluebird": "*",
+            "@types/node": "*"
+          }
+        },
+        "mime": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.2.tgz",
+          "integrity": "sha512-zJBfZDkwRu+j3Pdd2aHsR5GfH2jIWhmL1ZzBoc+X+3JEti2hbArWcyJ+1laC1D2/U/W1a/+Cegj0/OnEU2ybjg==",
+          "dev": true
+        }
+      }
+    },
+    "posix-character-classes": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+      "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+      "dev": true
+    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
+    "prepend-http": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
+      "dev": true
+    },
+    "preserve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+      "dev": true
+    },
+    "pretty-bytes": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-4.0.2.tgz",
+      "integrity": "sha1-sr+C5zUNZcbDOqlaqlpPYyf2HNk=",
       "dev": true
     },
     "prismjs": {
@@ -1521,16 +7535,403 @@
         "clipboard": "^2.0.0"
       }
     },
+    "private": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
+      "dev": true
+    },
+    "process-nextick-args": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+      "dev": true
+    },
+    "progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "optional": true
+    },
+    "proxy-addr": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.5.tgz",
+      "integrity": "sha512-t/7RxHXPH6cJtP0pRG6smSr9QJidhB+3kXu0KgXnbGYMgzEnUxRQ4/LDdfOwZEMyIh3/xHb8PX3t+lfL9z+YVQ==",
+      "dev": true,
+      "requires": {
+        "forwarded": "~0.1.2",
+        "ipaddr.js": "1.9.0"
+      }
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "dev": true
+    },
+    "psl": {
+      "version": "1.1.31",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
+      "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==",
+      "dev": true
+    },
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
     },
+    "q": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
+      "dev": true,
+      "optional": true
+    },
+    "qs": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+      "dev": true
+    },
+    "randomatic": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
+      "integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
+      "dev": true,
+      "requires": {
+        "is-number": "^4.0.0",
+        "kind-of": "^6.0.0",
+        "math-random": "^1.0.1"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
+        }
+      }
+    },
+    "range-parser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+      "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
+      "dev": true
+    },
+    "raw-body": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
+      "integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
+      "dev": true,
+      "requires": {
+        "bytes": "3.0.0",
+        "http-errors": "1.6.3",
+        "iconv-lite": "0.4.23",
+        "unpipe": "1.0.0"
+      }
+    },
+    "rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
+      "requires": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
+    "read-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+      "dev": true,
+      "requires": {
+        "load-json-file": "^1.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^1.0.0"
+      }
+    },
+    "read-pkg-up": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+      "dev": true,
+      "requires": {
+        "find-up": "^1.0.0",
+        "read-pkg": "^1.0.0"
+      }
+    },
+    "readable-stream": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "dev": true,
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        }
+      }
+    },
+    "redent": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+      "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+      "dev": true,
+      "requires": {
+        "indent-string": "^2.1.0",
+        "strip-indent": "^1.0.1"
+      },
+      "dependencies": {
+        "strip-indent": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+          "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+          "dev": true,
+          "requires": {
+            "get-stdin": "^4.0.1"
+          }
+        }
+      }
+    },
     "reduce-flatten": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-1.0.1.tgz",
       "integrity": "sha1-JYx479FT3fk8tWEjf2EYTzaW4yc=",
+      "dev": true
+    },
+    "regenerate": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
+      "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
+      "dev": true
+    },
+    "regenerate-unicode-properties": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.0.2.tgz",
+      "integrity": "sha512-SbA/iNrBUf6Pv2zU8Ekv1Qbhv92yxL4hiDa2siuxs4KKn4oOoMDHXjAf7+Nz9qinUQ46B1LcWEi/PhJfPWpZWQ==",
+      "dev": true,
+      "requires": {
+        "regenerate": "^1.4.0"
+      }
+    },
+    "regenerator-runtime": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+      "dev": true
+    },
+    "regenerator-transform": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.13.4.tgz",
+      "integrity": "sha512-T0QMBjK3J0MtxjPmdIMXm72Wvj2Abb0Bd4HADdfijwMdoIsyQZ6fWC7kDFhk2YinBBEMZDL7Y7wh0J1sGx3S4A==",
+      "dev": true,
+      "requires": {
+        "private": "^0.1.6"
+      }
+    },
+    "regex-cache": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+      "dev": true,
+      "requires": {
+        "is-equal-shallow": "^0.1.3"
+      }
+    },
+    "regex-not": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+      "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^3.0.2",
+        "safe-regex": "^1.1.0"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+          "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+          "dev": true,
+          "requires": {
+            "assign-symbols": "^1.0.0",
+            "is-extendable": "^1.0.1"
+          }
+        },
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
+        }
+      }
+    },
+    "regexpu-core": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.5.4.tgz",
+      "integrity": "sha512-BtizvGtFQKGPUcTy56o3nk1bGRp4SZOTYrDtGNlqCQufptV5IkkLN6Emw+yunAJjzf+C9FQFtvq7IoA3+oMYHQ==",
+      "dev": true,
+      "requires": {
+        "regenerate": "^1.4.0",
+        "regenerate-unicode-properties": "^8.0.2",
+        "regjsgen": "^0.5.0",
+        "regjsparser": "^0.6.0",
+        "unicode-match-property-ecmascript": "^1.0.4",
+        "unicode-match-property-value-ecmascript": "^1.1.0"
+      }
+    },
+    "registry-auth-token": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.4.0.tgz",
+      "integrity": "sha512-4LM6Fw8eBQdwMYcES4yTnn2TqIasbXuwDx3um+QRs7S55aMKCBKBxvPXl2RiUjHwuJLTyYfxSpmfSAjQpcuP+A==",
+      "dev": true,
+      "requires": {
+        "rc": "^1.1.6",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "registry-url": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
+      "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
+      "dev": true,
+      "requires": {
+        "rc": "^1.0.1"
+      }
+    },
+    "regjsgen": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.0.tgz",
+      "integrity": "sha512-RnIrLhrXCX5ow/E5/Mh2O4e/oa1/jW0eaBKTSy3LaCj+M3Bqvm97GWDp2yUtzIs4LEn65zR2yiYGFqb2ApnzDA==",
+      "dev": true
+    },
+    "regjsparser": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.0.tgz",
+      "integrity": "sha512-RQ7YyokLiQBomUJuUG8iGVvkgOLxwyZM8k6d3q5SAXpg4r5TZJZigKFvC6PpD+qQ98bCDC5YelPeA3EucDoNeQ==",
+      "dev": true,
+      "requires": {
+        "jsesc": "~0.5.0"
+      },
+      "dependencies": {
+        "jsesc": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+          "dev": true
+        }
+      }
+    },
+    "relateurl": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
+      "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=",
+      "dev": true
+    },
+    "remove-trailing-separator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+      "dev": true
+    },
+    "repeat-element": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
+      "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
+      "dev": true
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true
+    },
+    "repeating": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+      "dev": true,
+      "requires": {
+        "is-finite": "^1.0.0"
+      }
+    },
+    "replace-ext": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+      "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
+      "dev": true
+    },
+    "request": {
+      "version": "2.88.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+      "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+      "dev": true,
+      "requires": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.0",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.4.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      }
+    },
+    "requirejs": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.3.6.tgz",
+      "integrity": "sha512-ipEzlWQe6RK3jkzikgCupiTbTvm4S0/CAU5GlgptkN5SO6F3u0UD0K18wy6ErDqiCyP4J4YYe1HuAShvsxePLg==",
+      "dev": true
+    },
+    "requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
       "dev": true
     },
     "resolve": {
@@ -1542,6 +7943,103 @@
         "path-parse": "^1.0.6"
       }
     },
+    "resolve-dir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
+      "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
+      "dev": true,
+      "requires": {
+        "expand-tilde": "^2.0.0",
+        "global-modules": "^1.0.0"
+      }
+    },
+    "resolve-url": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+      "dev": true
+    },
+    "ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "dev": true
+    },
+    "rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
+      }
+    },
+    "rollup": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.10.0.tgz",
+      "integrity": "sha512-U9t/JaKtO0+X0pSmLVKMrAZEixrbVzITf193TiEhfoVKCnd7pDimIFo94IxUCgbn6+v5VmduHkubx2VV1s0Ftw==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "0.0.39",
+        "@types/node": "^11.13.4",
+        "acorn": "^6.1.1"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "11.13.5",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-11.13.5.tgz",
+          "integrity": "sha512-/OMMBnjVtDuwX1tg2pkYVSqRIDSmNTnvVvmvP/2xiMAAWf4a5+JozrApCrO4WCAILmXVxfNoQ3E+0HJbNpFVGg==",
+          "dev": true
+        },
+        "acorn": {
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
+          "integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
+          "dev": true
+        }
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "safe-regex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+      "dev": true,
+      "requires": {
+        "ret": "~0.1.10"
+      }
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
+    },
+    "samsam": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
+      "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
+      "dev": true
+    },
+    "sauce-connect-launcher": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/sauce-connect-launcher/-/sauce-connect-launcher-1.2.6.tgz",
+      "integrity": "sha512-yBTYfzI6AWRwoXJoIqmVgz+eCpWX6CsJ4Ap8fowjsGlN+27OKbnQxv6POd4Rzh57BH9WeA9K8orIzNxO8mMBQA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "adm-zip": "~0.4.3",
+        "async": "^2.1.2",
+        "https-proxy-agent": "^2.2.1",
+        "lodash": "^4.16.6",
+        "rimraf": "^2.5.4"
+      }
+    },
     "select": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
@@ -1549,11 +8047,209 @@
       "dev": true,
       "optional": true
     },
+    "select-hose": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
+      "integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo=",
+      "dev": true
+    },
+    "selenium-standalone": {
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/selenium-standalone/-/selenium-standalone-6.16.0.tgz",
+      "integrity": "sha512-tl7HFH2FOxJD1is7Pzzsl0pY4vuePSdSWiJdPn+6ETBkpeJDiuzou8hBjvWYWpD+eIVcOrmy3L0R3GzkdHLzDw==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "async": "^2.6.2",
+        "commander": "^2.19.0",
+        "cross-spawn": "^6.0.5",
+        "debug": "^4.1.1",
+        "lodash": "^4.17.11",
+        "minimist": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "progress": "2.0.3",
+        "request": "2.88.0",
+        "tar-stream": "2.0.0",
+        "urijs": "^1.19.1",
+        "which": "^1.3.1",
+        "yauzl": "^2.10.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+          "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+          "dev": true,
+          "optional": true
+        },
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true,
+          "optional": true
+        },
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "semver": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.0.0.tgz",
+      "integrity": "sha512-0UewU+9rFapKFnlbirLi3byoOuhrSsli/z/ihNnvM24vgF+8sNBiI1LZPBSH9wJKUwaUbw+s3hToDLCXkrghrQ==",
+      "dev": true
+    },
+    "semver-diff": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
+      "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
+      "dev": true,
+      "requires": {
+        "semver": "^5.0.3"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "dev": true
+        }
+      }
+    },
+    "send": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
+      "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "~1.6.2",
+        "mime": "1.4.1",
+        "ms": "2.0.0",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.0",
+        "statuses": "~1.4.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
+    "serve-static": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
+      "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
+      "dev": true,
+      "requires": {
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.2",
+        "send": "0.16.2"
+      }
+    },
+    "server-destroy": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/server-destroy/-/server-destroy-1.0.1.tgz",
+      "integrity": "sha1-8Tv5KOQrnD55OD5hzDmYtdFObN0=",
+      "dev": true
+    },
+    "serviceworker-cache-polyfill": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/serviceworker-cache-polyfill/-/serviceworker-cache-polyfill-4.0.0.tgz",
+      "integrity": "sha1-3hnuc77yGrPAdAo3sz22JGS6ves=",
+      "dev": true
+    },
+    "set-value": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
+      "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^2.0.1",
+        "is-extendable": "^0.1.1",
+        "is-plain-object": "^2.0.3",
+        "split-string": "^3.0.1"
+      }
+    },
+    "setprototypeof": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
+      "dev": true
+    },
     "shady-css-parser": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/shady-css-parser/-/shady-css-parser-0.1.0.tgz",
       "integrity": "sha512-irfJUUkEuDlNHKZNAp2r7zOyMlmbfVJ+kWSfjlCYYUx/7dJnANLCyTzQZsuxy5NJkvtNwSxY5Gj8MOlqXUQPyA==",
       "dev": true
+    },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
+    },
+    "simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "^0.3.1"
+      }
     },
     "sinon": {
       "version": "7.2.3",
@@ -1570,11 +8266,255 @@
         "supports-color": "^5.5.0"
       }
     },
+    "sinon-chai": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-2.14.0.tgz",
+      "integrity": "sha512-9stIF1utB0ywNHNT7RgiXbdmen8QDCRsrTjw+G9TgKt1Yexjiv8TOWZ6WHsTPz57Yky3DIswZvEqX8fpuHNDtQ==",
+      "dev": true
+    },
+    "snapdragon": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+      "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+      "dev": true,
+      "requires": {
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "map-cache": "^0.2.2",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
+    "snapdragon-node": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+      "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+      "dev": true,
+      "requires": {
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.0",
+        "snapdragon-util": "^3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
+        }
+      }
+    },
+    "snapdragon-util": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+      "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.2.0"
+      }
+    },
+    "socket.io": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.2.0.tgz",
+      "integrity": "sha512-wxXrIuZ8AILcn+f1B4ez4hJTPG24iNgxBBDaJfT6MsyOhVYiTXWexGoPkd87ktJG8kQEcL/NBvRi64+9k4Kc0w==",
+      "dev": true,
+      "requires": {
+        "debug": "~4.1.0",
+        "engine.io": "~3.3.1",
+        "has-binary2": "~1.0.2",
+        "socket.io-adapter": "~1.1.0",
+        "socket.io-client": "2.2.0",
+        "socket.io-parser": "~3.3.0"
+      }
+    },
+    "socket.io-adapter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-1.1.1.tgz",
+      "integrity": "sha1-KoBeihTWNyEk3ZFZrUUC+MsH8Gs=",
+      "dev": true
+    },
+    "socket.io-client": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.2.0.tgz",
+      "integrity": "sha512-56ZrkTDbdTLmBIyfFYesgOxsjcLnwAKoN4CiPyTVkMQj3zTUh0QAx3GbvIvLpFEOvQWu92yyWICxB0u7wkVbYA==",
+      "dev": true,
+      "requires": {
+        "backo2": "1.0.2",
+        "base64-arraybuffer": "0.1.5",
+        "component-bind": "1.0.0",
+        "component-emitter": "1.2.1",
+        "debug": "~3.1.0",
+        "engine.io-client": "~3.3.1",
+        "has-binary2": "~1.0.2",
+        "has-cors": "1.1.0",
+        "indexof": "0.0.1",
+        "object-component": "0.0.3",
+        "parseqs": "0.0.5",
+        "parseuri": "0.0.5",
+        "socket.io-parser": "~3.3.0",
+        "to-array": "0.1.4"
+      },
+      "dependencies": {
+        "component-emitter": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+          "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+          "dev": true
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
+    "socket.io-parser": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.3.0.tgz",
+      "integrity": "sha512-hczmV6bDgdaEbVqhAeVMM/jfUfzuEZHsQg6eOmLgJht6G3mPKMxYm75w2+qhAQZ+4X+1+ATZ+QFKeOZD5riHng==",
+      "dev": true,
+      "requires": {
+        "component-emitter": "1.2.1",
+        "debug": "~3.1.0",
+        "isarray": "2.0.1"
+      },
+      "dependencies": {
+        "component-emitter": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+          "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+          "dev": true
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "isarray": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
+          "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true
+    },
+    "source-map-resolve": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
+      "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
+      "dev": true,
+      "requires": {
+        "atob": "^2.1.1",
+        "decode-uri-component": "^0.2.0",
+        "resolve-url": "^0.2.1",
+        "source-map-url": "^0.4.0",
+        "urix": "^0.1.0"
+      }
     },
     "source-map-support": {
       "version": "0.5.10",
@@ -1586,11 +8526,298 @@
         "source-map": "^0.6.0"
       }
     },
+    "source-map-url": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+      "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+      "dev": true
+    },
+    "spdx-correct": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
+      "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+      "dev": true,
+      "requires": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-exceptions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+      "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
+      "dev": true
+    },
+    "spdx-expression-parse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "dev": true,
+      "requires": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-license-ids": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.4.tgz",
+      "integrity": "sha512-7j8LYJLeY/Yb6ACbQ7F76qy5jHkp0U6jgBfJsk97bwWlVUnUWsAgpyaCvo17h0/RQGnQ036tVDomiwoI4pDkQA==",
+      "dev": true
+    },
+    "spdy": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/spdy/-/spdy-3.4.7.tgz",
+      "integrity": "sha1-Qv9B7OXMD5mjpsKKq7c/XDsDrLw=",
+      "dev": true,
+      "requires": {
+        "debug": "^2.6.8",
+        "handle-thing": "^1.2.5",
+        "http-deceiver": "^1.2.7",
+        "safe-buffer": "^5.0.1",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^2.0.18"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
+    "spdy-transport": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.1.1.tgz",
+      "integrity": "sha512-q7D8c148escoB3Z7ySCASadkegMmUZW8Wb/Q1u0/XBgDKMO880rLQDj8Twiew/tYi7ghemKUi/whSYOwE17f5Q==",
+      "dev": true,
+      "requires": {
+        "debug": "^2.6.8",
+        "detect-node": "^2.0.3",
+        "hpack.js": "^2.1.6",
+        "obuf": "^1.1.1",
+        "readable-stream": "^2.2.9",
+        "safe-buffer": "^5.0.1",
+        "wbuf": "^1.7.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
+    "split-string": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^3.0.0"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+          "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+          "dev": true,
+          "requires": {
+            "assign-symbols": "^1.0.0",
+            "is-extendable": "^1.0.1"
+          }
+        },
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
+        }
+      }
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "sshpk": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+      "dev": true,
+      "requires": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      }
+    },
     "stable": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
       "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
       "dev": true
+    },
+    "stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
+      "dev": true
+    },
+    "stacky": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/stacky/-/stacky-1.3.1.tgz",
+      "integrity": "sha1-PxF+UYe5pz0j+HbWnwXIWxGAShI=",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.1",
+        "lodash": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "lodash": {
+          "version": "3.10.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
+    },
+    "static-extend": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+      "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+      "dev": true,
+      "requires": {
+        "define-property": "^0.2.5",
+        "object-copy": "^0.1.0"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        }
+      }
+    },
+    "statuses": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+      "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
+      "dev": true
+    },
+    "stream": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stream/-/stream-0.0.2.tgz",
+      "integrity": "sha1-f1Nj8Ff2WSxVlfALyAon9c7B8O8=",
+      "dev": true,
+      "requires": {
+        "emitter-component": "^1.1.1"
+      }
+    },
+    "stream-shift": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
+      "dev": true
+    },
+    "streamsearch": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
+      "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo=",
+      "dev": true
+    },
+    "string-width": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "dev": true,
+      "requires": {
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
+      }
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
     },
     "strip-ansi": {
       "version": "3.0.1",
@@ -1601,10 +8828,49 @@
         "ansi-regex": "^2.0.0"
       }
     },
+    "strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "dev": true
+    },
+    "strip-bom-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
+      "integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
+      "dev": true,
+      "requires": {
+        "first-chunk-stream": "^1.0.0",
+        "strip-bom": "^2.0.0"
+      },
+      "dependencies": {
+        "strip-bom": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "dev": true,
+          "requires": {
+            "is-utf8": "^0.2.0"
+          }
+        }
+      }
+    },
+    "strip-eof": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+      "dev": true
+    },
     "strip-indent": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
       "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
+      "dev": true
+    },
+    "strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
     },
     "supports-color": {
@@ -1614,6 +8880,34 @@
       "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
+      }
+    },
+    "sw-precache": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/sw-precache/-/sw-precache-5.2.1.tgz",
+      "integrity": "sha512-8FAy+BP/FXE+ILfiVTt+GQJ6UEf4CVHD9OfhzH0JX+3zoy2uFk7Vn9EfXASOtVmmIVbL3jE/W8Z66VgPSZcMhw==",
+      "dev": true,
+      "requires": {
+        "dom-urls": "^1.1.0",
+        "es6-promise": "^4.0.5",
+        "glob": "^7.1.1",
+        "lodash.defaults": "^4.2.0",
+        "lodash.template": "^4.4.0",
+        "meow": "^3.7.0",
+        "mkdirp": "^0.5.1",
+        "pretty-bytes": "^4.0.2",
+        "sw-toolbox": "^3.4.0",
+        "update-notifier": "^2.3.0"
+      }
+    },
+    "sw-toolbox": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/sw-toolbox/-/sw-toolbox-3.6.0.tgz",
+      "integrity": "sha1-Jt8dHHA0hljk3qKIQxkUm3sxg7U=",
+      "dev": true,
+      "requires": {
+        "path-to-regexp": "^1.0.1",
+        "serviceworker-cache-polyfill": "^4.0.0"
       }
     },
     "table-layout": {
@@ -1627,6 +8921,75 @@
         "lodash.padend": "^4.6.1",
         "typical": "^2.6.1",
         "wordwrapjs": "^3.0.0"
+      }
+    },
+    "tar-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.0.0.tgz",
+      "integrity": "sha512-n2vtsWshZOVr/SY4KtslPoUlyNh06I2SGgAOCZmquCEjlbV/LjY2CY80rDtdQRHFOYXNlgBDo6Fr3ww2CWPOtA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "bl": "^2.2.0",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz",
+          "integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
+    "temp": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
+      "integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "os-tmpdir": "^1.0.0",
+        "rimraf": "~2.2.6"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.2.8",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+          "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "term-size": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
+      "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
+      "dev": true,
+      "requires": {
+        "execa": "^0.7.0"
+      }
+    },
+    "ternary-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ternary-stream/-/ternary-stream-2.0.1.tgz",
+      "integrity": "sha1-Bk5Im0tb9gumpre8fy9cJ07Pgmk=",
+      "dev": true,
+      "requires": {
+        "duplexify": "^3.5.0",
+        "fork-stream": "^0.0.4",
+        "merge-stream": "^1.0.0",
+        "through2": "^2.0.1"
       }
     },
     "test-value": {
@@ -1645,6 +9008,56 @@
       "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
       "dev": true
     },
+    "text-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
+      "dev": true
+    },
+    "thenify": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.0.tgz",
+      "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
+      "dev": true,
+      "requires": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
+      "dev": true,
+      "requires": {
+        "thenify": ">= 3.1.0 < 4"
+      }
+    },
+    "through2": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+      "dev": true,
+      "requires": {
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
+      }
+    },
+    "through2-filter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
+      "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
+      "dev": true,
+      "requires": {
+        "through2": "~2.0.0",
+        "xtend": "~4.0.0"
+      }
+    },
+    "timed-out": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+      "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
+      "dev": true
+    },
     "tiny-emitter": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
@@ -1652,11 +9065,113 @@
       "dev": true,
       "optional": true
     },
+    "to-absolute-glob": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
+      "integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^2.0.1"
+      }
+    },
+    "to-array": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz",
+      "integrity": "sha1-F+bBH3PdTz10zaek/zI46a2b+JA=",
+      "dev": true
+    },
+    "to-buffer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
+      "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
+      "dev": true
+    },
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
       "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
       "dev": true
+    },
+    "to-object-path": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+      "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      }
+    },
+    "to-regex": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+      "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+      "dev": true,
+      "requires": {
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "regex-not": "^1.0.2",
+        "safe-regex": "^1.1.0"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+          "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+          "dev": true,
+          "requires": {
+            "assign-symbols": "^1.0.0",
+            "is-extendable": "^1.0.1"
+          }
+        },
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
+        }
+      }
+    },
+    "to-regex-range": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+      "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+      "dev": true,
+      "requires": {
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          }
+        }
+      }
+    },
+    "tough-cookie": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+      "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+      "dev": true,
+      "requires": {
+        "psl": "^1.1.24",
+        "punycode": "^1.4.1"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+          "dev": true
+        }
+      }
     },
     "tr46": {
       "version": "1.0.1",
@@ -1667,10 +9182,37 @@
         "punycode": "^2.1.0"
       }
     },
+    "trim-newlines": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+      "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
+      "dev": true
+    },
     "trim-right": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+      "dev": true
+    },
+    "triple-beam": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
+      "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw==",
+      "dev": true
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true
     },
     "type-check": {
@@ -1688,6 +9230,22 @@
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true
     },
+    "type-is": {
+      "version": "1.6.16",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
+      "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
+      "dev": true,
+      "requires": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.18"
+      }
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
     "typescript": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.1.tgz",
@@ -1700,10 +9258,224 @@
       "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0=",
       "dev": true
     },
+    "ua-parser-js": {
+      "version": "0.7.19",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.19.tgz",
+      "integrity": "sha512-T3PVJ6uz8i0HzPxOF9SWzWAlfN/DavlpQqepn22xgve/5QecC+XMCAtmUNnY7C9StehaV6exjUCI801lOI7QlQ==",
+      "dev": true
+    },
+    "uglify-js": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.4.tgz",
+      "integrity": "sha512-GpKo28q/7Bm5BcX9vOu4S46FwisbPbAmkkqPnGIpKvKTM96I85N6XHQV+k4I6FA2wxgLhcsSyHoNhzucwCflvA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "commander": "~2.20.0",
+        "source-map": "~0.6.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+          "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "underscore": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+      "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
+      "dev": true
+    },
+    "unicode-canonical-property-names-ecmascript": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
+      "integrity": "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ==",
+      "dev": true
+    },
+    "unicode-match-property-ecmascript": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
+      "integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
+      "dev": true,
+      "requires": {
+        "unicode-canonical-property-names-ecmascript": "^1.0.4",
+        "unicode-property-aliases-ecmascript": "^1.0.4"
+      }
+    },
+    "unicode-match-property-value-ecmascript": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.1.0.tgz",
+      "integrity": "sha512-hDTHvaBk3RmFzvSl0UVrUmC3PuW9wKVnpoUDYH0JDkSIovzw+J5viQmeYHxVSBptubnr7PbH2e0fnpDRQnQl5g==",
+      "dev": true
+    },
+    "unicode-property-aliases-ecmascript": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.5.tgz",
+      "integrity": "sha512-L5RAqCfXqAwR3RriF8pM0lU0w4Ryf/GgzONwi6KnL1taJQa7x1TCxdJnILX59WIGOwR57IVxn7Nej0fz1Ny6fw==",
+      "dev": true
+    },
+    "union-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
+      "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+      "dev": true,
+      "requires": {
+        "arr-union": "^3.1.0",
+        "get-value": "^2.0.6",
+        "is-extendable": "^0.1.1",
+        "set-value": "^0.4.3"
+      },
+      "dependencies": {
+        "set-value": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
+          "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-extendable": "^0.1.1",
+            "is-plain-object": "^2.0.1",
+            "to-object-path": "^0.3.0"
+          }
+        }
+      }
+    },
+    "unique-stream": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.3.1.tgz",
+      "integrity": "sha512-2nY4TnBE70yoxHkDli7DMazpWiP7xMdCYqU2nBRO0UB+ZpEkGsSija7MvmvnZFUeC+mrgiUfcHSr3LmRFIg4+A==",
+      "dev": true,
+      "requires": {
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "through2-filter": "^3.0.0"
+      },
+      "dependencies": {
+        "through2-filter": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-3.0.0.tgz",
+          "integrity": "sha512-jaRjI2WxN3W1V8/FMZ9HKIBXixtiqs3SQSX4/YGIiP3gL6djW48VoZq9tDqeCWs3MT8YY5wb/zli8VW8snY1CA==",
+          "dev": true,
+          "requires": {
+            "through2": "~2.0.0",
+            "xtend": "~4.0.0"
+          }
+        }
+      }
+    },
+    "unique-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
+      "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
+      "dev": true,
+      "requires": {
+        "crypto-random-string": "^1.0.0"
+      }
+    },
     "universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true
+    },
+    "unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+      "dev": true
+    },
+    "unset-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+      "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+      "dev": true,
+      "requires": {
+        "has-value": "^0.3.1",
+        "isobject": "^3.0.0"
+      },
+      "dependencies": {
+        "has-value": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+          "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+          "dev": true,
+          "requires": {
+            "get-value": "^2.0.3",
+            "has-values": "^0.1.4",
+            "isobject": "^2.0.0"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+              "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+              "dev": true,
+              "requires": {
+                "isarray": "1.0.0"
+              }
+            }
+          }
+        },
+        "has-values": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+          "dev": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
+      }
+    },
+    "untildify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/untildify/-/untildify-2.1.0.tgz",
+      "integrity": "sha1-F+soB5h/dpUunASF/DEdBqgmouA=",
+      "dev": true,
+      "requires": {
+        "os-homedir": "^1.0.0"
+      }
+    },
+    "unzip-response": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
+      "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
+      "dev": true
+    },
+    "update-notifier": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.5.0.tgz",
+      "integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
+      "dev": true,
+      "requires": {
+        "boxen": "^1.2.1",
+        "chalk": "^2.0.1",
+        "configstore": "^3.0.0",
+        "import-lazy": "^2.1.0",
+        "is-ci": "^1.0.10",
+        "is-installed-globally": "^0.1.0",
+        "is-npm": "^1.0.0",
+        "latest-version": "^3.0.0",
+        "semver-diff": "^2.0.0",
+        "xdg-basedir": "^3.0.0"
+      }
+    },
+    "upper-case": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
+      "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg=",
       "dev": true
     },
     "uri-js": {
@@ -1715,17 +9487,369 @@
         "punycode": "^2.1.0"
       }
     },
+    "urijs": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.1.tgz",
+      "integrity": "sha512-xVrGVi94ueCJNrBSTjWqjvtgvl3cyOTThp2zaMaFNGp3F542TR6sM3f2o8RqZl+AwteClSVmoCyt0ka4RjQOQg==",
+      "dev": true
+    },
+    "urix": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+      "dev": true
+    },
+    "url-parse-lax": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+      "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+      "dev": true,
+      "requires": {
+        "prepend-http": "^1.0.1"
+      }
+    },
+    "use": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
+      "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+      "dev": true
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+      "dev": true
+    },
+    "uuid": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+      "dev": true
+    },
+    "vali-date": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
+      "integrity": "sha1-G5BKWWCfsyjvB4E4Qgk09rhnCaY=",
+      "dev": true
+    },
+    "validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "requires": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "vargs": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/vargs/-/vargs-0.1.0.tgz",
+      "integrity": "sha1-a2GE2mUgzDIEzhtAfKwm2SYJ6/8=",
+      "dev": true
+    },
+    "vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
+      "dev": true
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      }
+    },
+    "vinyl": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
+      "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
+      "dev": true,
+      "requires": {
+        "clone": "^1.0.0",
+        "clone-stats": "^0.0.1",
+        "replace-ext": "0.0.1"
+      },
+      "dependencies": {
+        "clone": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+          "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+          "dev": true
+        }
+      }
+    },
+    "vinyl-fs": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
+      "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
+      "dev": true,
+      "requires": {
+        "duplexify": "^3.2.0",
+        "glob-stream": "^5.3.2",
+        "graceful-fs": "^4.0.0",
+        "gulp-sourcemaps": "1.6.0",
+        "is-valid-glob": "^0.3.0",
+        "lazystream": "^1.0.0",
+        "lodash.isequal": "^4.0.0",
+        "merge-stream": "^1.0.0",
+        "mkdirp": "^0.5.0",
+        "object-assign": "^4.0.0",
+        "readable-stream": "^2.0.4",
+        "strip-bom": "^2.0.0",
+        "strip-bom-stream": "^1.0.0",
+        "through2": "^2.0.0",
+        "through2-filter": "^2.0.0",
+        "vali-date": "^1.0.0",
+        "vinyl": "^1.0.0"
+      },
+      "dependencies": {
+        "strip-bom": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "dev": true,
+          "requires": {
+            "is-utf8": "^0.2.0"
+          }
+        }
+      }
+    },
+    "vlq": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.3.tgz",
+      "integrity": "sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow==",
+      "dev": true
+    },
     "vscode-uri": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-1.0.6.tgz",
       "integrity": "sha512-sLI2L0uGov3wKVb9EB+vIQBl9tVP90nqRvxSoJ35vI3NjxE8jfsE5DSOhWgSunHSZmKS4OCi2jrtfxK7uyp2ww==",
       "dev": true
     },
+    "wbuf": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.3.tgz",
+      "integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
+      "dev": true,
+      "requires": {
+        "minimalistic-assert": "^1.0.0"
+      }
+    },
+    "wct-istanbub": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/wct-istanbub/-/wct-istanbub-0.2.9.tgz",
+      "integrity": "sha512-+fT+4vwxdDjFPXjTYkAgnYf8bDtPW0hUprOf377ZG/aeDHxn0/U9c/6XmW6AtgREs6/oUuR6++AUr/t8ben+wA==",
+      "dev": true,
+      "requires": {
+        "convert-source-map": "^1.5.1",
+        "express": "^4.16.2",
+        "html-script-hook": "^0.10.0",
+        "istanbul-api": "^2.0.6",
+        "istanbul-lib-coverage": "^2.0.1",
+        "istanbul-lib-instrument": "^3.0.0",
+        "istanbul-lib-report": "^2.0.1",
+        "istanbul-lib-source-maps": "^2.0.1",
+        "merge-source-map": "^1.1.0",
+        "minimatch": "^3.0.0",
+        "parseurl": "^1.3.0",
+        "polymer-build": "^3.0.1",
+        "polyserve": "^0.27.11",
+        "web-component-tester": "^6.6.0"
+      }
+    },
+    "wct-local": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/wct-local/-/wct-local-2.1.3.tgz",
+      "integrity": "sha512-pOGyT07Bh6TAJVk7E3P+n5RybjtYBqm745fCfY5vuhQd069mN1WUlivMgZzWfJuvuXVpKFkAERrN/+tTjbmgmQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@types/express": "^4.0.30",
+        "@types/freeport": "^1.0.19",
+        "@types/launchpad": "^0.6.0",
+        "@types/which": "^1.3.1",
+        "chalk": "^2.3.0",
+        "cleankill": "^2.0.0",
+        "freeport": "^1.0.4",
+        "launchpad": "^0.7.0",
+        "selenium-standalone": "^6.7.0",
+        "which": "^1.0.8"
+      }
+    },
     "wct-mocha": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wct-mocha/-/wct-mocha-1.0.0.tgz",
       "integrity": "sha512-rvDjW4kJMV8/lpihKMDHMZwycT5ALtoLni/Q0Ggdg1rPRpIW5pjoslSR/UIl2gWRMYqAs9nFRVYxASwEYG6brA==",
       "dev": true
+    },
+    "wct-sauce": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/wct-sauce/-/wct-sauce-2.1.0.tgz",
+      "integrity": "sha512-c3R4PJcbpS7Gxv2vZ4HDAqpXV6cT9peslAWMU7hHH9PMhKDPbn8RNa6E4DVL0tOmZznB+3cRmtZ6+vJ/aDwu1A==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "chalk": "^2.4.1",
+        "cleankill": "^2.0.0",
+        "lodash": "^4.17.10",
+        "request": "^2.85.0",
+        "sauce-connect-launcher": "^1.0.0",
+        "temp": "^0.8.1",
+        "uuid": "^3.2.1"
+      }
+    },
+    "wd": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/wd/-/wd-1.11.2.tgz",
+      "integrity": "sha512-zXJY9ARjQQYN2LatLTRcW39EYzIVqKNhGpp4XWJmRgHBioG4FoenIOsoVbaO8lnFGgv31V99kAy5hB4eWGIwzA==",
+      "dev": true,
+      "requires": {
+        "archiver": "2.1.1",
+        "async": "2.0.1",
+        "lodash": "4.17.11",
+        "mkdirp": "^0.5.1",
+        "q": "1.4.1",
+        "request": "2.88.0",
+        "vargs": "0.1.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.0.1.tgz",
+          "integrity": "sha1-twnMAoCpw28J9FNr6CPIOKkEniU=",
+          "dev": true,
+          "requires": {
+            "lodash": "^4.8.0"
+          }
+        },
+        "q": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
+          "integrity": "sha1-VXBbzZPF82c1MMLCy8DCs63cKG4=",
+          "dev": true
+        }
+      }
+    },
+    "web-component-tester": {
+      "version": "6.9.2",
+      "resolved": "https://registry.npmjs.org/web-component-tester/-/web-component-tester-6.9.2.tgz",
+      "integrity": "sha512-s2kB/+IE8XWcnxY1fqSpqTiiHEGHWgUWariAbiRlxmAvWSuvaCVNALHYebsZrLCNCLHKcJR8/sGv/bw0MWMvjw==",
+      "dev": true,
+      "requires": {
+        "@polymer/sinonjs": "^1.14.1",
+        "@polymer/test-fixture": "^0.0.3",
+        "@webcomponents/webcomponentsjs": "^1.0.7",
+        "accessibility-developer-tools": "^2.12.0",
+        "async": "^2.4.1",
+        "body-parser": "^1.17.2",
+        "bower-config": "^1.4.0",
+        "chalk": "^1.1.3",
+        "cleankill": "^2.0.0",
+        "express": "^4.15.3",
+        "findup-sync": "^2.0.0",
+        "glob": "^7.1.2",
+        "lodash": "^3.10.1",
+        "multer": "^1.3.0",
+        "nomnom": "^1.8.1",
+        "polyserve": "^0.27.13",
+        "resolve": "^1.5.0",
+        "semver": "^5.3.0",
+        "send": "^0.16.1",
+        "server-destroy": "^1.0.1",
+        "sinon": "^2.3.5",
+        "sinon-chai": "^2.10.0",
+        "socket.io": "^2.0.3",
+        "stacky": "^1.3.1",
+        "update-notifier": "^2.2.0",
+        "wct-local": "^2.1.1",
+        "wct-sauce": "^2.0.2",
+        "wd": "^1.2.0"
+      },
+      "dependencies": {
+        "@polymer/test-fixture": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/@polymer/test-fixture/-/test-fixture-0.0.3.tgz",
+          "integrity": "sha1-REN1JpfU2Sk7vEEuoLXk00HxSdk=",
+          "dev": true
+        },
+        "@webcomponents/webcomponentsjs": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-1.3.3.tgz",
+          "integrity": "sha512-eLH04VBMpuZGzBIhOnUjECcQPEPcmfhWEijW9u1B5I+2PPYdWf3vWUExdDxu4Y3GljRSTCOlWnGtS9tpzmXMyQ==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "lodash": {
+          "version": "3.10.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
+          "dev": true
+        },
+        "lolex": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
+          "integrity": "sha1-OpoCg0UqR9dDnnJzG54H1zhuSfY=",
+          "dev": true
+        },
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "dev": true
+        },
+        "sinon": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/sinon/-/sinon-2.4.1.tgz",
+          "integrity": "sha512-vFTrO9Wt0ECffDYIPSP/E5bBugt0UjcBQOfQUMh66xzkyPEnhl/vM2LRZi2ajuTdkH07sA6DzrM6KvdvGIH8xw==",
+          "dev": true,
+          "requires": {
+            "diff": "^3.1.0",
+            "formatio": "1.2.0",
+            "lolex": "^1.6.0",
+            "native-promise-only": "^0.8.1",
+            "path-to-regexp": "^1.7.0",
+            "samsam": "^1.1.3",
+            "text-encoding": "0.6.4",
+            "type-detect": "^4.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
     },
     "webidl-conversions": {
       "version": "4.0.2",
@@ -1742,6 +9866,77 @@
         "lodash.sortby": "^4.7.0",
         "tr46": "^1.0.1",
         "webidl-conversions": "^4.0.2"
+      }
+    },
+    "which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "widest-line": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
+      "integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
+      "dev": true,
+      "requires": {
+        "string-width": "^2.1.1"
+      }
+    },
+    "winston": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.2.1.tgz",
+      "integrity": "sha512-zU6vgnS9dAWCEKg/QYigd6cgMVVNwyTzKs81XZtTFuRwJOcDdBg7AU0mXVyNbs7O5RH2zdv+BdNZUlx7mXPuOw==",
+      "dev": true,
+      "requires": {
+        "async": "^2.6.1",
+        "diagnostics": "^1.1.1",
+        "is-stream": "^1.1.0",
+        "logform": "^2.1.1",
+        "one-time": "0.0.4",
+        "readable-stream": "^3.1.1",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.3.0"
+      },
+      "dependencies": {
+        "logform": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/logform/-/logform-2.1.2.tgz",
+          "integrity": "sha512-+lZh4OpERDBLqjiwDLpAWNQu6KMjnlXH2ByZwCuSqVPJletw0kTWJf5CgSNAUKn1KUkv3m2cUz/LK8zyEy7wzQ==",
+          "dev": true,
+          "requires": {
+            "colors": "^1.2.1",
+            "fast-safe-stringify": "^2.0.4",
+            "fecha": "^2.3.3",
+            "ms": "^2.1.1",
+            "triple-beam": "^1.3.0"
+          }
+        },
+        "readable-stream": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz",
+          "integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
+    "winston-transport": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.3.0.tgz",
+      "integrity": "sha512-B2wPuwUi3vhzn/51Uukcao4dIduEiPOcOt9HJ3QeaXgkJ5Z7UwpBzxS4ZGNHtrxrUvTwemsQiSys0ihOf8Mp1A==",
+      "dev": true,
+      "requires": {
+        "readable-stream": "^2.3.6",
+        "triple-beam": "^1.2.0"
       }
     },
     "wordwrap": {
@@ -1765,6 +9960,93 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
+    },
+    "write-file-atomic": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.2.tgz",
+      "integrity": "sha512-s0b6vB3xIVRLWywa6X9TOMA7k9zio0TMOsl9ZnDkliA/cfJlpHXAscj0gbHVJiTdIuAYpIyqS5GW91fqm6gG5g==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.11",
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "ws": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-6.1.4.tgz",
+      "integrity": "sha512-eqZfL+NE/YQc1/ZynhojeV8q+H050oR8AZ2uIev7RU10svA9ZnJUddHcOUZTJLinZ9yEfdA2kSATS2qZK5fhJA==",
+      "dev": true,
+      "requires": {
+        "async-limiter": "~1.0.0"
+      }
+    },
+    "xdg-basedir": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
+      "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
+      "dev": true
+    },
+    "xmlbuilder": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-8.2.2.tgz",
+      "integrity": "sha1-aSSGc0ELS6QuGmE2VR0pIjNap3M=",
+      "dev": true,
+      "optional": true
+    },
+    "xmldom": {
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
+      "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk=",
+      "dev": true,
+      "optional": true
+    },
+    "xmlhttprequest-ssl": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
+      "integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4=",
+      "dev": true
+    },
+    "xtend": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+      "dev": true
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "dev": true
+    },
+    "yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    },
+    "yeast": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
+      "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk=",
+      "dev": true
+    },
+    "zip-stream": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-1.2.0.tgz",
+      "integrity": "sha1-qLxF9MG0lpnGuQGYuqyqzbzUugQ=",
+      "dev": true,
+      "requires": {
+        "archiver-utils": "^1.3.0",
+        "compress-commons": "^1.2.0",
+        "lodash": "^4.8.0",
+        "readable-stream": "^2.0.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,16 +18,18 @@
     "The Advanced REST client authors <arc@mulesoft.com>"
   ],
   "devDependencies": {
-    "@polymer/gen-typescript-declarations": "^1.6.1",
     "@api-components/api-model-generator": "^0.1.10",
-    "@polymer/iron-demo-helpers": "^3.0.0",
+    "@polymer/gen-typescript-declarations": "^1.6.1",
     "@polymer/iron-component-page": "^4.0.0",
+    "@polymer/iron-demo-helpers": "^3.0.0",
     "@polymer/iron-test-helpers": "^3.0.0",
     "@polymer/test-fixture": "^4.0.2",
     "@webcomponents/webcomponentsjs": "^2.0.0",
     "chai": "^4.2.0",
+    "istanbub": "^0.4.6",
     "mocha": "^5.2.0",
     "sinon": "^7.2.3",
+    "wct-istanbub": "^0.2.9",
     "wct-mocha": "^1.0.0"
   },
   "scripts": {

--- a/test/amf-helper-mixin-test.html
+++ b/test/amf-helper-mixin-test.html
@@ -94,7 +94,8 @@ suite('amf-helper-mixin', () => {
       const key = 'http://a.ml/vocabularies/';
       assert.equal(v.name, key);
       assert.equal(v.document, key + 'document#');
-      assert.equal(v.http, key + 'http#');
+      assert.equal(v.core, key + 'core#');
+      assert.equal(v.http, key + 'apiContract#'); // mapped
       assert.equal(v.security, key + 'security#');
       assert.equal(v.shapes, key + 'shapes#');
       assert.equal(v.data, key + 'data#');
@@ -120,12 +121,12 @@ suite('amf-helper-mixin', () => {
       });
     });
 
-    test('hydra properties are set', () => {
+    test('hydra properties have been mapped to aml.apiContract', () => {
       const h = AmfNamespace.w3.hydra;
       const key = 'http://www.w3.org/ns/hydra/';
       assert.equal(h.name, key);
-      assert.equal(h.core, key + 'core#');
-      assert.equal(h.supportedOperation, key + 'core#supportedOperation');
+      assert.equal(h.core, AmfNamespace.raml.vocabularies.apiContract); // mapped
+      assert.equal(h.supportedOperation, AmfNamespace.raml.vocabularies.apiContract + 'supportedOperation');
     });
 
     test('hydra cannot be changed', () => {
@@ -154,20 +155,21 @@ suite('amf-helper-mixin', () => {
       });
     });
 
-    test('schema properties are set', () => {
+    test('schema properties are mapped to aml.core / aml.apiContract (only WebAPI, name, description, displayName, title)', () => {
       const s = AmfNamespace.schema;
-      const key = 'http://schema.org/';
+      const ns = AmfNamespace;
+      const key = AmfNamespace.raml.vocabularies.core;
       assert.equal(s.name, key);
-      assert.equal(s.schemaName, key + 'name');
-      assert.equal(s.desc, key + 'description');
+      assert.equal(s.schemaName, ns.raml.vocabularies.core + 'name');
+      assert.equal(s.desc, ns.raml.vocabularies.core + 'description');
       assert.equal(s.doc, key + 'documentation');
-      assert.equal(s.webApi, key + 'WebAPI');
+      assert.equal(s.webApi, ns.raml.vocabularies.apiContract + 'WebAPI'); // special
       assert.equal(s.creativeWork, key + 'CreativeWork');
       [
         'displayName', 'title'
       ]
       .forEach((name) => {
-        assert.equal(s[name], key + name);
+        assert.equal(s[name], ns.raml.vocabularies.core + name);
       });
     });
 
@@ -505,7 +507,7 @@ suite('amf-helper-mixin', () => {
 
     test('Returns undefined if no description key', () => {
       assert.equal(element._computeDescription({
-        'http://schema.org/description': [{
+        'http://a.ml/vocabularies/core#description': [{
           '@value': ['test']
         }]
       }), 'test');
@@ -740,7 +742,7 @@ suite('amf-helper-mixin', () => {
       const id = endpoint['@id'];
       const result = element._computeEndpointModel(webApi, id);
       assert.typeOf(result, 'object');
-      assert.equal(result['@type'][0], 'http://a.ml/vocabularies/http#EndPoint');
+      assert.equal(result['@type'][0], 'http://a.ml/vocabularies/apiContract#EndPoint');
     });
   });
 
@@ -775,7 +777,7 @@ suite('amf-helper-mixin', () => {
       }
       const result = element._computeMethodModel(webApi, op['@id']);
       assert.typeOf(result, 'object');
-      assert.equal(result['@type'][0], 'http://www.w3.org/ns/hydra/core#Operation');
+      assert.equal(result['@type'][0], 'http://a.ml/vocabularies/apiContract#Operation');
     });
   });
 
@@ -841,7 +843,7 @@ suite('amf-helper-mixin', () => {
 
     test('Reference is resolved', () => {
       const itemsKey = 'http://a.ml/vocabularies/shapes#items';
-      const nameKey = 'http://schema.org/name';
+      const nameKey = 'http://a.ml/vocabularies/core#name';
       const shape = resolved[itemsKey][0];
       assert.equal(shape[nameKey][0]['@value'], 'Pic');
     });
@@ -904,10 +906,10 @@ suite('amf-helper-mixin', () => {
 
     test('Resolves link target', () => {
       const endpoint = element._computeEndpointByPath(webApi, '/referenceId');
-      const op = endpoint['http://www.w3.org/ns/hydra/core#supportedOperation'][0];
-      const expects = op['http://www.w3.org/ns/hydra/core#expects'][0];
-      const payload = expects['http://a.ml/vocabularies/http#payload'][0];
-      const schema = payload['http://a.ml/vocabularies/http#schema'][0];
+      const op = endpoint['http://a.ml/vocabularies/apiContract#supportedOperation'][0];
+      const expects = op['http://a.ml/vocabularies/apiContract#expects'][0];
+      const payload = expects['http://a.ml/vocabularies/apiContract#payload'][0];
+      const schema = payload['http://a.ml/vocabularies/apiContract#schema'][0];
       const result = element._resolve(schema);
       assert.typeOf(result['http://www.w3.org/ns/shacl#name'], 'array');
     });
@@ -1023,7 +1025,7 @@ suite('amf-helper-mixin', () => {
     test('Returns value from example', () => {
       const ns = AmfNamespace;
       const sKey = element._getAmfKey(ns.raml.vocabularies.http + 'schema');
-      const exKey = element._getAmfKey(ns.raml.vocabularies.document + 'examples');
+      const exKey = element._getAmfKey(ns.raml.vocabularies.apiContract + 'examples');
       const rKey = element._getAmfKey(ns.w3.shacl.name + 'raw');
       const obj = {};
       obj[sKey] = [{}];

--- a/test/base-uri-test.html
+++ b/test/base-uri-test.html
@@ -59,10 +59,10 @@ suite('Base URI test', () => {
   const noSchemeServer = {
     '@id': 'file://test/demo-api/demo-api.raml#/web-api/https%3A%2F%2Fapi.mulesoft.com%2F%7Bversion%7D',
     '@type': [
-      'http://raml.org/vocabularies/http#Server',
+      'http://raml.org/vocabularies/apiContract#Server',
       'http://raml.org/vocabularies/document#DomainElement'
     ],
-    'http://a.ml/vocabularies/http#url': [
+    'http://a.ml/vocabularies/apiContract#url': [
       {
         '@value': 'api.mulesoft.com/test'
       }

--- a/test/compact-model-test.html
+++ b/test/compact-model-test.html
@@ -43,11 +43,11 @@ suite('Compact model tests', () => {
     setup(() => {
       element = fixture('Basic');
     });
-    const key = 'http://schema.org/description';
+    const key = 'http://a.ml/vocabularies/core#description';
     test('Returns a value from context', function() {
       element.amfModel = model;
       const result = element._getAmfKey(key);
-      assert.equal(result, 'schema-org:description');
+      assert.equal(result, 'core:description');
     });
 
     test('Returns the key if no AMF', function() {
@@ -80,9 +80,9 @@ suite('Compact model tests', () => {
 
     test('Returns the value', () => {
       element.amfModel = model;
-      const key = 'http://a.ml/vocabularies/http#scheme';
+      const key = 'http://a.ml/vocabularies/apiContract#scheme';
       const result = element._getValue({
-        'raml-http:scheme': [{
+        'apiContract:scheme': [{
           '@value': 'test'
         }]
       }, key);
@@ -107,9 +107,9 @@ suite('Compact model tests', () => {
 
     test('Returns the values', () => {
       element.amfModel = model;
-      const key = 'http://a.ml/vocabularies/http#scheme';
+      const key = 'http://a.ml/vocabularies/apiContract#scheme';
       const result = element._getValueArray({
-        'raml-http:scheme': [{
+        'apiContract:scheme': [{
           '@value': 'test'
         }, {
           '@value': 'test2'
@@ -119,9 +119,9 @@ suite('Compact model tests', () => {
     });
 
     test('Returns undefined if no model', () => {
-      const key = 'http://a.ml/vocabularies/http#scheme';
+      const key = 'http://a.ml/vocabularies/apiContract#scheme';
       const result = element._getValueArray({
-        'raml-http:scheme': [{
+        'apiContract:scheme': [{
           '@value': 'test'
         }, {
           '@value': 'test2'
@@ -182,7 +182,7 @@ suite('Compact model tests', () => {
 
     test('Returns undefined if no description key', () => {
       assert.equal(element._computeDescription({
-        'schema-org:description': [{
+        'core:description': [{
           '@value': ['test']
         }]
       }), 'test');
@@ -323,7 +323,7 @@ suite('Compact model tests', () => {
       const id = endpoint['@id'];
       const result = element._computeEndpointModel(webApi, id);
       assert.typeOf(result, 'object');
-      assert.equal(result['@type'][0], 'raml-http:EndPoint');
+      assert.equal(result['@type'][0], 'apiContract:EndPoint');
     });
   });
 
@@ -343,7 +343,7 @@ suite('Compact model tests', () => {
       }
       const result = element._computeMethodModel(webApi, op['@id']);
       assert.typeOf(result, 'object');
-      assert.equal(result['@type'][0], 'hydra:Operation');
+      assert.equal(result['@type'][0], 'apiContract:Operation');
     });
   });
 
@@ -395,7 +395,7 @@ suite('Compact model tests', () => {
 
     test('Reference is resolved', () => {
       const itemsKey = element._getAmfKey('http://a.ml/vocabularies/shapes#items');
-      const nameKey = element._getAmfKey('http://schema.org/name');
+      const nameKey = element._getAmfKey('http://a.ml/vocabularies/core#name');
       const shape = resolved[itemsKey][0];
       assert.equal(shape[nameKey][0]['@value'], 'Pic');
     });
@@ -431,13 +431,14 @@ suite('Compact model tests', () => {
       const soKey = element._getAmfKey(AmfNamespace.w3.hydra.supportedOperation);
       const op = element._ensureArray(endpoint[soKey])[0];
       const expects = element._ensureArray(
-        op[element._getAmfKey('http://www.w3.org/ns/hydra/core#expects')])[0];
+        op[element._getAmfKey('http://a.ml/vocabularies/apiContract#expects')])[0];
       const payload = element._ensureArray(
-        expects[element._getAmfKey('http://a.ml/vocabularies/http#payload')])[0];
+        expects[element._getAmfKey('http://a.ml/vocabularies/apiContract#payload')])[0];
       const schema = element._ensureArray(
-        payload[element._getAmfKey('http://a.ml/vocabularies/http#schema')])[0];
+        payload[element._getAmfKey('http://a.ml/vocabularies/apiContract#schema')])[0];
       const result = element._resolve(schema);
-      assert.typeOf(result[element._getAmfKey('http://www.w3.org/ns/shacl#name')], 'array');
+      const finalResult = result[element._getAmfKey('http://www.w3.org/ns/shacl#name')];
+      assert.typeOf(finalResult, 'array');
     });
   });
 });

--- a/test/demo-api-compact.json
+++ b/test/demo-api-compact.json
@@ -9,54 +9,54 @@
 ],
 "doc:encodes": [
 {
-"@id": "#202",
+"@id": "#216",
 "@type": [
-"schema-org:WebAPI",
+"apiContract:WebAPI",
 "doc:RootDomainElement",
 "doc:DomainElement"
 ],
-"schema-org:name": [
+"core:name": [
 {
 "@value": "Navigation demo API"
 }
 ],
-"raml-http:server": [
+"apiContract:server": [
 {
-"@id": "#383",
+"@id": "#398",
 "@type": [
-"raml-http:Server",
+"apiContract:Server",
 "doc:DomainElement"
 ],
-"raml-http:url": [
+"apiContract:url": [
 {
 "@value": "https://api.mulesoft.com/{version}"
 }
 ],
-"raml-http:variable": [
+"apiContract:variable": [
 {
-"@id": "#384",
+"@id": "#399",
 "@type": [
-"raml-http:Parameter",
+"apiContract:Parameter",
 "doc:DomainElement"
 ],
-"schema-org:name": [
+"core:name": [
 {
 "@value": "version"
 }
 ],
-"hydra:required": [
+"apiContract:required": [
 {
 "@value": true
 }
 ],
-"raml-http:binding": [
+"apiContract:binding": [
 {
 "@value": "path"
 }
 ],
-"raml-http:schema": [
+"apiContract:schema": [
 {
-"@id": "#385",
+"@id": "#400",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -77,7 +77,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#384/source-map",
+"@id": "#399/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -85,7 +85,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#384"
+"@value": "amf://id#399"
 }
 ],
 "sourcemaps:value": [
@@ -101,7 +101,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#383/source-map",
+"@id": "#398/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -109,7 +109,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "raml-http:url"
+"@value": "apiContract:url"
 }
 ],
 "sourcemaps:value": [
@@ -123,7 +123,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#383"
+"@value": "amf://id#398"
 }
 ],
 "sourcemaps:value": [
@@ -137,36 +137,36 @@
 ]
 }
 ],
-"raml-http:scheme": [
+"apiContract:scheme": [
 {
 "@value": "HTTPS"
 }
 ],
-"schema-org:version": [
+"core:version": [
 {
 "@value": "v2"
 }
 ],
-"schema-org:documentation": [
+"core:documentation": [
 {
-"@id": "#386",
+"@id": "#401",
 "@type": [
-"schema-org:CreativeWork",
+"core:CreativeWork",
 "doc:DomainElement"
 ],
-"schema-org:title": [
+"core:title": [
 {
 "@value": "How to begin"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "Example content\n"
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#386/source-map",
+"@id": "#401/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -174,7 +174,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -186,7 +186,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#386"
+"@value": "amf://id#401"
 }
 ],
 "sourcemaps:value": [
@@ -198,7 +198,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:title"
+"@value": "core:title"
 }
 ],
 "sourcemaps:value": [
@@ -212,24 +212,24 @@
 ]
 },
 {
-"@id": "#387",
+"@id": "#402",
 "@type": [
-"schema-org:CreativeWork",
+"core:CreativeWork",
 "doc:DomainElement"
 ],
-"schema-org:title": [
+"core:title": [
 {
 "@value": "Other documentation entry"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "Example content\n"
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#387/source-map",
+"@id": "#402/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -237,7 +237,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -249,7 +249,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#387"
+"@value": "amf://id#402"
 }
 ],
 "sourcemaps:value": [
@@ -261,7 +261,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:title"
+"@value": "core:title"
 }
 ],
 "sourcemaps:value": [
@@ -275,48 +275,48 @@
 ]
 }
 ],
-"raml-http:endpoint": [
+"apiContract:endpoint": [
 {
-"@id": "#203",
+"@id": "#217",
 "@type": [
-"raml-http:EndPoint",
+"apiContract:EndPoint",
 "doc:DomainElement"
 ],
-"raml-http:path": [
+"apiContract:path": [
 {
 "@value": "/files"
 }
 ],
-"schema-org:name": [
+"core:name": [
 {
 "@value": "Files"
 }
 ],
-"hydra:supportedOperation": [
+"apiContract:supportedOperation": [
 {
-"@id": "#204",
+"@id": "#218",
 "@type": [
-"hydra:Operation",
+"apiContract:Operation",
 "doc:DomainElement"
 ],
-"hydra:method": [
+"apiContract:method": [
 {
 "@value": "post"
 }
 ],
-"schema-org:name": [
+"core:name": [
 {
 "@value": "Insert"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "Insert a new file.\nThis method supports an /upload URI and accepts uploaded media with the following characteristics:\n\n- Maximum file size: 5120GB\n- Accepted Media MIME types: */*\n\nNote: Apps creating shortcuts with files.insert must specify the MIME type `application/vnd.google-apps.drive-sdk`.\n\nApps should specify a file extension in the title property when inserting files with the API. For example, an operation to insert a JPEG file should specify something like `\"title\": \"cat.jpg\"` in the metadata.\n\nSubsequent GET requests include the read-only fileExtension property populated with the extension originally specified in the title property. When a Google Drive user requests to download a file, or when the file is downloaded through the sync client, Drive builds a full filename (with extension) based on the title. In cases where the extension is missing, Google Drive attempts to determine the extension based on the file's MIME type.\n\n### HTTP request\n\nThis method provides media upload functionality through two separate URIs. For more details, see the document on media upload.\n\n- Upload URI, for media upload requests: `POST https://www.googleapis.com/upload/drive/v2/files`\n- Metadata URI, for metadata-only requests: `POST https://www.googleapis.com/drive/v2/files`\n"
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#204/source-map",
+"@id": "#218/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -324,7 +324,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -336,7 +336,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#204"
+"@value": "amf://id#218"
 }
 ],
 "sourcemaps:value": [
@@ -348,7 +348,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:name"
+"@value": "core:name"
 }
 ],
 "sourcemaps:value": [
@@ -362,46 +362,46 @@
 ]
 },
 {
-"@id": "#205",
+"@id": "#219",
 "@type": [
-"hydra:Operation",
+"apiContract:Operation",
 "doc:DomainElement"
 ],
-"hydra:method": [
+"apiContract:method": [
 {
 "@value": "get"
 }
 ],
-"schema-org:name": [
+"core:name": [
 {
 "@value": "list"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "Lists the user's files. Try it now or see an example.\n\nRequests with `files.list` accept the `q` parameter, which is a search query combining one or more search terms. For more information, see Search for files.\n\nNote: Note: This method returns all files by default. This includes files with trashed=true in the results. Use the trashed=false query parameter to filter these from the results.\n"
 }
 ],
 "security:security": [
 {
-"@id": "#206",
+"@id": "#220",
 "@type": [
 "security:ParametrizedSecurityScheme",
 "doc:DomainElement"
 ],
-"security:name": [
+"core:name": [
 {
 "@value": "basic"
 }
 ],
 "security:scheme": [
 {
-"@id": "#200",
+"@id": "#214",
 "@type": [
 "security:SecurityScheme",
 "doc:DomainElement"
 ],
-"security:name": [
+"core:name": [
 {
 "@value": "basic"
 }
@@ -411,14 +411,14 @@
 "@value": "Basic Authentication"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "Test basic auth method\n"
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#200/source-map",
+"@id": "#214/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -426,7 +426,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#200"
+"@value": "amf://id#214"
 }
 ],
 "sourcemaps:value": [
@@ -440,7 +440,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -452,7 +452,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "security:name"
+"@value": "core:name"
 }
 ],
 "sourcemaps:value": [
@@ -464,7 +464,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#200"
+"@value": "amf://id#214"
 }
 ],
 "sourcemaps:value": [
@@ -492,7 +492,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#206/source-map",
+"@id": "#220/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -500,7 +500,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#206"
+"@value": "amf://id#220"
 }
 ],
 "sourcemaps:value": [
@@ -516,7 +516,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#205/source-map",
+"@id": "#219/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -524,7 +524,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -536,7 +536,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#205"
+"@value": "amf://id#219"
 }
 ],
 "sourcemaps:value": [
@@ -548,7 +548,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:name"
+"@value": "core:name"
 }
 ],
 "sourcemaps:value": [
@@ -564,7 +564,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#203/source-map",
+"@id": "#217/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -572,7 +572,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:name"
+"@value": "core:name"
 }
 ],
 "sourcemaps:value": [
@@ -584,7 +584,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#203"
+"@value": "amf://id#217"
 }
 ],
 "sourcemaps:value": [
@@ -598,41 +598,41 @@
 ]
 },
 {
-"@id": "#207",
+"@id": "#221",
 "@type": [
-"raml-http:EndPoint",
+"apiContract:EndPoint",
 "doc:DomainElement"
 ],
-"raml-http:path": [
+"apiContract:path": [
 {
 "@value": "/files/{fileId}"
 }
 ],
-"schema-org:name": [
+"core:name": [
 {
 "@value": "Get file"
 }
 ],
-"hydra:supportedOperation": [
+"apiContract:supportedOperation": [
 {
-"@id": "#208",
+"@id": "#222",
 "@type": [
-"hydra:Operation",
+"apiContract:Operation",
 "doc:DomainElement"
 ],
-"hydra:method": [
+"apiContract:method": [
 {
 "@value": "get"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "Gets a file's metadata by ID."
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#208/source-map",
+"@id": "#222/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -640,7 +640,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -652,7 +652,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#208"
+"@value": "amf://id#222"
 }
 ],
 "sourcemaps:value": [
@@ -666,24 +666,24 @@
 ]
 },
 {
-"@id": "#209",
+"@id": "#223",
 "@type": [
-"hydra:Operation",
+"apiContract:Operation",
 "doc:DomainElement"
 ],
-"hydra:method": [
+"apiContract:method": [
 {
 "@value": "patch"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "Updates file metadata. This method supports patch semantics."
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#209/source-map",
+"@id": "#223/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -691,7 +691,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -703,7 +703,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#209"
+"@value": "amf://id#223"
 }
 ],
 "sourcemaps:value": [
@@ -717,24 +717,24 @@
 ]
 },
 {
-"@id": "#210",
+"@id": "#224",
 "@type": [
-"hydra:Operation",
+"apiContract:Operation",
 "doc:DomainElement"
 ],
-"hydra:method": [
+"apiContract:method": [
 {
 "@value": "put"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "Updates file metadata and/or content."
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#210/source-map",
+"@id": "#224/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -742,7 +742,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -754,7 +754,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#210"
+"@value": "amf://id#224"
 }
 ],
 "sourcemaps:value": [
@@ -768,24 +768,24 @@
 ]
 },
 {
-"@id": "#211",
+"@id": "#225",
 "@type": [
-"hydra:Operation",
+"apiContract:Operation",
 "doc:DomainElement"
 ],
-"hydra:method": [
+"apiContract:method": [
 {
 "@value": "delete"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "Permanently deletes a file by ID. Skips the trash. The currently authenticated user must own the file."
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#211/source-map",
+"@id": "#225/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -793,7 +793,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -805,7 +805,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#211"
+"@value": "amf://id#225"
 }
 ],
 "sourcemaps:value": [
@@ -819,36 +819,36 @@
 ]
 }
 ],
-"raml-http:parameter": [
+"apiContract:parameter": [
 {
-"@id": "#212",
+"@id": "#226",
 "@type": [
-"raml-http:Parameter",
+"apiContract:Parameter",
 "doc:DomainElement"
 ],
-"schema-org:name": [
+"core:name": [
 {
 "@value": "fileId"
 }
 ],
-"raml-http:paramName": [
+"apiContract:paramName": [
 {
 "@value": "fileId"
 }
 ],
-"hydra:required": [
+"apiContract:required": [
 {
 "@value": true
 }
 ],
-"raml-http:binding": [
+"apiContract:binding": [
 {
 "@value": "path"
 }
 ],
-"raml-http:schema": [
+"apiContract:schema": [
 {
-"@id": "#213",
+"@id": "#227",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -869,7 +869,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#212/source-map",
+"@id": "#226/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -877,7 +877,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#212"
+"@value": "amf://id#226"
 }
 ],
 "sourcemaps:value": [
@@ -893,7 +893,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#207/source-map",
+"@id": "#221/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -901,7 +901,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#207"
+"@value": "amf://id#221"
 }
 ],
 "sourcemaps:value": [
@@ -915,7 +915,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:name"
+"@value": "core:name"
 }
 ],
 "sourcemaps:value": [
@@ -927,7 +927,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#207"
+"@value": "amf://id#221"
 }
 ],
 "sourcemaps:value": [
@@ -941,36 +941,36 @@
 ]
 },
 {
-"@id": "#214",
+"@id": "#228",
 "@type": [
-"raml-http:EndPoint",
+"apiContract:EndPoint",
 "doc:DomainElement"
 ],
-"raml-http:path": [
+"apiContract:path": [
 {
 "@value": "/files/{fileId}/copy"
 }
 ],
-"hydra:supportedOperation": [
+"apiContract:supportedOperation": [
 {
-"@id": "#215",
+"@id": "#229",
 "@type": [
-"hydra:Operation",
+"apiContract:Operation",
 "doc:DomainElement"
 ],
-"hydra:method": [
+"apiContract:method": [
 {
 "@value": "post"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "Creates a copy of the specified file."
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#215/source-map",
+"@id": "#229/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -978,7 +978,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -990,7 +990,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#215"
+"@value": "amf://id#229"
 }
 ],
 "sourcemaps:value": [
@@ -1004,36 +1004,36 @@
 ]
 }
 ],
-"raml-http:parameter": [
+"apiContract:parameter": [
 {
-"@id": "#216",
+"@id": "#230",
 "@type": [
-"raml-http:Parameter",
+"apiContract:Parameter",
 "doc:DomainElement"
 ],
-"schema-org:name": [
+"core:name": [
 {
 "@value": "fileId"
 }
 ],
-"raml-http:paramName": [
+"apiContract:paramName": [
 {
 "@value": "fileId"
 }
 ],
-"hydra:required": [
+"apiContract:required": [
 {
 "@value": true
 }
 ],
-"raml-http:binding": [
+"apiContract:binding": [
 {
 "@value": "path"
 }
 ],
-"raml-http:schema": [
+"apiContract:schema": [
 {
-"@id": "#217",
+"@id": "#231",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -1054,7 +1054,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#216/source-map",
+"@id": "#230/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -1062,7 +1062,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#216"
+"@value": "amf://id#230"
 }
 ],
 "sourcemaps:value": [
@@ -1078,7 +1078,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#214/source-map",
+"@id": "#228/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -1086,7 +1086,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#214"
+"@value": "amf://id#228"
 }
 ],
 "sourcemaps:value": [
@@ -1100,7 +1100,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#214"
+"@value": "amf://id#228"
 }
 ],
 "sourcemaps:value": [
@@ -1114,36 +1114,36 @@
 ]
 },
 {
-"@id": "#218",
+"@id": "#232",
 "@type": [
-"raml-http:EndPoint",
+"apiContract:EndPoint",
 "doc:DomainElement"
 ],
-"raml-http:path": [
+"apiContract:path": [
 {
 "@value": "/files/{fileId}/touch"
 }
 ],
-"hydra:supportedOperation": [
+"apiContract:supportedOperation": [
 {
-"@id": "#219",
+"@id": "#233",
 "@type": [
-"hydra:Operation",
+"apiContract:Operation",
 "doc:DomainElement"
 ],
-"hydra:method": [
+"apiContract:method": [
 {
 "@value": "post"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "Set the file's updated time to the current server time."
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#219/source-map",
+"@id": "#233/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -1151,7 +1151,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -1163,7 +1163,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#219"
+"@value": "amf://id#233"
 }
 ],
 "sourcemaps:value": [
@@ -1177,36 +1177,36 @@
 ]
 }
 ],
-"raml-http:parameter": [
+"apiContract:parameter": [
 {
-"@id": "#220",
+"@id": "#234",
 "@type": [
-"raml-http:Parameter",
+"apiContract:Parameter",
 "doc:DomainElement"
 ],
-"schema-org:name": [
+"core:name": [
 {
 "@value": "fileId"
 }
 ],
-"raml-http:paramName": [
+"apiContract:paramName": [
 {
 "@value": "fileId"
 }
 ],
-"hydra:required": [
+"apiContract:required": [
 {
 "@value": true
 }
 ],
-"raml-http:binding": [
+"apiContract:binding": [
 {
 "@value": "path"
 }
 ],
-"raml-http:schema": [
+"apiContract:schema": [
 {
-"@id": "#221",
+"@id": "#235",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -1227,7 +1227,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#220/source-map",
+"@id": "#234/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -1235,7 +1235,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#220"
+"@value": "amf://id#234"
 }
 ],
 "sourcemaps:value": [
@@ -1251,7 +1251,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#218/source-map",
+"@id": "#232/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -1259,7 +1259,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#218"
+"@value": "amf://id#232"
 }
 ],
 "sourcemaps:value": [
@@ -1273,7 +1273,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#218"
+"@value": "amf://id#232"
 }
 ],
 "sourcemaps:value": [
@@ -1287,36 +1287,36 @@
 ]
 },
 {
-"@id": "#222",
+"@id": "#236",
 "@type": [
-"raml-http:EndPoint",
+"apiContract:EndPoint",
 "doc:DomainElement"
 ],
-"raml-http:path": [
+"apiContract:path": [
 {
 "@value": "/files/{fileId}/trash"
 }
 ],
-"hydra:supportedOperation": [
+"apiContract:supportedOperation": [
 {
-"@id": "#223",
+"@id": "#237",
 "@type": [
-"hydra:Operation",
+"apiContract:Operation",
 "doc:DomainElement"
 ],
-"hydra:method": [
+"apiContract:method": [
 {
 "@value": "post"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "Moves a file to the trash. The currently authenticated user must own the file."
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#223/source-map",
+"@id": "#237/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -1324,7 +1324,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -1336,7 +1336,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#223"
+"@value": "amf://id#237"
 }
 ],
 "sourcemaps:value": [
@@ -1350,655 +1350,34 @@
 ]
 }
 ],
-"raml-http:parameter": [
-{
-"@id": "#224",
-"@type": [
-"raml-http:Parameter",
-"doc:DomainElement"
-],
-"schema-org:name": [
-{
-"@value": "fileId"
-}
-],
-"raml-http:paramName": [
-{
-"@value": "fileId"
-}
-],
-"hydra:required": [
-{
-"@value": true
-}
-],
-"raml-http:binding": [
-{
-"@value": "path"
-}
-],
-"raml-http:schema": [
-{
-"@id": "#225",
-"@type": [
-"raml-shapes:ScalarShape",
-"shacl:Shape",
-"raml-shapes:Shape",
-"doc:DomainElement"
-],
-"shacl:datatype": [
-{
-"@id": "http://www.w3.org/2001/XMLSchema#string"
-}
-],
-"shacl:name": [
-{
-"@value": "fileId"
-}
-]
-}
-],
-"sourcemaps:sources": [
-{
-"@id": "#224/source-map",
-"@type": [
-"sourcemaps:SourceMap"
-],
-"sourcemaps:synthesized-field": [
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#224"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "true"
-}
-]
-}
-]
-}
-]
-}
-],
-"sourcemaps:sources": [
-{
-"@id": "#222/source-map",
-"@type": [
-"sourcemaps:SourceMap"
-],
-"sourcemaps:parent-end-point": [
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#222"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "file://test/demo-api/demo-api.raml#/web-api/end-points/%2Ffiles%2F%7BfileId%7D"
-}
-]
-}
-],
-"sourcemaps:lexical": [
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#222"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(140,4)-(143,0)]"
-}
-]
-}
-]
-}
-]
-},
-{
-"@id": "#226",
-"@type": [
-"raml-http:EndPoint",
-"doc:DomainElement"
-],
-"raml-http:path": [
-{
-"@value": "/files/{fileId}/untrash"
-}
-],
-"hydra:supportedOperation": [
-{
-"@id": "#227",
-"@type": [
-"hydra:Operation",
-"doc:DomainElement"
-],
-"hydra:method": [
-{
-"@value": "post"
-}
-],
-"schema-org:description": [
-{
-"@value": "Restores a file from the trash."
-}
-],
-"sourcemaps:sources": [
-{
-"@id": "#227/source-map",
-"@type": [
-"sourcemaps:SourceMap"
-],
-"sourcemaps:lexical": [
-{
-"sourcemaps:element": [
-{
-"@value": "schema-org:description"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(145,8)-(146,0)]"
-}
-]
-},
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#227"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(144,6)-(146,0)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"raml-http:parameter": [
-{
-"@id": "#228",
-"@type": [
-"raml-http:Parameter",
-"doc:DomainElement"
-],
-"schema-org:name": [
-{
-"@value": "fileId"
-}
-],
-"raml-http:paramName": [
-{
-"@value": "fileId"
-}
-],
-"hydra:required": [
-{
-"@value": true
-}
-],
-"raml-http:binding": [
-{
-"@value": "path"
-}
-],
-"raml-http:schema": [
-{
-"@id": "#229",
-"@type": [
-"raml-shapes:ScalarShape",
-"shacl:Shape",
-"raml-shapes:Shape",
-"doc:DomainElement"
-],
-"shacl:datatype": [
-{
-"@id": "http://www.w3.org/2001/XMLSchema#string"
-}
-],
-"shacl:name": [
-{
-"@value": "fileId"
-}
-]
-}
-],
-"sourcemaps:sources": [
-{
-"@id": "#228/source-map",
-"@type": [
-"sourcemaps:SourceMap"
-],
-"sourcemaps:synthesized-field": [
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#228"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "true"
-}
-]
-}
-]
-}
-]
-}
-],
-"sourcemaps:sources": [
-{
-"@id": "#226/source-map",
-"@type": [
-"sourcemaps:SourceMap"
-],
-"sourcemaps:parent-end-point": [
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#226"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "file://test/demo-api/demo-api.raml#/web-api/end-points/%2Ffiles%2F%7BfileId%7D"
-}
-]
-}
-],
-"sourcemaps:lexical": [
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#226"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(143,4)-(146,0)]"
-}
-]
-}
-]
-}
-]
-},
-{
-"@id": "#230",
-"@type": [
-"raml-http:EndPoint",
-"doc:DomainElement"
-],
-"raml-http:path": [
-{
-"@value": "/files/{fileId}/parents"
-}
-],
-"hydra:supportedOperation": [
-{
-"@id": "#231",
-"@type": [
-"hydra:Operation",
-"doc:DomainElement"
-],
-"hydra:method": [
-{
-"@value": "get"
-}
-],
-"schema-org:description": [
-{
-"@value": "Lists a file's parents."
-}
-],
-"sourcemaps:sources": [
-{
-"@id": "#231/source-map",
-"@type": [
-"sourcemaps:SourceMap"
-],
-"sourcemaps:lexical": [
-{
-"sourcemaps:element": [
-{
-"@value": "schema-org:description"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(148,8)-(149,0)]"
-}
-]
-},
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#231"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(147,6)-(149,0)]"
-}
-]
-}
-]
-}
-]
-},
-{
-"@id": "#232",
-"@type": [
-"hydra:Operation",
-"doc:DomainElement"
-],
-"hydra:method": [
-{
-"@value": "post"
-}
-],
-"schema-org:description": [
-{
-"@value": "Adds a parent folder for a file."
-}
-],
-"sourcemaps:sources": [
-{
-"@id": "#232/source-map",
-"@type": [
-"sourcemaps:SourceMap"
-],
-"sourcemaps:lexical": [
-{
-"sourcemaps:element": [
-{
-"@value": "schema-org:description"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(150,8)-(151,0)]"
-}
-]
-},
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#232"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(149,6)-(151,0)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"raml-http:parameter": [
-{
-"@id": "#233",
-"@type": [
-"raml-http:Parameter",
-"doc:DomainElement"
-],
-"schema-org:name": [
-{
-"@value": "fileId"
-}
-],
-"raml-http:paramName": [
-{
-"@value": "fileId"
-}
-],
-"hydra:required": [
-{
-"@value": true
-}
-],
-"raml-http:binding": [
-{
-"@value": "path"
-}
-],
-"raml-http:schema": [
-{
-"@id": "#234",
-"@type": [
-"raml-shapes:ScalarShape",
-"shacl:Shape",
-"raml-shapes:Shape",
-"doc:DomainElement"
-],
-"shacl:datatype": [
-{
-"@id": "http://www.w3.org/2001/XMLSchema#string"
-}
-],
-"shacl:name": [
-{
-"@value": "fileId"
-}
-]
-}
-],
-"sourcemaps:sources": [
-{
-"@id": "#233/source-map",
-"@type": [
-"sourcemaps:SourceMap"
-],
-"sourcemaps:synthesized-field": [
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#233"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "true"
-}
-]
-}
-]
-}
-]
-}
-],
-"sourcemaps:sources": [
-{
-"@id": "#230/source-map",
-"@type": [
-"sourcemaps:SourceMap"
-],
-"sourcemaps:parent-end-point": [
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#230"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "file://test/demo-api/demo-api.raml#/web-api/end-points/%2Ffiles%2F%7BfileId%7D"
-}
-]
-}
-],
-"sourcemaps:lexical": [
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#230"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(146,4)-(160,0)]"
-}
-]
-}
-]
-}
-]
-},
-{
-"@id": "#235",
-"@type": [
-"raml-http:EndPoint",
-"doc:DomainElement"
-],
-"raml-http:path": [
-{
-"@value": "/files/{fileId}/parents/{parentId}"
-}
-],
-"hydra:supportedOperation": [
-{
-"@id": "#236",
-"@type": [
-"hydra:Operation",
-"doc:DomainElement"
-],
-"hydra:method": [
-{
-"@value": "get"
-}
-],
-"schema-org:description": [
-{
-"@value": "Gets a specific parent reference."
-}
-],
-"sourcemaps:sources": [
-{
-"@id": "#236/source-map",
-"@type": [
-"sourcemaps:SourceMap"
-],
-"sourcemaps:lexical": [
-{
-"sourcemaps:element": [
-{
-"@value": "schema-org:description"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(157,10)-(158,0)]"
-}
-]
-},
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#236"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(156,8)-(158,0)]"
-}
-]
-}
-]
-}
-]
-},
-{
-"@id": "#237",
-"@type": [
-"hydra:Operation",
-"doc:DomainElement"
-],
-"hydra:method": [
-{
-"@value": "delete"
-}
-],
-"schema-org:description": [
-{
-"@value": "Removes a parent from a file."
-}
-],
-"sourcemaps:sources": [
-{
-"@id": "#237/source-map",
-"@type": [
-"sourcemaps:SourceMap"
-],
-"sourcemaps:lexical": [
-{
-"sourcemaps:element": [
-{
-"@value": "schema-org:description"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(159,10)-(160,0)]"
-}
-]
-},
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#237"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(158,8)-(160,0)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"raml-http:parameter": [
+"apiContract:parameter": [
 {
 "@id": "#238",
 "@type": [
-"raml-http:Parameter",
+"apiContract:Parameter",
 "doc:DomainElement"
 ],
-"schema-org:name": [
+"core:name": [
 {
 "@value": "fileId"
 }
 ],
-"raml-http:paramName": [
+"apiContract:paramName": [
 {
 "@value": "fileId"
 }
 ],
-"hydra:required": [
+"apiContract:required": [
 {
 "@value": true
 }
 ],
-"raml-http:binding": [
+"apiContract:binding": [
 {
 "@value": "path"
 }
 ],
-"raml-http:schema": [
+"apiContract:schema": [
 {
 "@id": "#239",
 "@type": [
@@ -2041,41 +1420,662 @@
 ]
 }
 ]
+}
+],
+"sourcemaps:sources": [
+{
+"@id": "#236/source-map",
+"@type": [
+"sourcemaps:SourceMap"
+],
+"sourcemaps:parent-end-point": [
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#236"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "file://test/demo-api/demo-api.raml#/web-api/end-points/%2Ffiles%2F%7BfileId%7D"
+}
+]
+}
+],
+"sourcemaps:lexical": [
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#236"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(140,4)-(143,0)]"
+}
+]
+}
+]
+}
+]
 },
 {
 "@id": "#240",
 "@type": [
-"raml-http:Parameter",
+"apiContract:EndPoint",
 "doc:DomainElement"
 ],
-"schema-org:name": [
+"apiContract:path": [
 {
-"@value": "parentId"
+"@value": "/files/{fileId}/untrash"
 }
 ],
-"raml-http:paramName": [
+"apiContract:supportedOperation": [
 {
-"@value": "parentId"
+"@id": "#241",
+"@type": [
+"apiContract:Operation",
+"doc:DomainElement"
+],
+"apiContract:method": [
+{
+"@value": "post"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
-"@value": "The ID of the parent."
+"@value": "Restores a file from the trash."
 }
 ],
-"hydra:required": [
+"sourcemaps:sources": [
+{
+"@id": "#241/source-map",
+"@type": [
+"sourcemaps:SourceMap"
+],
+"sourcemaps:lexical": [
+{
+"sourcemaps:element": [
+{
+"@value": "core:description"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(145,8)-(146,0)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#241"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(144,6)-(146,0)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"apiContract:parameter": [
+{
+"@id": "#242",
+"@type": [
+"apiContract:Parameter",
+"doc:DomainElement"
+],
+"core:name": [
+{
+"@value": "fileId"
+}
+],
+"apiContract:paramName": [
+{
+"@value": "fileId"
+}
+],
+"apiContract:required": [
 {
 "@value": true
 }
 ],
-"raml-http:binding": [
+"apiContract:binding": [
 {
 "@value": "path"
 }
 ],
-"raml-http:schema": [
+"apiContract:schema": [
 {
-"@id": "#241",
+"@id": "#243",
+"@type": [
+"raml-shapes:ScalarShape",
+"shacl:Shape",
+"raml-shapes:Shape",
+"doc:DomainElement"
+],
+"shacl:datatype": [
+{
+"@id": "http://www.w3.org/2001/XMLSchema#string"
+}
+],
+"shacl:name": [
+{
+"@value": "fileId"
+}
+]
+}
+],
+"sourcemaps:sources": [
+{
+"@id": "#242/source-map",
+"@type": [
+"sourcemaps:SourceMap"
+],
+"sourcemaps:synthesized-field": [
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#242"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "true"
+}
+]
+}
+]
+}
+]
+}
+],
+"sourcemaps:sources": [
+{
+"@id": "#240/source-map",
+"@type": [
+"sourcemaps:SourceMap"
+],
+"sourcemaps:parent-end-point": [
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#240"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "file://test/demo-api/demo-api.raml#/web-api/end-points/%2Ffiles%2F%7BfileId%7D"
+}
+]
+}
+],
+"sourcemaps:lexical": [
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#240"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(143,4)-(146,0)]"
+}
+]
+}
+]
+}
+]
+},
+{
+"@id": "#244",
+"@type": [
+"apiContract:EndPoint",
+"doc:DomainElement"
+],
+"apiContract:path": [
+{
+"@value": "/files/{fileId}/parents"
+}
+],
+"apiContract:supportedOperation": [
+{
+"@id": "#245",
+"@type": [
+"apiContract:Operation",
+"doc:DomainElement"
+],
+"apiContract:method": [
+{
+"@value": "get"
+}
+],
+"core:description": [
+{
+"@value": "Lists a file's parents."
+}
+],
+"sourcemaps:sources": [
+{
+"@id": "#245/source-map",
+"@type": [
+"sourcemaps:SourceMap"
+],
+"sourcemaps:lexical": [
+{
+"sourcemaps:element": [
+{
+"@value": "core:description"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(148,8)-(149,0)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#245"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(147,6)-(149,0)]"
+}
+]
+}
+]
+}
+]
+},
+{
+"@id": "#246",
+"@type": [
+"apiContract:Operation",
+"doc:DomainElement"
+],
+"apiContract:method": [
+{
+"@value": "post"
+}
+],
+"core:description": [
+{
+"@value": "Adds a parent folder for a file."
+}
+],
+"sourcemaps:sources": [
+{
+"@id": "#246/source-map",
+"@type": [
+"sourcemaps:SourceMap"
+],
+"sourcemaps:lexical": [
+{
+"sourcemaps:element": [
+{
+"@value": "core:description"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(150,8)-(151,0)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#246"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(149,6)-(151,0)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"apiContract:parameter": [
+{
+"@id": "#247",
+"@type": [
+"apiContract:Parameter",
+"doc:DomainElement"
+],
+"core:name": [
+{
+"@value": "fileId"
+}
+],
+"apiContract:paramName": [
+{
+"@value": "fileId"
+}
+],
+"apiContract:required": [
+{
+"@value": true
+}
+],
+"apiContract:binding": [
+{
+"@value": "path"
+}
+],
+"apiContract:schema": [
+{
+"@id": "#248",
+"@type": [
+"raml-shapes:ScalarShape",
+"shacl:Shape",
+"raml-shapes:Shape",
+"doc:DomainElement"
+],
+"shacl:datatype": [
+{
+"@id": "http://www.w3.org/2001/XMLSchema#string"
+}
+],
+"shacl:name": [
+{
+"@value": "fileId"
+}
+]
+}
+],
+"sourcemaps:sources": [
+{
+"@id": "#247/source-map",
+"@type": [
+"sourcemaps:SourceMap"
+],
+"sourcemaps:synthesized-field": [
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#247"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "true"
+}
+]
+}
+]
+}
+]
+}
+],
+"sourcemaps:sources": [
+{
+"@id": "#244/source-map",
+"@type": [
+"sourcemaps:SourceMap"
+],
+"sourcemaps:parent-end-point": [
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#244"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "file://test/demo-api/demo-api.raml#/web-api/end-points/%2Ffiles%2F%7BfileId%7D"
+}
+]
+}
+],
+"sourcemaps:lexical": [
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#244"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(146,4)-(160,0)]"
+}
+]
+}
+]
+}
+]
+},
+{
+"@id": "#249",
+"@type": [
+"apiContract:EndPoint",
+"doc:DomainElement"
+],
+"apiContract:path": [
+{
+"@value": "/files/{fileId}/parents/{parentId}"
+}
+],
+"apiContract:supportedOperation": [
+{
+"@id": "#250",
+"@type": [
+"apiContract:Operation",
+"doc:DomainElement"
+],
+"apiContract:method": [
+{
+"@value": "get"
+}
+],
+"core:description": [
+{
+"@value": "Gets a specific parent reference."
+}
+],
+"sourcemaps:sources": [
+{
+"@id": "#250/source-map",
+"@type": [
+"sourcemaps:SourceMap"
+],
+"sourcemaps:lexical": [
+{
+"sourcemaps:element": [
+{
+"@value": "core:description"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(157,10)-(158,0)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#250"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(156,8)-(158,0)]"
+}
+]
+}
+]
+}
+]
+},
+{
+"@id": "#251",
+"@type": [
+"apiContract:Operation",
+"doc:DomainElement"
+],
+"apiContract:method": [
+{
+"@value": "delete"
+}
+],
+"core:description": [
+{
+"@value": "Removes a parent from a file."
+}
+],
+"sourcemaps:sources": [
+{
+"@id": "#251/source-map",
+"@type": [
+"sourcemaps:SourceMap"
+],
+"sourcemaps:lexical": [
+{
+"sourcemaps:element": [
+{
+"@value": "core:description"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(159,10)-(160,0)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#251"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(158,8)-(160,0)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"apiContract:parameter": [
+{
+"@id": "#252",
+"@type": [
+"apiContract:Parameter",
+"doc:DomainElement"
+],
+"core:name": [
+{
+"@value": "fileId"
+}
+],
+"apiContract:paramName": [
+{
+"@value": "fileId"
+}
+],
+"apiContract:required": [
+{
+"@value": true
+}
+],
+"apiContract:binding": [
+{
+"@value": "path"
+}
+],
+"apiContract:schema": [
+{
+"@id": "#253",
+"@type": [
+"raml-shapes:ScalarShape",
+"shacl:Shape",
+"raml-shapes:Shape",
+"doc:DomainElement"
+],
+"shacl:datatype": [
+{
+"@id": "http://www.w3.org/2001/XMLSchema#string"
+}
+],
+"shacl:name": [
+{
+"@value": "fileId"
+}
+]
+}
+],
+"sourcemaps:sources": [
+{
+"@id": "#252/source-map",
+"@type": [
+"sourcemaps:SourceMap"
+],
+"sourcemaps:synthesized-field": [
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#252"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "true"
+}
+]
+}
+]
+}
+]
+},
+{
+"@id": "#254",
+"@type": [
+"apiContract:Parameter",
+"doc:DomainElement"
+],
+"core:name": [
+{
+"@value": "parentId"
+}
+],
+"apiContract:paramName": [
+{
+"@value": "parentId"
+}
+],
+"core:description": [
+{
+"@value": "The ID of the parent."
+}
+],
+"apiContract:required": [
+{
+"@value": true
+}
+],
+"apiContract:binding": [
+{
+"@value": "path"
+}
+],
+"apiContract:schema": [
+{
+"@id": "#255",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -2092,14 +2092,14 @@
 "@value": "schema"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "The ID of the parent."
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#241/source-map",
+"@id": "#255/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -2107,7 +2107,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#241"
+"@value": "amf://id#255"
 }
 ],
 "sourcemaps:value": [
@@ -2121,7 +2121,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -2133,7 +2133,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#241"
+"@value": "amf://id#255"
 }
 ],
 "sourcemaps:value": [
@@ -2161,7 +2161,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#240/source-map",
+"@id": "#254/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -2169,7 +2169,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -2181,7 +2181,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#240"
+"@value": "amf://id#254"
 }
 ],
 "sourcemaps:value": [
@@ -2197,7 +2197,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#235/source-map",
+"@id": "#249/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -2205,7 +2205,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#235"
+"@value": "amf://id#249"
 }
 ],
 "sourcemaps:value": [
@@ -2219,7 +2219,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "raml-http:parameter"
+"@value": "apiContract:parameter"
 }
 ],
 "sourcemaps:value": [
@@ -2231,7 +2231,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#235"
+"@value": "amf://id#249"
 }
 ],
 "sourcemaps:value": [
@@ -2245,36 +2245,36 @@
 ]
 },
 {
-"@id": "#242",
+"@id": "#256",
 "@type": [
-"raml-http:EndPoint",
+"apiContract:EndPoint",
 "doc:DomainElement"
 ],
-"raml-http:path": [
+"apiContract:path": [
 {
 "@value": "/files/{fileId}/permissions"
 }
 ],
-"hydra:supportedOperation": [
+"apiContract:supportedOperation": [
 {
-"@id": "#243",
+"@id": "#257",
 "@type": [
-"hydra:Operation",
+"apiContract:Operation",
 "doc:DomainElement"
 ],
-"hydra:method": [
+"apiContract:method": [
 {
 "@value": "get"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "Lists a file's permissions."
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#243/source-map",
+"@id": "#257/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -2282,7 +2282,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -2294,7 +2294,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#243"
+"@value": "amf://id#257"
 }
 ],
 "sourcemaps:value": [
@@ -2308,24 +2308,24 @@
 ]
 },
 {
-"@id": "#244",
+"@id": "#258",
 "@type": [
-"hydra:Operation",
+"apiContract:Operation",
 "doc:DomainElement"
 ],
-"hydra:method": [
+"apiContract:method": [
 {
 "@value": "post"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "Inserts a permission for a file.\n\nWarning: Concurrent permissions operations on the same file are not supported; only the last update is applied.\n"
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#244/source-map",
+"@id": "#258/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -2333,7 +2333,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -2345,7 +2345,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#244"
+"@value": "amf://id#258"
 }
 ],
 "sourcemaps:value": [
@@ -2359,734 +2359,34 @@
 ]
 }
 ],
-"raml-http:parameter": [
-{
-"@id": "#245",
-"@type": [
-"raml-http:Parameter",
-"doc:DomainElement"
-],
-"schema-org:name": [
-{
-"@value": "fileId"
-}
-],
-"raml-http:paramName": [
-{
-"@value": "fileId"
-}
-],
-"hydra:required": [
-{
-"@value": true
-}
-],
-"raml-http:binding": [
-{
-"@value": "path"
-}
-],
-"raml-http:schema": [
-{
-"@id": "#246",
-"@type": [
-"raml-shapes:ScalarShape",
-"shacl:Shape",
-"raml-shapes:Shape",
-"doc:DomainElement"
-],
-"shacl:datatype": [
-{
-"@id": "http://www.w3.org/2001/XMLSchema#string"
-}
-],
-"shacl:name": [
-{
-"@value": "fileId"
-}
-]
-}
-],
-"sourcemaps:sources": [
-{
-"@id": "#245/source-map",
-"@type": [
-"sourcemaps:SourceMap"
-],
-"sourcemaps:synthesized-field": [
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#245"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "true"
-}
-]
-}
-]
-}
-]
-}
-],
-"sourcemaps:sources": [
-{
-"@id": "#242/source-map",
-"@type": [
-"sourcemaps:SourceMap"
-],
-"sourcemaps:parent-end-point": [
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#242"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "file://test/demo-api/demo-api.raml#/web-api/end-points/%2Ffiles%2F%7BfileId%7D"
-}
-]
-}
-],
-"sourcemaps:lexical": [
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#242"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(160,4)-(192,0)]"
-}
-]
-}
-]
-}
-]
-},
-{
-"@id": "#247",
-"@type": [
-"raml-http:EndPoint",
-"doc:DomainElement"
-],
-"raml-http:path": [
-{
-"@value": "/files/{fileId}/permissions/{permissionId}"
-}
-],
-"hydra:supportedOperation": [
-{
-"@id": "#248",
-"@type": [
-"hydra:Operation",
-"doc:DomainElement"
-],
-"hydra:method": [
-{
-"@value": "get"
-}
-],
-"schema-org:description": [
-{
-"@value": "Gets a permission by ID."
-}
-],
-"sourcemaps:sources": [
-{
-"@id": "#248/source-map",
-"@type": [
-"sourcemaps:SourceMap"
-],
-"sourcemaps:lexical": [
-{
-"sourcemaps:element": [
-{
-"@value": "schema-org:description"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(174,10)-(175,0)]"
-}
-]
-},
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#248"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(173,8)-(175,0)]"
-}
-]
-}
-]
-}
-]
-},
-{
-"@id": "#249",
-"@type": [
-"hydra:Operation",
-"doc:DomainElement"
-],
-"hydra:method": [
-{
-"@value": "put"
-}
-],
-"schema-org:description": [
-{
-"@value": "Updates a permission.\n\n**Warning**: Concurrent permissions operations on the same file are not supported; only the last update is applied.\n"
-}
-],
-"sourcemaps:sources": [
-{
-"@id": "#249/source-map",
-"@type": [
-"sourcemaps:SourceMap"
-],
-"sourcemaps:lexical": [
-{
-"sourcemaps:element": [
-{
-"@value": "schema-org:description"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(176,10)-(180,0)]"
-}
-]
-},
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#249"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(175,8)-(180,0)]"
-}
-]
-}
-]
-}
-]
-},
-{
-"@id": "#250",
-"@type": [
-"hydra:Operation",
-"doc:DomainElement"
-],
-"hydra:method": [
-{
-"@value": "delete"
-}
-],
-"schema-org:description": [
-{
-"@value": "Deletes a permission from a file.\n\nWarning: Concurrent permissions operations on the same file are not supported; only the last update is applied.\n"
-}
-],
-"hydra:returns": [
-{
-"@id": "#251",
-"@type": [
-"raml-http:Response",
-"doc:DomainElement"
-],
-"schema-org:name": [
-{
-"@value": "204"
-}
-],
-"hydra:statusCode": [
-{
-"@value": "204"
-}
-],
-"raml-http:payload": [],
-"sourcemaps:sources": [
-{
-"@id": "#251/source-map",
-"@type": [
-"sourcemaps:SourceMap"
-],
-"sourcemaps:lexical": [
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#251"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(186,12)-(187,0)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"sourcemaps:sources": [
-{
-"@id": "#250/source-map",
-"@type": [
-"sourcemaps:SourceMap"
-],
-"sourcemaps:lexical": [
-{
-"sourcemaps:element": [
-{
-"@value": "hydra:returns"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(185,10)-(187,0)]"
-}
-]
-},
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#250"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(180,8)-(187,0)]"
-}
-]
-},
-{
-"sourcemaps:element": [
-{
-"@value": "schema-org:description"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(181,10)-(185,0)]"
-}
-]
-}
-]
-}
-]
-},
-{
-"@id": "#252",
-"@type": [
-"hydra:Operation",
-"doc:DomainElement"
-],
-"hydra:method": [
-{
-"@value": "patch"
-}
-],
-"schema-org:description": [
-{
-"@value": "Updates a permission. This method supports patch semantics.\n\n**Warning**: Concurrent permissions operations on the same file are not supported; only the last update is applied.\n"
-}
-],
-"sourcemaps:sources": [
-{
-"@id": "#252/source-map",
-"@type": [
-"sourcemaps:SourceMap"
-],
-"sourcemaps:lexical": [
-{
-"sourcemaps:element": [
-{
-"@value": "schema-org:description"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(188,10)-(192,0)]"
-}
-]
-},
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#252"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(187,8)-(192,0)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"raml-http:parameter": [
-{
-"@id": "#253",
-"@type": [
-"raml-http:Parameter",
-"doc:DomainElement"
-],
-"schema-org:name": [
-{
-"@value": "fileId"
-}
-],
-"raml-http:paramName": [
-{
-"@value": "fileId"
-}
-],
-"hydra:required": [
-{
-"@value": true
-}
-],
-"raml-http:binding": [
-{
-"@value": "path"
-}
-],
-"raml-http:schema": [
-{
-"@id": "#254",
-"@type": [
-"raml-shapes:ScalarShape",
-"shacl:Shape",
-"raml-shapes:Shape",
-"doc:DomainElement"
-],
-"shacl:datatype": [
-{
-"@id": "http://www.w3.org/2001/XMLSchema#string"
-}
-],
-"shacl:name": [
-{
-"@value": "fileId"
-}
-]
-}
-],
-"sourcemaps:sources": [
-{
-"@id": "#253/source-map",
-"@type": [
-"sourcemaps:SourceMap"
-],
-"sourcemaps:synthesized-field": [
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#253"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "true"
-}
-]
-}
-]
-}
-]
-},
-{
-"@id": "#255",
-"@type": [
-"raml-http:Parameter",
-"doc:DomainElement"
-],
-"schema-org:name": [
-{
-"@value": "permissionId"
-}
-],
-"raml-http:paramName": [
-{
-"@value": "permissionId"
-}
-],
-"schema-org:description": [
-{
-"@value": "The ID for the permission."
-}
-],
-"hydra:required": [
-{
-"@value": true
-}
-],
-"raml-http:binding": [
-{
-"@value": "path"
-}
-],
-"raml-http:schema": [
-{
-"@id": "#256",
-"@type": [
-"raml-shapes:ScalarShape",
-"shacl:Shape",
-"raml-shapes:Shape",
-"doc:DomainElement"
-],
-"shacl:datatype": [
-{
-"@id": "http://www.w3.org/2001/XMLSchema#string"
-}
-],
-"shacl:name": [
-{
-"@value": "schema"
-}
-],
-"schema-org:description": [
-{
-"@value": "The ID for the permission."
-}
-],
-"sourcemaps:sources": [
-{
-"@id": "#256/source-map",
-"@type": [
-"sourcemaps:SourceMap"
-],
-"sourcemaps:type-property-lexical-info": [
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#256"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(171,12)-(171,16)]"
-}
-]
-}
-],
-"sourcemaps:lexical": [
-{
-"sourcemaps:element": [
-{
-"@value": "schema-org:description"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(172,12)-(173,0)]"
-}
-]
-},
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#256"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(170,10)-(173,0)]"
-}
-]
-},
-{
-"sourcemaps:element": [
-{
-"@value": "shacl:datatype"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(171,12)-(172,0)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"sourcemaps:sources": [
-{
-"@id": "#255/source-map",
-"@type": [
-"sourcemaps:SourceMap"
-],
-"sourcemaps:lexical": [
-{
-"sourcemaps:element": [
-{
-"@value": "schema-org:description"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(172,12)-(173,0)]"
-}
-]
-},
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#255"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(170,10)-(173,0)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"sourcemaps:sources": [
-{
-"@id": "#247/source-map",
-"@type": [
-"sourcemaps:SourceMap"
-],
-"sourcemaps:parent-end-point": [
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#247"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "file://test/demo-api/demo-api.raml#/web-api/end-points/%2Ffiles%2F%7BfileId%7D%2Fpermissions"
-}
-]
-}
-],
-"sourcemaps:lexical": [
-{
-"sourcemaps:element": [
-{
-"@value": "raml-http:parameter"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(169,22)-(173,0)]"
-}
-]
-},
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#247"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(168,6)-(192,0)]"
-}
-]
-}
-]
-}
-]
-},
-{
-"@id": "#257",
-"@type": [
-"raml-http:EndPoint",
-"doc:DomainElement"
-],
-"raml-http:path": [
-{
-"@value": "/files/{fileId}/revisions"
-}
-],
-"hydra:supportedOperation": [
-{
-"@id": "#258",
-"@type": [
-"hydra:Operation",
-"doc:DomainElement"
-],
-"hydra:method": [
-{
-"@value": "get"
-}
-],
-"sourcemaps:sources": [
-{
-"@id": "#258/source-map",
-"@type": [
-"sourcemaps:SourceMap"
-],
-"sourcemaps:lexical": [
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#258"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(193,6)-(194,0)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"raml-http:parameter": [
+"apiContract:parameter": [
 {
 "@id": "#259",
 "@type": [
-"raml-http:Parameter",
+"apiContract:Parameter",
 "doc:DomainElement"
 ],
-"schema-org:name": [
+"core:name": [
 {
 "@value": "fileId"
 }
 ],
-"raml-http:paramName": [
+"apiContract:paramName": [
 {
 "@value": "fileId"
 }
 ],
-"hydra:required": [
+"apiContract:required": [
 {
 "@value": true
 }
 ],
-"raml-http:binding": [
+"apiContract:binding": [
 {
 "@value": "path"
 }
 ],
-"raml-http:schema": [
+"apiContract:schema": [
 {
 "@id": "#260",
 "@type": [
@@ -3133,7 +2433,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#257/source-map",
+"@id": "#256/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -3141,7 +2441,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#257"
+"@value": "amf://id#256"
 }
 ],
 "sourcemaps:value": [
@@ -3155,12 +2455,12 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#257"
+"@value": "amf://id#256"
 }
 ],
 "sourcemaps:value": [
 {
-"@value": "[(192,4)-(208,0)]"
+"@value": "[(160,4)-(192,0)]"
 }
 ]
 }
@@ -3171,24 +2471,29 @@
 {
 "@id": "#261",
 "@type": [
-"raml-http:EndPoint",
+"apiContract:EndPoint",
 "doc:DomainElement"
 ],
-"raml-http:path": [
+"apiContract:path": [
 {
-"@value": "/files/{fileId}/revisions/{revisionId}"
+"@value": "/files/{fileId}/permissions/{permissionId}"
 }
 ],
-"hydra:supportedOperation": [
+"apiContract:supportedOperation": [
 {
 "@id": "#262",
 "@type": [
-"hydra:Operation",
+"apiContract:Operation",
 "doc:DomainElement"
 ],
-"hydra:method": [
+"apiContract:method": [
 {
 "@value": "get"
+}
+],
+"core:description": [
+{
+"@value": "Gets a permission by ID."
 }
 ],
 "sourcemaps:sources": [
@@ -3201,12 +2506,24 @@
 {
 "sourcemaps:element": [
 {
+"@value": "core:description"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(174,10)-(175,0)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
 "@value": "amf://id#262"
 }
 ],
 "sourcemaps:value": [
 {
-"@value": "[(200,8)-(202,0)]"
+"@value": "[(173,8)-(175,0)]"
 }
 ]
 }
@@ -3217,12 +2534,17 @@
 {
 "@id": "#263",
 "@type": [
-"hydra:Operation",
+"apiContract:Operation",
 "doc:DomainElement"
 ],
-"hydra:method": [
+"apiContract:method": [
 {
 "@value": "put"
+}
+],
+"core:description": [
+{
+"@value": "Updates a permission.\n\n**Warning**: Concurrent permissions operations on the same file are not supported; only the last update is applied.\n"
 }
 ],
 "sourcemaps:sources": [
@@ -3235,12 +2557,24 @@
 {
 "sourcemaps:element": [
 {
+"@value": "core:description"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(176,10)-(180,0)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
 "@value": "amf://id#263"
 }
 ],
 "sourcemaps:value": [
 {
-"@value": "[(202,8)-(204,0)]"
+"@value": "[(175,8)-(180,0)]"
 }
 ]
 }
@@ -3251,48 +2585,37 @@
 {
 "@id": "#264",
 "@type": [
-"hydra:Operation",
+"apiContract:Operation",
 "doc:DomainElement"
 ],
-"hydra:method": [
+"apiContract:method": [
 {
 "@value": "delete"
 }
 ],
-"sourcemaps:sources": [
+"core:description": [
 {
-"@id": "#264/source-map",
-"@type": [
-"sourcemaps:SourceMap"
-],
-"sourcemaps:lexical": [
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#264"
+"@value": "Deletes a permission from a file.\n\nWarning: Concurrent permissions operations on the same file are not supported; only the last update is applied.\n"
 }
 ],
-"sourcemaps:value": [
-{
-"@value": "[(204,8)-(206,0)]"
-}
-]
-}
-]
-}
-]
-},
+"apiContract:returns": [
 {
 "@id": "#265",
 "@type": [
-"hydra:Operation",
+"apiContract:Response",
 "doc:DomainElement"
 ],
-"hydra:method": [
+"core:name": [
 {
-"@value": "patch"
+"@value": "204"
 }
 ],
+"apiContract:statusCode": [
+{
+"@value": "204"
+}
+],
+"apiContract:payload": [],
 "sourcemaps:sources": [
 {
 "@id": "#265/source-map",
@@ -3308,7 +2631,7 @@
 ],
 "sourcemaps:value": [
 {
-"@value": "[(206,8)-(208,0)]"
+"@value": "[(186,12)-(187,0)]"
 }
 ]
 }
@@ -3317,36 +2640,135 @@
 ]
 }
 ],
-"raml-http:parameter": [
+"sourcemaps:sources": [
+{
+"@id": "#264/source-map",
+"@type": [
+"sourcemaps:SourceMap"
+],
+"sourcemaps:lexical": [
+{
+"sourcemaps:element": [
+{
+"@value": "apiContract:returns"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(185,10)-(187,0)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#264"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(180,8)-(187,0)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "core:description"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(181,10)-(185,0)]"
+}
+]
+}
+]
+}
+]
+},
 {
 "@id": "#266",
 "@type": [
-"raml-http:Parameter",
+"apiContract:Operation",
 "doc:DomainElement"
 ],
-"schema-org:name": [
+"apiContract:method": [
+{
+"@value": "patch"
+}
+],
+"core:description": [
+{
+"@value": "Updates a permission. This method supports patch semantics.\n\n**Warning**: Concurrent permissions operations on the same file are not supported; only the last update is applied.\n"
+}
+],
+"sourcemaps:sources": [
+{
+"@id": "#266/source-map",
+"@type": [
+"sourcemaps:SourceMap"
+],
+"sourcemaps:lexical": [
+{
+"sourcemaps:element": [
+{
+"@value": "core:description"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(188,10)-(192,0)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#266"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(187,8)-(192,0)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"apiContract:parameter": [
+{
+"@id": "#267",
+"@type": [
+"apiContract:Parameter",
+"doc:DomainElement"
+],
+"core:name": [
 {
 "@value": "fileId"
 }
 ],
-"raml-http:paramName": [
+"apiContract:paramName": [
 {
 "@value": "fileId"
 }
 ],
-"hydra:required": [
+"apiContract:required": [
 {
 "@value": true
 }
 ],
-"raml-http:binding": [
+"apiContract:binding": [
 {
 "@value": "path"
 }
 ],
-"raml-http:schema": [
+"apiContract:schema": [
 {
-"@id": "#267",
+"@id": "#268",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -3367,7 +2789,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#266/source-map",
+"@id": "#267/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -3375,7 +2797,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#266"
+"@value": "amf://id#267"
 }
 ],
 "sourcemaps:value": [
@@ -3389,39 +2811,39 @@
 ]
 },
 {
-"@id": "#268",
+"@id": "#269",
 "@type": [
-"raml-http:Parameter",
+"apiContract:Parameter",
 "doc:DomainElement"
 ],
-"schema-org:name": [
+"core:name": [
 {
-"@value": "revisionId"
+"@value": "permissionId"
 }
 ],
-"raml-http:paramName": [
+"apiContract:paramName": [
 {
-"@value": "revisionId"
+"@value": "permissionId"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
-"@value": "The ID of the revision."
+"@value": "The ID for the permission."
 }
 ],
-"hydra:required": [
+"apiContract:required": [
 {
 "@value": true
 }
 ],
-"raml-http:binding": [
+"apiContract:binding": [
 {
 "@value": "path"
 }
 ],
-"raml-http:schema": [
+"apiContract:schema": [
 {
-"@id": "#269",
+"@id": "#270",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -3438,21 +2860,9 @@
 "@value": "schema"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
-"@value": "The ID of the revision."
-}
-],
-"shacl:defaultValue": [
-{
-"@id": "#270",
-"@type": [
-"data:Scalar"
-],
-"data:value": [
-{
-"@value": "defaultRevision",
-"@type": "xsd:string"
+"@value": "The ID for the permission."
 }
 ],
 "sourcemaps:sources": [
@@ -3461,7 +2871,7 @@
 "@type": [
 "sourcemaps:SourceMap"
 ],
-"sourcemaps:lexical": [
+"sourcemaps:type-property-lexical-info": [
 {
 "sourcemaps:element": [
 {
@@ -3470,36 +2880,7 @@
 ],
 "sourcemaps:value": [
 {
-"@value": "[(199,21)-(199,36)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"shacl:defaultValueStr": [
-{
-"@value": "defaultRevision"
-}
-],
-"sourcemaps:sources": [
-{
-"@id": "#269/source-map",
-"@type": [
-"sourcemaps:SourceMap"
-],
-"sourcemaps:type-property-lexical-info": [
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#269"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(197,12)-(197,16)]"
+"@value": "[(171,12)-(171,16)]"
 }
 ]
 }
@@ -3508,12 +2889,24 @@
 {
 "sourcemaps:element": [
 {
-"@value": "shacl:defaultValueStr"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
 {
-"@value": "[(199,12)-(200,0)]"
+"@value": "[(172,12)-(173,0)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#270"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(170,10)-(173,0)]"
 }
 ]
 },
@@ -3525,7 +2918,31 @@
 ],
 "sourcemaps:value": [
 {
-"@value": "[(197,12)-(198,0)]"
+"@value": "[(171,12)-(172,0)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"sourcemaps:sources": [
+{
+"@id": "#269/source-map",
+"@type": [
+"sourcemaps:SourceMap"
+],
+"sourcemaps:lexical": [
+{
+"sourcemaps:element": [
+{
+"@value": "core:description"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(172,12)-(173,0)]"
 }
 ]
 },
@@ -3537,55 +2954,7 @@
 ],
 "sourcemaps:value": [
 {
-"@value": "[(196,10)-(200,0)]"
-}
-]
-},
-{
-"sourcemaps:element": [
-{
-"@value": "schema-org:description"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(198,12)-(199,0)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"sourcemaps:sources": [
-{
-"@id": "#268/source-map",
-"@type": [
-"sourcemaps:SourceMap"
-],
-"sourcemaps:lexical": [
-{
-"sourcemaps:element": [
-{
-"@value": "schema-org:description"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(198,12)-(199,0)]"
-}
-]
-},
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#268"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(196,10)-(200,0)]"
+"@value": "[(170,10)-(173,0)]"
 }
 ]
 }
@@ -3609,7 +2978,7 @@
 ],
 "sourcemaps:value": [
 {
-"@value": "file://test/demo-api/demo-api.raml#/web-api/end-points/%2Ffiles%2F%7BfileId%7D%2Frevisions"
+"@value": "file://test/demo-api/demo-api.raml#/web-api/end-points/%2Ffiles%2F%7BfileId%7D%2Fpermissions"
 }
 ]
 }
@@ -3618,12 +2987,12 @@
 {
 "sourcemaps:element": [
 {
-"@value": "raml-http:parameter"
+"@value": "apiContract:parameter"
 }
 ],
 "sourcemaps:value": [
 {
-"@value": "[(195,22)-(200,0)]"
+"@value": "[(169,22)-(173,0)]"
 }
 ]
 },
@@ -3635,7 +3004,7 @@
 ],
 "sourcemaps:value": [
 {
-"@value": "[(194,6)-(208,0)]"
+"@value": "[(168,6)-(192,0)]"
 }
 ]
 }
@@ -3646,22 +3015,22 @@
 {
 "@id": "#271",
 "@type": [
-"raml-http:EndPoint",
+"apiContract:EndPoint",
 "doc:DomainElement"
 ],
-"raml-http:path": [
+"apiContract:path": [
 {
-"@value": "/files/{fileId}/comments"
+"@value": "/files/{fileId}/revisions"
 }
 ],
-"hydra:supportedOperation": [
+"apiContract:supportedOperation": [
 {
 "@id": "#272",
 "@type": [
-"hydra:Operation",
+"apiContract:Operation",
 "doc:DomainElement"
 ],
-"hydra:method": [
+"apiContract:method": [
 {
 "@value": "get"
 }
@@ -3681,96 +3050,45 @@
 ],
 "sourcemaps:value": [
 {
-"@value": "[(209,6)-(211,0)]"
+"@value": "[(193,6)-(194,0)]"
 }
 ]
 }
 ]
 }
 ]
-},
+}
+],
+"apiContract:parameter": [
 {
 "@id": "#273",
 "@type": [
-"hydra:Operation",
+"apiContract:Parameter",
 "doc:DomainElement"
 ],
-"hydra:method": [
-{
-"@value": "post"
-}
-],
-"schema-org:description": [
-{
-"@value": "Creates a new comment on the given file."
-}
-],
-"sourcemaps:sources": [
-{
-"@id": "#273/source-map",
-"@type": [
-"sourcemaps:SourceMap"
-],
-"sourcemaps:lexical": [
-{
-"sourcemaps:element": [
-{
-"@value": "schema-org:description"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(212,8)-(213,0)]"
-}
-]
-},
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#273"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(211,6)-(213,0)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"raml-http:parameter": [
-{
-"@id": "#274",
-"@type": [
-"raml-http:Parameter",
-"doc:DomainElement"
-],
-"schema-org:name": [
+"core:name": [
 {
 "@value": "fileId"
 }
 ],
-"raml-http:paramName": [
+"apiContract:paramName": [
 {
 "@value": "fileId"
 }
 ],
-"hydra:required": [
+"apiContract:required": [
 {
 "@value": true
 }
 ],
-"raml-http:binding": [
+"apiContract:binding": [
 {
 "@value": "path"
 }
 ],
-"raml-http:schema": [
+"apiContract:schema": [
 {
-"@id": "#275",
+"@id": "#274",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -3791,7 +3109,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#274/source-map",
+"@id": "#273/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -3799,7 +3117,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#274"
+"@value": "amf://id#273"
 }
 ],
 "sourcemaps:value": [
@@ -3842,7 +3160,7 @@
 ],
 "sourcemaps:value": [
 {
-"@value": "[(208,4)-(250,0)]"
+"@value": "[(192,4)-(208,0)]"
 }
 ]
 }
@@ -3851,31 +3169,60 @@
 ]
 },
 {
-"@id": "#276",
+"@id": "#275",
 "@type": [
-"raml-http:EndPoint",
+"apiContract:EndPoint",
 "doc:DomainElement"
 ],
-"raml-http:path": [
+"apiContract:path": [
 {
-"@value": "/files/{fileId}/comments/{commentId}"
+"@value": "/files/{fileId}/revisions/{revisionId}"
 }
 ],
-"hydra:supportedOperation": [
+"apiContract:supportedOperation": [
 {
-"@id": "#277",
+"@id": "#276",
 "@type": [
-"hydra:Operation",
+"apiContract:Operation",
 "doc:DomainElement"
 ],
-"hydra:method": [
+"apiContract:method": [
 {
 "@value": "get"
 }
 ],
-"schema-org:description": [
+"sourcemaps:sources": [
 {
-"@value": "Gets a comment by ID."
+"@id": "#276/source-map",
+"@type": [
+"sourcemaps:SourceMap"
+],
+"sourcemaps:lexical": [
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#276"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(200,8)-(202,0)]"
+}
+]
+}
+]
+}
+]
+},
+{
+"@id": "#277",
+"@type": [
+"apiContract:Operation",
+"doc:DomainElement"
+],
+"apiContract:method": [
+{
+"@value": "put"
 }
 ],
 "sourcemaps:sources": [
@@ -3888,24 +3235,12 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(219,10)-(221,0)]"
-}
-]
-},
-{
-"sourcemaps:element": [
-{
 "@value": "amf://id#277"
 }
 ],
 "sourcemaps:value": [
 {
-"@value": "[(218,8)-(221,0)]"
+"@value": "[(202,8)-(204,0)]"
 }
 ]
 }
@@ -3916,12 +3251,12 @@
 {
 "@id": "#278",
 "@type": [
-"hydra:Operation",
+"apiContract:Operation",
 "doc:DomainElement"
 ],
-"hydra:method": [
+"apiContract:method": [
 {
-"@value": "put"
+"@value": "delete"
 }
 ],
 "sourcemaps:sources": [
@@ -3939,7 +3274,7 @@
 ],
 "sourcemaps:value": [
 {
-"@value": "[(221,8)-(223,0)]"
+"@value": "[(204,8)-(206,0)]"
 }
 ]
 }
@@ -3950,17 +3285,12 @@
 {
 "@id": "#279",
 "@type": [
-"hydra:Operation",
+"apiContract:Operation",
 "doc:DomainElement"
 ],
-"hydra:method": [
+"apiContract:method": [
 {
-"@value": "delete"
-}
-],
-"schema-org:description": [
-{
-"@value": "Deletes a comment."
+"@value": "patch"
 }
 ],
 "sourcemaps:sources": [
@@ -3973,7 +3303,679 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "amf://id#279"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(206,8)-(208,0)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"apiContract:parameter": [
+{
+"@id": "#280",
+"@type": [
+"apiContract:Parameter",
+"doc:DomainElement"
+],
+"core:name": [
+{
+"@value": "fileId"
+}
+],
+"apiContract:paramName": [
+{
+"@value": "fileId"
+}
+],
+"apiContract:required": [
+{
+"@value": true
+}
+],
+"apiContract:binding": [
+{
+"@value": "path"
+}
+],
+"apiContract:schema": [
+{
+"@id": "#281",
+"@type": [
+"raml-shapes:ScalarShape",
+"shacl:Shape",
+"raml-shapes:Shape",
+"doc:DomainElement"
+],
+"shacl:datatype": [
+{
+"@id": "http://www.w3.org/2001/XMLSchema#string"
+}
+],
+"shacl:name": [
+{
+"@value": "fileId"
+}
+]
+}
+],
+"sourcemaps:sources": [
+{
+"@id": "#280/source-map",
+"@type": [
+"sourcemaps:SourceMap"
+],
+"sourcemaps:synthesized-field": [
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#280"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "true"
+}
+]
+}
+]
+}
+]
+},
+{
+"@id": "#282",
+"@type": [
+"apiContract:Parameter",
+"doc:DomainElement"
+],
+"core:name": [
+{
+"@value": "revisionId"
+}
+],
+"apiContract:paramName": [
+{
+"@value": "revisionId"
+}
+],
+"core:description": [
+{
+"@value": "The ID of the revision."
+}
+],
+"apiContract:required": [
+{
+"@value": true
+}
+],
+"apiContract:binding": [
+{
+"@value": "path"
+}
+],
+"apiContract:schema": [
+{
+"@id": "#283",
+"@type": [
+"raml-shapes:ScalarShape",
+"shacl:Shape",
+"raml-shapes:Shape",
+"doc:DomainElement"
+],
+"shacl:datatype": [
+{
+"@id": "http://www.w3.org/2001/XMLSchema#string"
+}
+],
+"shacl:name": [
+{
+"@value": "schema"
+}
+],
+"core:description": [
+{
+"@value": "The ID of the revision."
+}
+],
+"shacl:defaultValue": [
+{
+"@id": "#284",
+"@type": [
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
+],
+"data:value": [
+{
+"@value": "defaultRevision",
+"@type": "xsd:string"
+}
+],
+"sourcemaps:sources": [
+{
+"@id": "#284/source-map",
+"@type": [
+"sourcemaps:SourceMap"
+],
+"sourcemaps:lexical": [
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#284"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(199,21)-(199,36)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"shacl:defaultValueStr": [
+{
+"@value": "defaultRevision"
+}
+],
+"sourcemaps:sources": [
+{
+"@id": "#283/source-map",
+"@type": [
+"sourcemaps:SourceMap"
+],
+"sourcemaps:type-property-lexical-info": [
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#283"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(197,12)-(197,16)]"
+}
+]
+}
+],
+"sourcemaps:lexical": [
+{
+"sourcemaps:element": [
+{
+"@value": "shacl:defaultValueStr"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(199,12)-(200,0)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "shacl:datatype"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(197,12)-(198,0)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#283"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(196,10)-(200,0)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "core:description"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(198,12)-(199,0)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"sourcemaps:sources": [
+{
+"@id": "#282/source-map",
+"@type": [
+"sourcemaps:SourceMap"
+],
+"sourcemaps:lexical": [
+{
+"sourcemaps:element": [
+{
+"@value": "core:description"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(198,12)-(199,0)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#282"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(196,10)-(200,0)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"sourcemaps:sources": [
+{
+"@id": "#275/source-map",
+"@type": [
+"sourcemaps:SourceMap"
+],
+"sourcemaps:parent-end-point": [
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#275"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "file://test/demo-api/demo-api.raml#/web-api/end-points/%2Ffiles%2F%7BfileId%7D%2Frevisions"
+}
+]
+}
+],
+"sourcemaps:lexical": [
+{
+"sourcemaps:element": [
+{
+"@value": "apiContract:parameter"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(195,22)-(200,0)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#275"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(194,6)-(208,0)]"
+}
+]
+}
+]
+}
+]
+},
+{
+"@id": "#285",
+"@type": [
+"apiContract:EndPoint",
+"doc:DomainElement"
+],
+"apiContract:path": [
+{
+"@value": "/files/{fileId}/comments"
+}
+],
+"apiContract:supportedOperation": [
+{
+"@id": "#286",
+"@type": [
+"apiContract:Operation",
+"doc:DomainElement"
+],
+"apiContract:method": [
+{
+"@value": "get"
+}
+],
+"sourcemaps:sources": [
+{
+"@id": "#286/source-map",
+"@type": [
+"sourcemaps:SourceMap"
+],
+"sourcemaps:lexical": [
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#286"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(209,6)-(211,0)]"
+}
+]
+}
+]
+}
+]
+},
+{
+"@id": "#287",
+"@type": [
+"apiContract:Operation",
+"doc:DomainElement"
+],
+"apiContract:method": [
+{
+"@value": "post"
+}
+],
+"core:description": [
+{
+"@value": "Creates a new comment on the given file."
+}
+],
+"sourcemaps:sources": [
+{
+"@id": "#287/source-map",
+"@type": [
+"sourcemaps:SourceMap"
+],
+"sourcemaps:lexical": [
+{
+"sourcemaps:element": [
+{
+"@value": "core:description"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(212,8)-(213,0)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#287"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(211,6)-(213,0)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"apiContract:parameter": [
+{
+"@id": "#288",
+"@type": [
+"apiContract:Parameter",
+"doc:DomainElement"
+],
+"core:name": [
+{
+"@value": "fileId"
+}
+],
+"apiContract:paramName": [
+{
+"@value": "fileId"
+}
+],
+"apiContract:required": [
+{
+"@value": true
+}
+],
+"apiContract:binding": [
+{
+"@value": "path"
+}
+],
+"apiContract:schema": [
+{
+"@id": "#289",
+"@type": [
+"raml-shapes:ScalarShape",
+"shacl:Shape",
+"raml-shapes:Shape",
+"doc:DomainElement"
+],
+"shacl:datatype": [
+{
+"@id": "http://www.w3.org/2001/XMLSchema#string"
+}
+],
+"shacl:name": [
+{
+"@value": "fileId"
+}
+]
+}
+],
+"sourcemaps:sources": [
+{
+"@id": "#288/source-map",
+"@type": [
+"sourcemaps:SourceMap"
+],
+"sourcemaps:synthesized-field": [
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#288"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "true"
+}
+]
+}
+]
+}
+]
+}
+],
+"sourcemaps:sources": [
+{
+"@id": "#285/source-map",
+"@type": [
+"sourcemaps:SourceMap"
+],
+"sourcemaps:parent-end-point": [
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#285"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "file://test/demo-api/demo-api.raml#/web-api/end-points/%2Ffiles%2F%7BfileId%7D"
+}
+]
+}
+],
+"sourcemaps:lexical": [
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#285"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(208,4)-(250,0)]"
+}
+]
+}
+]
+}
+]
+},
+{
+"@id": "#290",
+"@type": [
+"apiContract:EndPoint",
+"doc:DomainElement"
+],
+"apiContract:path": [
+{
+"@value": "/files/{fileId}/comments/{commentId}"
+}
+],
+"apiContract:supportedOperation": [
+{
+"@id": "#291",
+"@type": [
+"apiContract:Operation",
+"doc:DomainElement"
+],
+"apiContract:method": [
+{
+"@value": "get"
+}
+],
+"core:description": [
+{
+"@value": "Gets a comment by ID."
+}
+],
+"sourcemaps:sources": [
+{
+"@id": "#291/source-map",
+"@type": [
+"sourcemaps:SourceMap"
+],
+"sourcemaps:lexical": [
+{
+"sourcemaps:element": [
+{
+"@value": "core:description"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(219,10)-(221,0)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#291"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(218,8)-(221,0)]"
+}
+]
+}
+]
+}
+]
+},
+{
+"@id": "#292",
+"@type": [
+"apiContract:Operation",
+"doc:DomainElement"
+],
+"apiContract:method": [
+{
+"@value": "put"
+}
+],
+"sourcemaps:sources": [
+{
+"@id": "#292/source-map",
+"@type": [
+"sourcemaps:SourceMap"
+],
+"sourcemaps:lexical": [
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#292"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(221,8)-(223,0)]"
+}
+]
+}
+]
+}
+]
+},
+{
+"@id": "#293",
+"@type": [
+"apiContract:Operation",
+"doc:DomainElement"
+],
+"apiContract:method": [
+{
+"@value": "delete"
+}
+],
+"core:description": [
+{
+"@value": "Deletes a comment."
+}
+],
+"sourcemaps:sources": [
+{
+"@id": "#293/source-map",
+"@type": [
+"sourcemaps:SourceMap"
+],
+"sourcemaps:lexical": [
+{
+"sourcemaps:element": [
+{
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -3985,7 +3987,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#279"
+"@value": "amf://id#293"
 }
 ],
 "sourcemaps:value": [
@@ -3999,19 +4001,19 @@
 ]
 },
 {
-"@id": "#280",
+"@id": "#294",
 "@type": [
-"hydra:Operation",
+"apiContract:Operation",
 "doc:DomainElement"
 ],
-"hydra:method": [
+"apiContract:method": [
 {
 "@value": "patch"
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#280/source-map",
+"@id": "#294/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -4019,7 +4021,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#280"
+"@value": "amf://id#294"
 }
 ],
 "sourcemaps:value": [
@@ -4033,36 +4035,36 @@
 ]
 }
 ],
-"raml-http:parameter": [
+"apiContract:parameter": [
 {
-"@id": "#281",
+"@id": "#295",
 "@type": [
-"raml-http:Parameter",
+"apiContract:Parameter",
 "doc:DomainElement"
 ],
-"schema-org:name": [
+"core:name": [
 {
 "@value": "fileId"
 }
 ],
-"raml-http:paramName": [
+"apiContract:paramName": [
 {
 "@value": "fileId"
 }
 ],
-"hydra:required": [
+"apiContract:required": [
 {
 "@value": true
 }
 ],
-"raml-http:binding": [
+"apiContract:binding": [
 {
 "@value": "path"
 }
 ],
-"raml-http:schema": [
+"apiContract:schema": [
 {
-"@id": "#282",
+"@id": "#296",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -4083,7 +4085,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#281/source-map",
+"@id": "#295/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -4091,7 +4093,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#281"
+"@value": "amf://id#295"
 }
 ],
 "sourcemaps:value": [
@@ -4105,34 +4107,34 @@
 ]
 },
 {
-"@id": "#283",
+"@id": "#297",
 "@type": [
-"raml-http:Parameter",
+"apiContract:Parameter",
 "doc:DomainElement"
 ],
-"schema-org:name": [
+"core:name": [
 {
 "@value": "commentId"
 }
 ],
-"raml-http:paramName": [
+"apiContract:paramName": [
 {
 "@value": "commentId"
 }
 ],
-"hydra:required": [
+"apiContract:required": [
 {
 "@value": true
 }
 ],
-"raml-http:binding": [
+"apiContract:binding": [
 {
 "@value": "path"
 }
 ],
-"raml-http:schema": [
+"apiContract:schema": [
 {
-"@id": "#284",
+"@id": "#298",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -4149,11 +4151,18 @@
 "@value": "schema"
 }
 ],
-"doc:examples": [
+"apiContract:examples": [
 {
-"@id": "#285",
+"@id": "#299",
 "@type": [
-"doc:Example",
+"apiContract:NamedExamples",
+"doc:DomainElement"
+],
+"apiContract:examples": [
+{
+"@id": "#300",
+"@type": [
+"apiContract:Example",
 "doc:DomainElement"
 ],
 "doc:strict": [
@@ -4163,9 +4172,11 @@
 ],
 "doc:structuredValue": [
 {
-"@id": "#285",
+"@id": "#300",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -4175,7 +4186,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#285/source-map",
+"@id": "#300/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -4183,7 +4194,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#285"
+"@value": "amf://id#300"
 }
 ],
 "sourcemaps:value": [
@@ -4204,7 +4215,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#285/source-map",
+"@id": "#300/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -4238,7 +4249,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#285"
+"@value": "amf://id#300"
 }
 ],
 "sourcemaps:value": [
@@ -4252,12 +4263,14 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#285"
+"@value": "amf://id#300"
 }
 ],
 "sourcemaps:value": [
 {
-"@value": "amf://id#283"
+"@value": "amf://id#297"
+}
+]
 }
 ]
 }
@@ -4268,7 +4281,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#284/source-map",
+"@id": "#298/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -4276,7 +4289,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#284"
+"@value": "amf://id#298"
 }
 ],
 "sourcemaps:value": [
@@ -4302,7 +4315,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#284"
+"@value": "amf://id#298"
 }
 ],
 "sourcemaps:value": [
@@ -4318,7 +4331,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#283/source-map",
+"@id": "#297/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -4326,7 +4339,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#283"
+"@value": "amf://id#297"
 }
 ],
 "sourcemaps:value": [
@@ -4342,7 +4355,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#276/source-map",
+"@id": "#290/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -4350,7 +4363,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#276"
+"@value": "amf://id#290"
 }
 ],
 "sourcemaps:value": [
@@ -4364,7 +4377,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "raml-http:parameter"
+"@value": "apiContract:parameter"
 }
 ],
 "sourcemaps:value": [
@@ -4376,7 +4389,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#276"
+"@value": "amf://id#290"
 }
 ],
 "sourcemaps:value": [
@@ -4390,31 +4403,31 @@
 ]
 },
 {
-"@id": "#286",
+"@id": "#301",
 "@type": [
-"raml-http:EndPoint",
+"apiContract:EndPoint",
 "doc:DomainElement"
 ],
-"raml-http:path": [
+"apiContract:path": [
 {
 "@value": "/files/{fileId}/comments/{commentId}/replies"
 }
 ],
-"hydra:supportedOperation": [
+"apiContract:supportedOperation": [
 {
-"@id": "#287",
+"@id": "#302",
 "@type": [
-"hydra:Operation",
+"apiContract:Operation",
 "doc:DomainElement"
 ],
-"hydra:method": [
+"apiContract:method": [
 {
 "@value": "get"
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#287/source-map",
+"@id": "#302/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -4422,7 +4435,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#287"
+"@value": "amf://id#302"
 }
 ],
 "sourcemaps:value": [
@@ -4436,19 +4449,19 @@
 ]
 },
 {
-"@id": "#288",
+"@id": "#303",
 "@type": [
-"hydra:Operation",
+"apiContract:Operation",
 "doc:DomainElement"
 ],
-"hydra:method": [
+"apiContract:method": [
 {
 "@value": "post"
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#288/source-map",
+"@id": "#303/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -4456,7 +4469,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#288"
+"@value": "amf://id#303"
 }
 ],
 "sourcemaps:value": [
@@ -4470,36 +4483,36 @@
 ]
 }
 ],
-"raml-http:parameter": [
+"apiContract:parameter": [
 {
-"@id": "#289",
+"@id": "#304",
 "@type": [
-"raml-http:Parameter",
+"apiContract:Parameter",
 "doc:DomainElement"
 ],
-"schema-org:name": [
+"core:name": [
 {
 "@value": "fileId"
 }
 ],
-"raml-http:paramName": [
+"apiContract:paramName": [
 {
 "@value": "fileId"
 }
 ],
-"hydra:required": [
+"apiContract:required": [
 {
 "@value": true
 }
 ],
-"raml-http:binding": [
+"apiContract:binding": [
 {
 "@value": "path"
 }
 ],
-"raml-http:schema": [
+"apiContract:schema": [
 {
-"@id": "#290",
+"@id": "#305",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -4520,7 +4533,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#289/source-map",
+"@id": "#304/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -4528,7 +4541,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#289"
+"@value": "amf://id#304"
 }
 ],
 "sourcemaps:value": [
@@ -4542,34 +4555,34 @@
 ]
 },
 {
-"@id": "#291",
+"@id": "#306",
 "@type": [
-"raml-http:Parameter",
+"apiContract:Parameter",
 "doc:DomainElement"
 ],
-"schema-org:name": [
+"core:name": [
 {
 "@value": "commentId"
 }
 ],
-"raml-http:paramName": [
+"apiContract:paramName": [
 {
 "@value": "commentId"
 }
 ],
-"hydra:required": [
+"apiContract:required": [
 {
 "@value": true
 }
 ],
-"raml-http:binding": [
+"apiContract:binding": [
 {
 "@value": "path"
 }
 ],
-"raml-http:schema": [
+"apiContract:schema": [
 {
-"@id": "#292",
+"@id": "#307",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -4586,11 +4599,18 @@
 "@value": "schema"
 }
 ],
-"doc:examples": [
+"apiContract:examples": [
 {
-"@id": "#285",
+"@id": "#299",
 "@type": [
-"doc:Example",
+"apiContract:NamedExamples",
+"doc:DomainElement"
+],
+"apiContract:examples": [
+{
+"@id": "#300",
+"@type": [
+"apiContract:Example",
 "doc:DomainElement"
 ],
 "doc:strict": [
@@ -4600,9 +4620,11 @@
 ],
 "doc:structuredValue": [
 {
-"@id": "#285",
+"@id": "#300",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -4612,7 +4634,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#285/source-map",
+"@id": "#300/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -4620,7 +4642,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#285"
+"@value": "amf://id#300"
 }
 ],
 "sourcemaps:value": [
@@ -4641,7 +4663,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#285/source-map",
+"@id": "#300/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -4675,7 +4697,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#285"
+"@value": "amf://id#300"
 }
 ],
 "sourcemaps:value": [
@@ -4689,12 +4711,14 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#285"
+"@value": "amf://id#300"
 }
 ],
 "sourcemaps:value": [
 {
-"@value": "amf://id#283"
+"@value": "amf://id#297"
+}
+]
 }
 ]
 }
@@ -4705,7 +4729,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#292/source-map",
+"@id": "#307/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -4713,7 +4737,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#292"
+"@value": "amf://id#307"
 }
 ],
 "sourcemaps:value": [
@@ -4739,7 +4763,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#292"
+"@value": "amf://id#307"
 }
 ],
 "sourcemaps:value": [
@@ -4755,7 +4779,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#291/source-map",
+"@id": "#306/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -4763,7 +4787,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#291"
+"@value": "amf://id#306"
 }
 ],
 "sourcemaps:value": [
@@ -4777,499 +4801,12 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#291"
+"@value": "amf://id#306"
 }
 ],
 "sourcemaps:value": [
 {
 "@value": "[(215,10)-(218,0)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"sourcemaps:sources": [
-{
-"@id": "#286/source-map",
-"@type": [
-"sourcemaps:SourceMap"
-],
-"sourcemaps:parent-end-point": [
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#286"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "file://test/demo-api/demo-api.raml#/web-api/end-points/%2Ffiles%2F%7BfileId%7D%2Fcomments%2F%7BcommentId%7D"
-}
-]
-}
-],
-"sourcemaps:lexical": [
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#286"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(228,8)-(250,0)]"
-}
-]
-}
-]
-}
-]
-},
-{
-"@id": "#293",
-"@type": [
-"raml-http:EndPoint",
-"doc:DomainElement"
-],
-"raml-http:path": [
-{
-"@value": "/files/{fileId}/comments/{commentId}/replies/{replyId}"
-}
-],
-"hydra:supportedOperation": [
-{
-"@id": "#294",
-"@type": [
-"hydra:Operation",
-"doc:DomainElement"
-],
-"hydra:method": [
-{
-"@value": "get"
-}
-],
-"schema-org:description": [
-{
-"@value": "Gets a reply."
-}
-],
-"sourcemaps:sources": [
-{
-"@id": "#294/source-map",
-"@type": [
-"sourcemaps:SourceMap"
-],
-"sourcemaps:lexical": [
-{
-"sourcemaps:element": [
-{
-"@value": "schema-org:description"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(239,14)-(241,0)]"
-}
-]
-},
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#294"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(238,12)-(241,0)]"
-}
-]
-}
-]
-}
-]
-},
-{
-"@id": "#295",
-"@type": [
-"hydra:Operation",
-"doc:DomainElement"
-],
-"hydra:method": [
-{
-"@value": "put"
-}
-],
-"schema-org:description": [
-{
-"@value": "Updates an existing reply."
-}
-],
-"sourcemaps:sources": [
-{
-"@id": "#295/source-map",
-"@type": [
-"sourcemaps:SourceMap"
-],
-"sourcemaps:lexical": [
-{
-"sourcemaps:element": [
-{
-"@value": "schema-org:description"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(242,14)-(244,0)]"
-}
-]
-},
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#295"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(241,12)-(244,0)]"
-}
-]
-}
-]
-}
-]
-},
-{
-"@id": "#296",
-"@type": [
-"hydra:Operation",
-"doc:DomainElement"
-],
-"hydra:method": [
-{
-"@value": "delete"
-}
-],
-"schema-org:description": [
-{
-"@value": "Deletes a reply."
-}
-],
-"sourcemaps:sources": [
-{
-"@id": "#296/source-map",
-"@type": [
-"sourcemaps:SourceMap"
-],
-"sourcemaps:lexical": [
-{
-"sourcemaps:element": [
-{
-"@value": "schema-org:description"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(245,14)-(247,0)]"
-}
-]
-},
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#296"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(244,12)-(247,0)]"
-}
-]
-}
-]
-}
-]
-},
-{
-"@id": "#297",
-"@type": [
-"hydra:Operation",
-"doc:DomainElement"
-],
-"hydra:method": [
-{
-"@value": "patch"
-}
-],
-"schema-org:description": [
-{
-"@value": "Updates an existing reply. This method supports patch semantics."
-}
-],
-"sourcemaps:sources": [
-{
-"@id": "#297/source-map",
-"@type": [
-"sourcemaps:SourceMap"
-],
-"sourcemaps:lexical": [
-{
-"sourcemaps:element": [
-{
-"@value": "schema-org:description"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(248,14)-(250,0)]"
-}
-]
-},
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#297"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(247,12)-(250,0)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"raml-http:parameter": [
-{
-"@id": "#298",
-"@type": [
-"raml-http:Parameter",
-"doc:DomainElement"
-],
-"schema-org:name": [
-{
-"@value": "fileId"
-}
-],
-"raml-http:paramName": [
-{
-"@value": "fileId"
-}
-],
-"hydra:required": [
-{
-"@value": true
-}
-],
-"raml-http:binding": [
-{
-"@value": "path"
-}
-],
-"raml-http:schema": [
-{
-"@id": "#299",
-"@type": [
-"raml-shapes:ScalarShape",
-"shacl:Shape",
-"raml-shapes:Shape",
-"doc:DomainElement"
-],
-"shacl:datatype": [
-{
-"@id": "http://www.w3.org/2001/XMLSchema#string"
-}
-],
-"shacl:name": [
-{
-"@value": "fileId"
-}
-]
-}
-],
-"sourcemaps:sources": [
-{
-"@id": "#298/source-map",
-"@type": [
-"sourcemaps:SourceMap"
-],
-"sourcemaps:synthesized-field": [
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#298"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "true"
-}
-]
-}
-]
-}
-]
-},
-{
-"@id": "#300",
-"@type": [
-"raml-http:Parameter",
-"doc:DomainElement"
-],
-"schema-org:name": [
-{
-"@value": "commentId"
-}
-],
-"raml-http:paramName": [
-{
-"@value": "commentId"
-}
-],
-"hydra:required": [
-{
-"@value": true
-}
-],
-"raml-http:binding": [
-{
-"@value": "path"
-}
-],
-"raml-http:schema": [
-{
-"@id": "#301",
-"@type": [
-"raml-shapes:ScalarShape",
-"shacl:Shape",
-"raml-shapes:Shape",
-"doc:DomainElement"
-],
-"shacl:datatype": [
-{
-"@id": "http://www.w3.org/2001/XMLSchema#string"
-}
-],
-"shacl:name": [
-{
-"@value": "schema"
-}
-],
-"doc:examples": [
-{
-"@id": "#285",
-"@type": [
-"doc:Example",
-"doc:DomainElement"
-],
-"doc:strict": [
-{
-"@value": true
-}
-],
-"doc:structuredValue": [
-{
-"@id": "#285",
-"@type": [
-"data:Scalar"
-],
-"data:value": [
-{
-"@value": "commant-id",
-"@type": "xsd:string"
-}
-],
-"sourcemaps:sources": [
-{
-"@id": "#285/source-map",
-"@type": [
-"sourcemaps:SourceMap"
-],
-"sourcemaps:lexical": [
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#285"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(217,21)-(217,31)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"shacl:raw": [
-{
-"@value": "commant-id"
-}
-],
-"sourcemaps:sources": [
-{
-"@id": "#285/source-map",
-"@type": [
-"sourcemaps:SourceMap"
-],
-"sourcemaps:synthesized-field": [
-{
-"sourcemaps:element": [
-{
-"@value": "doc:strict"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "true"
-}
-]
-}
-],
-"sourcemaps:lexical": [
-{
-"sourcemaps:element": [
-{
-"@value": "shacl:raw"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(217,21)-(217,31)]"
-}
-]
-},
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#285"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(217,21)-(217,31)]"
-}
-]
-}
-],
-"sourcemaps:tracked-element": [
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#285"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "amf://id#283"
 }
 ]
 }
@@ -5284,11 +4821,509 @@
 "@type": [
 "sourcemaps:SourceMap"
 ],
-"sourcemaps:type-property-lexical-info": [
+"sourcemaps:parent-end-point": [
 {
 "sourcemaps:element": [
 {
 "@value": "amf://id#301"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "file://test/demo-api/demo-api.raml#/web-api/end-points/%2Ffiles%2F%7BfileId%7D%2Fcomments%2F%7BcommentId%7D"
+}
+]
+}
+],
+"sourcemaps:lexical": [
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#301"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(228,8)-(250,0)]"
+}
+]
+}
+]
+}
+]
+},
+{
+"@id": "#308",
+"@type": [
+"apiContract:EndPoint",
+"doc:DomainElement"
+],
+"apiContract:path": [
+{
+"@value": "/files/{fileId}/comments/{commentId}/replies/{replyId}"
+}
+],
+"apiContract:supportedOperation": [
+{
+"@id": "#309",
+"@type": [
+"apiContract:Operation",
+"doc:DomainElement"
+],
+"apiContract:method": [
+{
+"@value": "get"
+}
+],
+"core:description": [
+{
+"@value": "Gets a reply."
+}
+],
+"sourcemaps:sources": [
+{
+"@id": "#309/source-map",
+"@type": [
+"sourcemaps:SourceMap"
+],
+"sourcemaps:lexical": [
+{
+"sourcemaps:element": [
+{
+"@value": "core:description"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(239,14)-(241,0)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#309"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(238,12)-(241,0)]"
+}
+]
+}
+]
+}
+]
+},
+{
+"@id": "#310",
+"@type": [
+"apiContract:Operation",
+"doc:DomainElement"
+],
+"apiContract:method": [
+{
+"@value": "put"
+}
+],
+"core:description": [
+{
+"@value": "Updates an existing reply."
+}
+],
+"sourcemaps:sources": [
+{
+"@id": "#310/source-map",
+"@type": [
+"sourcemaps:SourceMap"
+],
+"sourcemaps:lexical": [
+{
+"sourcemaps:element": [
+{
+"@value": "core:description"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(242,14)-(244,0)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#310"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(241,12)-(244,0)]"
+}
+]
+}
+]
+}
+]
+},
+{
+"@id": "#311",
+"@type": [
+"apiContract:Operation",
+"doc:DomainElement"
+],
+"apiContract:method": [
+{
+"@value": "delete"
+}
+],
+"core:description": [
+{
+"@value": "Deletes a reply."
+}
+],
+"sourcemaps:sources": [
+{
+"@id": "#311/source-map",
+"@type": [
+"sourcemaps:SourceMap"
+],
+"sourcemaps:lexical": [
+{
+"sourcemaps:element": [
+{
+"@value": "core:description"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(245,14)-(247,0)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#311"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(244,12)-(247,0)]"
+}
+]
+}
+]
+}
+]
+},
+{
+"@id": "#312",
+"@type": [
+"apiContract:Operation",
+"doc:DomainElement"
+],
+"apiContract:method": [
+{
+"@value": "patch"
+}
+],
+"core:description": [
+{
+"@value": "Updates an existing reply. This method supports patch semantics."
+}
+],
+"sourcemaps:sources": [
+{
+"@id": "#312/source-map",
+"@type": [
+"sourcemaps:SourceMap"
+],
+"sourcemaps:lexical": [
+{
+"sourcemaps:element": [
+{
+"@value": "core:description"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(248,14)-(250,0)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#312"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(247,12)-(250,0)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"apiContract:parameter": [
+{
+"@id": "#313",
+"@type": [
+"apiContract:Parameter",
+"doc:DomainElement"
+],
+"core:name": [
+{
+"@value": "fileId"
+}
+],
+"apiContract:paramName": [
+{
+"@value": "fileId"
+}
+],
+"apiContract:required": [
+{
+"@value": true
+}
+],
+"apiContract:binding": [
+{
+"@value": "path"
+}
+],
+"apiContract:schema": [
+{
+"@id": "#314",
+"@type": [
+"raml-shapes:ScalarShape",
+"shacl:Shape",
+"raml-shapes:Shape",
+"doc:DomainElement"
+],
+"shacl:datatype": [
+{
+"@id": "http://www.w3.org/2001/XMLSchema#string"
+}
+],
+"shacl:name": [
+{
+"@value": "fileId"
+}
+]
+}
+],
+"sourcemaps:sources": [
+{
+"@id": "#313/source-map",
+"@type": [
+"sourcemaps:SourceMap"
+],
+"sourcemaps:synthesized-field": [
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#313"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "true"
+}
+]
+}
+]
+}
+]
+},
+{
+"@id": "#315",
+"@type": [
+"apiContract:Parameter",
+"doc:DomainElement"
+],
+"core:name": [
+{
+"@value": "commentId"
+}
+],
+"apiContract:paramName": [
+{
+"@value": "commentId"
+}
+],
+"apiContract:required": [
+{
+"@value": true
+}
+],
+"apiContract:binding": [
+{
+"@value": "path"
+}
+],
+"apiContract:schema": [
+{
+"@id": "#316",
+"@type": [
+"raml-shapes:ScalarShape",
+"shacl:Shape",
+"raml-shapes:Shape",
+"doc:DomainElement"
+],
+"shacl:datatype": [
+{
+"@id": "http://www.w3.org/2001/XMLSchema#string"
+}
+],
+"shacl:name": [
+{
+"@value": "schema"
+}
+],
+"apiContract:examples": [
+{
+"@id": "#299",
+"@type": [
+"apiContract:NamedExamples",
+"doc:DomainElement"
+],
+"apiContract:examples": [
+{
+"@id": "#300",
+"@type": [
+"apiContract:Example",
+"doc:DomainElement"
+],
+"doc:strict": [
+{
+"@value": true
+}
+],
+"doc:structuredValue": [
+{
+"@id": "#300",
+"@type": [
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
+],
+"data:value": [
+{
+"@value": "commant-id",
+"@type": "xsd:string"
+}
+],
+"sourcemaps:sources": [
+{
+"@id": "#300/source-map",
+"@type": [
+"sourcemaps:SourceMap"
+],
+"sourcemaps:lexical": [
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#300"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(217,21)-(217,31)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"shacl:raw": [
+{
+"@value": "commant-id"
+}
+],
+"sourcemaps:sources": [
+{
+"@id": "#300/source-map",
+"@type": [
+"sourcemaps:SourceMap"
+],
+"sourcemaps:synthesized-field": [
+{
+"sourcemaps:element": [
+{
+"@value": "doc:strict"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "true"
+}
+]
+}
+],
+"sourcemaps:lexical": [
+{
+"sourcemaps:element": [
+{
+"@value": "shacl:raw"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(217,21)-(217,31)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#300"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(217,21)-(217,31)]"
+}
+]
+}
+],
+"sourcemaps:tracked-element": [
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#300"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "amf://id#297"
+}
+]
+}
+]
+}
+]
+}
+]
+}
+],
+"sourcemaps:sources": [
+{
+"@id": "#316/source-map",
+"@type": [
+"sourcemaps:SourceMap"
+],
+"sourcemaps:type-property-lexical-info": [
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#316"
 }
 ],
 "sourcemaps:value": [
@@ -5314,7 +5349,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#301"
+"@value": "amf://id#316"
 }
 ],
 "sourcemaps:value": [
@@ -5330,7 +5365,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#300/source-map",
+"@id": "#315/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -5338,7 +5373,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#300"
+"@value": "amf://id#315"
 }
 ],
 "sourcemaps:value": [
@@ -5352,7 +5387,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#300"
+"@value": "amf://id#315"
 }
 ],
 "sourcemaps:value": [
@@ -5366,39 +5401,39 @@
 ]
 },
 {
-"@id": "#302",
+"@id": "#317",
 "@type": [
-"raml-http:Parameter",
+"apiContract:Parameter",
 "doc:DomainElement"
 ],
-"schema-org:name": [
+"core:name": [
 {
 "@value": "replyId"
 }
 ],
-"raml-http:paramName": [
+"apiContract:paramName": [
 {
 "@value": "replyId"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "The ID of the reply."
 }
 ],
-"hydra:required": [
+"apiContract:required": [
 {
 "@value": true
 }
 ],
-"raml-http:binding": [
+"apiContract:binding": [
 {
 "@value": "path"
 }
 ],
-"raml-http:schema": [
+"apiContract:schema": [
 {
-"@id": "#303",
+"@id": "#318",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -5415,14 +5450,14 @@
 "@value": "schema"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "The ID of the reply."
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#303/source-map",
+"@id": "#318/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -5430,7 +5465,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#303"
+"@value": "amf://id#318"
 }
 ],
 "sourcemaps:value": [
@@ -5444,7 +5479,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -5456,7 +5491,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#303"
+"@value": "amf://id#318"
 }
 ],
 "sourcemaps:value": [
@@ -5484,7 +5519,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#302/source-map",
+"@id": "#317/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -5492,7 +5527,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -5504,7 +5539,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#302"
+"@value": "amf://id#317"
 }
 ],
 "sourcemaps:value": [
@@ -5520,7 +5555,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#293/source-map",
+"@id": "#308/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -5528,7 +5563,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#293"
+"@value": "amf://id#308"
 }
 ],
 "sourcemaps:value": [
@@ -5542,7 +5577,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "raml-http:parameter"
+"@value": "apiContract:parameter"
 }
 ],
 "sourcemaps:value": [
@@ -5554,7 +5589,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#293"
+"@value": "amf://id#308"
 }
 ],
 "sourcemaps:value": [
@@ -5568,36 +5603,36 @@
 ]
 },
 {
-"@id": "#304",
+"@id": "#319",
 "@type": [
-"raml-http:EndPoint",
+"apiContract:EndPoint",
 "doc:DomainElement"
 ],
-"raml-http:path": [
+"apiContract:path": [
 {
 "@value": "/files/{fileId}/realtime"
 }
 ],
-"hydra:supportedOperation": [
+"apiContract:supportedOperation": [
 {
-"@id": "#305",
+"@id": "#320",
 "@type": [
-"hydra:Operation",
+"apiContract:Operation",
 "doc:DomainElement"
 ],
-"hydra:method": [
+"apiContract:method": [
 {
 "@value": "get"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "Exports the contents of the Realtime API data model associated with this file as JSON."
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#305/source-map",
+"@id": "#320/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -5605,7 +5640,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -5617,7 +5652,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#305"
+"@value": "amf://id#320"
 }
 ],
 "sourcemaps:value": [
@@ -5631,29 +5666,29 @@
 ]
 },
 {
-"@id": "#306",
+"@id": "#321",
 "@type": [
-"hydra:Operation",
+"apiContract:Operation",
 "doc:DomainElement"
 ],
-"hydra:method": [
+"apiContract:method": [
 {
 "@value": "put"
 }
 ],
-"schema-org:name": [
+"core:name": [
 {
 "@value": "update"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "Overwrites the Realtime API data model associated with this file with the provided JSON data model.\n\nThis method supports an /upload URI and accepts uploaded media with the following characteristics:\n\n- **Maximum file size**: 10MB\n- **Accepted Media MIME** types: */*\n"
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#306/source-map",
+"@id": "#321/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -5661,7 +5696,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -5673,7 +5708,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#306"
+"@value": "amf://id#321"
 }
 ],
 "sourcemaps:value": [
@@ -5685,7 +5720,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:name"
+"@value": "core:name"
 }
 ],
 "sourcemaps:value": [
@@ -5699,36 +5734,36 @@
 ]
 }
 ],
-"raml-http:parameter": [
+"apiContract:parameter": [
 {
-"@id": "#307",
+"@id": "#322",
 "@type": [
-"raml-http:Parameter",
+"apiContract:Parameter",
 "doc:DomainElement"
 ],
-"schema-org:name": [
+"core:name": [
 {
 "@value": "fileId"
 }
 ],
-"raml-http:paramName": [
+"apiContract:paramName": [
 {
 "@value": "fileId"
 }
 ],
-"hydra:required": [
+"apiContract:required": [
 {
 "@value": true
 }
 ],
-"raml-http:binding": [
+"apiContract:binding": [
 {
 "@value": "path"
 }
 ],
-"raml-http:schema": [
+"apiContract:schema": [
 {
-"@id": "#308",
+"@id": "#323",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -5749,7 +5784,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#307/source-map",
+"@id": "#322/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -5757,7 +5792,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#307"
+"@value": "amf://id#322"
 }
 ],
 "sourcemaps:value": [
@@ -5773,7 +5808,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#304/source-map",
+"@id": "#319/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -5781,7 +5816,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#304"
+"@value": "amf://id#319"
 }
 ],
 "sourcemaps:value": [
@@ -5795,7 +5830,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#304"
+"@value": "amf://id#319"
 }
 ],
 "sourcemaps:value": [
@@ -5809,36 +5844,36 @@
 ]
 },
 {
-"@id": "#309",
+"@id": "#324",
 "@type": [
-"raml-http:EndPoint",
+"apiContract:EndPoint",
 "doc:DomainElement"
 ],
-"raml-http:path": [
+"apiContract:path": [
 {
 "@value": "/files/{fileId}/properties"
 }
 ],
-"hydra:supportedOperation": [
+"apiContract:supportedOperation": [
 {
-"@id": "#310",
+"@id": "#325",
 "@type": [
-"hydra:Operation",
+"apiContract:Operation",
 "doc:DomainElement"
 ],
-"hydra:method": [
+"apiContract:method": [
 {
 "@value": "get"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "Lists a file's properties."
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#310/source-map",
+"@id": "#325/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -5846,7 +5881,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -5858,7 +5893,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#310"
+"@value": "amf://id#325"
 }
 ],
 "sourcemaps:value": [
@@ -5872,24 +5907,24 @@
 ]
 },
 {
-"@id": "#311",
+"@id": "#326",
 "@type": [
-"hydra:Operation",
+"apiContract:Operation",
 "doc:DomainElement"
 ],
-"hydra:method": [
+"apiContract:method": [
 {
 "@value": "post"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "Adds a property to a file."
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#311/source-map",
+"@id": "#326/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -5897,7 +5932,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -5909,7 +5944,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#311"
+"@value": "amf://id#326"
 }
 ],
 "sourcemaps:value": [
@@ -5923,36 +5958,36 @@
 ]
 }
 ],
-"raml-http:parameter": [
+"apiContract:parameter": [
 {
-"@id": "#312",
+"@id": "#327",
 "@type": [
-"raml-http:Parameter",
+"apiContract:Parameter",
 "doc:DomainElement"
 ],
-"schema-org:name": [
+"core:name": [
 {
 "@value": "fileId"
 }
 ],
-"raml-http:paramName": [
+"apiContract:paramName": [
 {
 "@value": "fileId"
 }
 ],
-"hydra:required": [
+"apiContract:required": [
 {
 "@value": true
 }
 ],
-"raml-http:binding": [
+"apiContract:binding": [
 {
 "@value": "path"
 }
 ],
-"raml-http:schema": [
+"apiContract:schema": [
 {
-"@id": "#313",
+"@id": "#328",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -5973,7 +6008,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#312/source-map",
+"@id": "#327/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -5981,7 +6016,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#312"
+"@value": "amf://id#327"
 }
 ],
 "sourcemaps:value": [
@@ -5997,7 +6032,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#309/source-map",
+"@id": "#324/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -6005,7 +6040,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#309"
+"@value": "amf://id#324"
 }
 ],
 "sourcemaps:value": [
@@ -6019,7 +6054,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#309"
+"@value": "amf://id#324"
 }
 ],
 "sourcemaps:value": [
@@ -6033,31 +6068,31 @@
 ]
 },
 {
-"@id": "#314",
+"@id": "#329",
 "@type": [
-"raml-http:EndPoint",
+"apiContract:EndPoint",
 "doc:DomainElement"
 ],
-"raml-http:path": [
+"apiContract:path": [
 {
 "@value": "/files/{fileId}/properties/{propertyKey}"
 }
 ],
-"hydra:supportedOperation": [
+"apiContract:supportedOperation": [
 {
-"@id": "#315",
+"@id": "#330",
 "@type": [
-"hydra:Operation",
+"apiContract:Operation",
 "doc:DomainElement"
 ],
-"hydra:method": [
+"apiContract:method": [
 {
 "@value": "get"
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#315/source-map",
+"@id": "#330/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -6065,7 +6100,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#315"
+"@value": "amf://id#330"
 }
 ],
 "sourcemaps:value": [
@@ -6079,19 +6114,19 @@
 ]
 },
 {
-"@id": "#316",
+"@id": "#331",
 "@type": [
-"hydra:Operation",
+"apiContract:Operation",
 "doc:DomainElement"
 ],
-"hydra:method": [
+"apiContract:method": [
 {
 "@value": "put"
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#316/source-map",
+"@id": "#331/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -6099,7 +6134,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#316"
+"@value": "amf://id#331"
 }
 ],
 "sourcemaps:value": [
@@ -6113,19 +6148,19 @@
 ]
 },
 {
-"@id": "#317",
+"@id": "#332",
 "@type": [
-"hydra:Operation",
+"apiContract:Operation",
 "doc:DomainElement"
 ],
-"hydra:method": [
+"apiContract:method": [
 {
 "@value": "delete"
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#317/source-map",
+"@id": "#332/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -6133,7 +6168,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#317"
+"@value": "amf://id#332"
 }
 ],
 "sourcemaps:value": [
@@ -6147,19 +6182,19 @@
 ]
 },
 {
-"@id": "#318",
+"@id": "#333",
 "@type": [
-"hydra:Operation",
+"apiContract:Operation",
 "doc:DomainElement"
 ],
-"hydra:method": [
+"apiContract:method": [
 {
 "@value": "patch"
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#318/source-map",
+"@id": "#333/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -6167,7 +6202,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#318"
+"@value": "amf://id#333"
 }
 ],
 "sourcemaps:value": [
@@ -6181,36 +6216,36 @@
 ]
 }
 ],
-"raml-http:parameter": [
+"apiContract:parameter": [
 {
-"@id": "#319",
+"@id": "#334",
 "@type": [
-"raml-http:Parameter",
+"apiContract:Parameter",
 "doc:DomainElement"
 ],
-"schema-org:name": [
+"core:name": [
 {
 "@value": "fileId"
 }
 ],
-"raml-http:paramName": [
+"apiContract:paramName": [
 {
 "@value": "fileId"
 }
 ],
-"hydra:required": [
+"apiContract:required": [
 {
 "@value": true
 }
 ],
-"raml-http:binding": [
+"apiContract:binding": [
 {
 "@value": "path"
 }
 ],
-"raml-http:schema": [
+"apiContract:schema": [
 {
-"@id": "#320",
+"@id": "#335",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -6231,7 +6266,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#319/source-map",
+"@id": "#334/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -6239,7 +6274,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#319"
+"@value": "amf://id#334"
 }
 ],
 "sourcemaps:value": [
@@ -6253,39 +6288,39 @@
 ]
 },
 {
-"@id": "#321",
+"@id": "#336",
 "@type": [
-"raml-http:Parameter",
+"apiContract:Parameter",
 "doc:DomainElement"
 ],
-"schema-org:name": [
+"core:name": [
 {
 "@value": "propertyKey"
 }
 ],
-"raml-http:paramName": [
+"apiContract:paramName": [
 {
 "@value": "propertyKey"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "The key of the property."
 }
 ],
-"hydra:required": [
+"apiContract:required": [
 {
 "@value": true
 }
 ],
-"raml-http:binding": [
+"apiContract:binding": [
 {
 "@value": "path"
 }
 ],
-"raml-http:schema": [
+"apiContract:schema": [
 {
-"@id": "#322",
+"@id": "#337",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -6302,14 +6337,14 @@
 "@value": "schema"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "The key of the property."
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#322/source-map",
+"@id": "#337/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -6317,7 +6352,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#322"
+"@value": "amf://id#337"
 }
 ],
 "sourcemaps:value": [
@@ -6331,7 +6366,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -6343,7 +6378,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#322"
+"@value": "amf://id#337"
 }
 ],
 "sourcemaps:value": [
@@ -6371,7 +6406,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#321/source-map",
+"@id": "#336/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -6379,7 +6414,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -6391,7 +6426,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#321"
+"@value": "amf://id#336"
 }
 ],
 "sourcemaps:value": [
@@ -6407,7 +6442,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#314/source-map",
+"@id": "#329/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -6415,7 +6450,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#314"
+"@value": "amf://id#329"
 }
 ],
 "sourcemaps:value": [
@@ -6429,7 +6464,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "raml-http:parameter"
+"@value": "apiContract:parameter"
 }
 ],
 "sourcemaps:value": [
@@ -6441,7 +6476,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#314"
+"@value": "amf://id#329"
 }
 ],
 "sourcemaps:value": [
@@ -6455,36 +6490,36 @@
 ]
 },
 {
-"@id": "#323",
+"@id": "#338",
 "@type": [
-"raml-http:EndPoint",
+"apiContract:EndPoint",
 "doc:DomainElement"
 ],
-"raml-http:path": [
+"apiContract:path": [
 {
 "@value": "/files/trash"
 }
 ],
-"hydra:supportedOperation": [
+"apiContract:supportedOperation": [
 {
-"@id": "#324",
+"@id": "#339",
 "@type": [
-"hydra:Operation",
+"apiContract:Operation",
 "doc:DomainElement"
 ],
-"hydra:method": [
+"apiContract:method": [
 {
 "@value": "delete"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "Permanently deletes all of the user's trashed files."
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#324/source-map",
+"@id": "#339/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -6492,7 +6527,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -6504,7 +6539,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#324"
+"@value": "amf://id#339"
 }
 ],
 "sourcemaps:value": [
@@ -6520,7 +6555,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#323/source-map",
+"@id": "#338/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -6528,7 +6563,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#323"
+"@value": "amf://id#338"
 }
 ],
 "sourcemaps:value": [
@@ -6542,7 +6577,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#323"
+"@value": "amf://id#338"
 }
 ],
 "sourcemaps:value": [
@@ -6556,36 +6591,36 @@
 ]
 },
 {
-"@id": "#325",
+"@id": "#340",
 "@type": [
-"raml-http:EndPoint",
+"apiContract:EndPoint",
 "doc:DomainElement"
 ],
-"raml-http:path": [
+"apiContract:path": [
 {
 "@value": "/files/{folderId}/children"
 }
 ],
-"hydra:supportedOperation": [
+"apiContract:supportedOperation": [
 {
-"@id": "#326",
+"@id": "#341",
 "@type": [
-"hydra:Operation",
+"apiContract:Operation",
 "doc:DomainElement"
 ],
-"hydra:method": [
+"apiContract:method": [
 {
 "@value": "post"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "Inserts a file into a folder."
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#326/source-map",
+"@id": "#341/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -6593,7 +6628,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -6605,7 +6640,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#326"
+"@value": "amf://id#341"
 }
 ],
 "sourcemaps:value": [
@@ -6619,24 +6654,24 @@
 ]
 },
 {
-"@id": "#327",
+"@id": "#342",
 "@type": [
-"hydra:Operation",
+"apiContract:Operation",
 "doc:DomainElement"
 ],
-"hydra:method": [
+"apiContract:method": [
 {
 "@value": "get"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "Lists a folder's children. To list all children of the root folder, use the alias root for the folderId value."
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#327/source-map",
+"@id": "#342/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -6644,7 +6679,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -6656,7 +6691,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#327"
+"@value": "amf://id#342"
 }
 ],
 "sourcemaps:value": [
@@ -6670,36 +6705,36 @@
 ]
 }
 ],
-"raml-http:parameter": [
+"apiContract:parameter": [
 {
-"@id": "#328",
+"@id": "#343",
 "@type": [
-"raml-http:Parameter",
+"apiContract:Parameter",
 "doc:DomainElement"
 ],
-"schema-org:name": [
+"core:name": [
 {
 "@value": "folderId"
 }
 ],
-"raml-http:paramName": [
+"apiContract:paramName": [
 {
 "@value": "folderId"
 }
 ],
-"hydra:required": [
+"apiContract:required": [
 {
 "@value": true
 }
 ],
-"raml-http:binding": [
+"apiContract:binding": [
 {
 "@value": "path"
 }
 ],
-"raml-http:schema": [
+"apiContract:schema": [
 {
-"@id": "#329",
+"@id": "#344",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -6720,7 +6755,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#328/source-map",
+"@id": "#343/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -6728,7 +6763,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#328"
+"@value": "amf://id#343"
 }
 ],
 "sourcemaps:value": [
@@ -6744,7 +6779,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#325/source-map",
+"@id": "#340/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -6752,7 +6787,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#325"
+"@value": "amf://id#340"
 }
 ],
 "sourcemaps:value": [
@@ -6766,7 +6801,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#325"
+"@value": "amf://id#340"
 }
 ],
 "sourcemaps:value": [
@@ -6780,36 +6815,36 @@
 ]
 },
 {
-"@id": "#330",
+"@id": "#345",
 "@type": [
-"raml-http:EndPoint",
+"apiContract:EndPoint",
 "doc:DomainElement"
 ],
-"raml-http:path": [
+"apiContract:path": [
 {
 "@value": "/files/{folderId}/children/{childId}"
 }
 ],
-"hydra:supportedOperation": [
+"apiContract:supportedOperation": [
 {
-"@id": "#331",
+"@id": "#346",
 "@type": [
-"hydra:Operation",
+"apiContract:Operation",
 "doc:DomainElement"
 ],
-"hydra:method": [
+"apiContract:method": [
 {
 "@value": "delete"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "Removes a child from a folder."
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#331/source-map",
+"@id": "#346/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -6817,7 +6852,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -6829,7 +6864,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#331"
+"@value": "amf://id#346"
 }
 ],
 "sourcemaps:value": [
@@ -6843,24 +6878,24 @@
 ]
 },
 {
-"@id": "#332",
+"@id": "#347",
 "@type": [
-"hydra:Operation",
+"apiContract:Operation",
 "doc:DomainElement"
 ],
-"hydra:method": [
+"apiContract:method": [
 {
 "@value": "get"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "Gets a specific child reference."
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#332/source-map",
+"@id": "#347/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -6868,7 +6903,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -6880,7 +6915,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#332"
+"@value": "amf://id#347"
 }
 ],
 "sourcemaps:value": [
@@ -6894,36 +6929,36 @@
 ]
 }
 ],
-"raml-http:parameter": [
+"apiContract:parameter": [
 {
-"@id": "#333",
+"@id": "#348",
 "@type": [
-"raml-http:Parameter",
+"apiContract:Parameter",
 "doc:DomainElement"
 ],
-"schema-org:name": [
+"core:name": [
 {
 "@value": "folderId"
 }
 ],
-"raml-http:paramName": [
+"apiContract:paramName": [
 {
 "@value": "folderId"
 }
 ],
-"hydra:required": [
+"apiContract:required": [
 {
 "@value": true
 }
 ],
-"raml-http:binding": [
+"apiContract:binding": [
 {
 "@value": "path"
 }
 ],
-"raml-http:schema": [
+"apiContract:schema": [
 {
-"@id": "#334",
+"@id": "#349",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -6944,7 +6979,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#333/source-map",
+"@id": "#348/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -6952,7 +6987,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#333"
+"@value": "amf://id#348"
 }
 ],
 "sourcemaps:value": [
@@ -6966,34 +7001,34 @@
 ]
 },
 {
-"@id": "#335",
+"@id": "#350",
 "@type": [
-"raml-http:Parameter",
+"apiContract:Parameter",
 "doc:DomainElement"
 ],
-"schema-org:name": [
+"core:name": [
 {
 "@value": "childId"
 }
 ],
-"raml-http:paramName": [
+"apiContract:paramName": [
 {
 "@value": "childId"
 }
 ],
-"hydra:required": [
+"apiContract:required": [
 {
 "@value": true
 }
 ],
-"raml-http:binding": [
+"apiContract:binding": [
 {
 "@value": "path"
 }
 ],
-"raml-http:schema": [
+"apiContract:schema": [
 {
-"@id": "#336",
+"@id": "#351",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -7014,7 +7049,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#335/source-map",
+"@id": "#350/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -7022,7 +7057,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#335"
+"@value": "amf://id#350"
 }
 ],
 "sourcemaps:value": [
@@ -7038,7 +7073,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#330/source-map",
+"@id": "#345/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -7046,7 +7081,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#330"
+"@value": "amf://id#345"
 }
 ],
 "sourcemaps:value": [
@@ -7060,7 +7095,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#330"
+"@value": "amf://id#345"
 }
 ],
 "sourcemaps:value": [
@@ -7074,41 +7109,41 @@
 ]
 },
 {
-"@id": "#337",
+"@id": "#352",
 "@type": [
-"raml-http:EndPoint",
+"apiContract:EndPoint",
 "doc:DomainElement"
 ],
-"raml-http:path": [
+"apiContract:path": [
 {
 "@value": "/about"
 }
 ],
-"schema-org:name": [
+"core:name": [
 {
 "@value": "About"
 }
 ],
-"hydra:supportedOperation": [
+"apiContract:supportedOperation": [
 {
-"@id": "#338",
+"@id": "#353",
 "@type": [
-"hydra:Operation",
+"apiContract:Operation",
 "doc:DomainElement"
 ],
-"hydra:method": [
+"apiContract:method": [
 {
 "@value": "get"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "Gets the information about the current user along with Drive API settings."
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#338/source-map",
+"@id": "#353/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -7116,7 +7151,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -7128,7 +7163,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#338"
+"@value": "amf://id#353"
 }
 ],
 "sourcemaps:value": [
@@ -7144,7 +7179,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#337/source-map",
+"@id": "#352/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -7152,7 +7187,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:name"
+"@value": "core:name"
 }
 ],
 "sourcemaps:value": [
@@ -7164,7 +7199,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#337"
+"@value": "amf://id#352"
 }
 ],
 "sourcemaps:value": [
@@ -7178,36 +7213,36 @@
 ]
 },
 {
-"@id": "#339",
+"@id": "#354",
 "@type": [
-"raml-http:EndPoint",
+"apiContract:EndPoint",
 "doc:DomainElement"
 ],
-"raml-http:path": [
+"apiContract:path": [
 {
 "@value": "/changes"
 }
 ],
-"schema-org:name": [
+"core:name": [
 {
 "@value": "Changes"
 }
 ],
-"hydra:supportedOperation": [
+"apiContract:supportedOperation": [
 {
-"@id": "#340",
+"@id": "#355",
 "@type": [
-"hydra:Operation",
+"apiContract:Operation",
 "doc:DomainElement"
 ],
-"hydra:method": [
+"apiContract:method": [
 {
 "@value": "get"
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#340/source-map",
+"@id": "#355/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -7215,7 +7250,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#340"
+"@value": "amf://id#355"
 }
 ],
 "sourcemaps:value": [
@@ -7231,7 +7266,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#339/source-map",
+"@id": "#354/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -7239,7 +7274,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:name"
+"@value": "core:name"
 }
 ],
 "sourcemaps:value": [
@@ -7251,7 +7286,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#339"
+"@value": "amf://id#354"
 }
 ],
 "sourcemaps:value": [
@@ -7265,36 +7300,36 @@
 ]
 },
 {
-"@id": "#341",
+"@id": "#356",
 "@type": [
-"raml-http:EndPoint",
+"apiContract:EndPoint",
 "doc:DomainElement"
 ],
-"raml-http:path": [
+"apiContract:path": [
 {
 "@value": "/changes/{changeId}"
 }
 ],
-"hydra:supportedOperation": [
+"apiContract:supportedOperation": [
 {
-"@id": "#342",
+"@id": "#357",
 "@type": [
-"hydra:Operation",
+"apiContract:Operation",
 "doc:DomainElement"
 ],
-"hydra:method": [
+"apiContract:method": [
 {
 "@value": "get"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "Gets a specific change."
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#342/source-map",
+"@id": "#357/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -7302,7 +7337,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -7314,7 +7349,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#342"
+"@value": "amf://id#357"
 }
 ],
 "sourcemaps:value": [
@@ -7328,41 +7363,41 @@
 ]
 }
 ],
-"raml-http:parameter": [
+"apiContract:parameter": [
 {
-"@id": "#343",
+"@id": "#358",
 "@type": [
-"raml-http:Parameter",
+"apiContract:Parameter",
 "doc:DomainElement"
 ],
-"schema-org:name": [
+"core:name": [
 {
 "@value": "changeId"
 }
 ],
-"raml-http:paramName": [
+"apiContract:paramName": [
 {
 "@value": "changeId"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "The ID of the change."
 }
 ],
-"hydra:required": [
+"apiContract:required": [
 {
 "@value": true
 }
 ],
-"raml-http:binding": [
+"apiContract:binding": [
 {
 "@value": "path"
 }
 ],
-"raml-http:schema": [
+"apiContract:schema": [
 {
-"@id": "#344",
+"@id": "#359",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -7379,14 +7414,14 @@
 "@value": "schema"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "The ID of the change."
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#344/source-map",
+"@id": "#359/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -7394,7 +7429,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#344"
+"@value": "amf://id#359"
 }
 ],
 "sourcemaps:value": [
@@ -7408,7 +7443,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -7420,7 +7455,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#344"
+"@value": "amf://id#359"
 }
 ],
 "sourcemaps:value": [
@@ -7448,7 +7483,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#343/source-map",
+"@id": "#358/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -7456,7 +7491,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -7468,7 +7503,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#343"
+"@value": "amf://id#358"
 }
 ],
 "sourcemaps:value": [
@@ -7484,7 +7519,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#341/source-map",
+"@id": "#356/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -7492,7 +7527,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#341"
+"@value": "amf://id#356"
 }
 ],
 "sourcemaps:value": [
@@ -7506,7 +7541,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "raml-http:parameter"
+"@value": "apiContract:parameter"
 }
 ],
 "sourcemaps:value": [
@@ -7518,7 +7553,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#341"
+"@value": "amf://id#356"
 }
 ],
 "sourcemaps:value": [
@@ -7532,75 +7567,75 @@
 ]
 },
 {
-"@id": "#345",
+"@id": "#360",
 "@type": [
-"raml-http:EndPoint",
+"apiContract:EndPoint",
 "doc:DomainElement"
 ],
-"raml-http:path": [
+"apiContract:path": [
 {
 "@value": "/changes/watch"
 }
 ],
-"hydra:supportedOperation": [
+"apiContract:supportedOperation": [
 {
-"@id": "#346",
+"@id": "#361",
 "@type": [
-"hydra:Operation",
+"apiContract:Operation",
 "doc:DomainElement"
 ],
-"hydra:method": [
+"apiContract:method": [
 {
 "@value": "post"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "Watch for all changes to a user's Drive."
 }
 ],
-"hydra:expects": [
+"apiContract:expects": [
 {
-"@id": "#347",
+"@id": "#362",
 "@type": [
-"raml-http:Request",
+"apiContract:Request",
 "doc:DomainElement"
 ],
-"raml-http:parameter": [
+"apiContract:parameter": [
 {
-"@id": "#348",
+"@id": "#363",
 "@type": [
-"raml-http:Parameter",
+"apiContract:Parameter",
 "doc:DomainElement"
 ],
-"schema-org:name": [
+"core:name": [
 {
 "@value": "spaces"
 }
 ],
-"raml-http:paramName": [
+"apiContract:paramName": [
 {
 "@value": "spaces"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "A comma-separated list of spaces to query. Supported values are:\n\n- **drive**\n- **appDataFolder**\n- **photos**\n"
 }
 ],
-"hydra:required": [
+"apiContract:required": [
 {
 "@value": false
 }
 ],
-"raml-http:binding": [
+"apiContract:binding": [
 {
 "@value": "query"
 }
 ],
-"raml-http:schema": [
+"apiContract:schema": [
 {
-"@id": "#349",
+"@id": "#364",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -7617,14 +7652,14 @@
 "@value": "schema"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "A comma-separated list of spaces to query. Supported values are:\n\n- **drive**\n- **appDataFolder**\n- **photos**\n"
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#349/source-map",
+"@id": "#364/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -7632,7 +7667,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#349"
+"@value": "amf://id#364"
 }
 ],
 "sourcemaps:value": [
@@ -7646,7 +7681,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -7658,7 +7693,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#349"
+"@value": "amf://id#364"
 }
 ],
 "sourcemaps:value": [
@@ -7686,7 +7721,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#348/source-map",
+"@id": "#363/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -7694,7 +7729,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "hydra:required"
+"@value": "apiContract:required"
 }
 ],
 "sourcemaps:value": [
@@ -7706,7 +7741,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#348"
+"@value": "amf://id#363"
 }
 ],
 "sourcemaps:value": [
@@ -7718,7 +7753,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -7732,36 +7767,36 @@
 ]
 }
 ],
-"raml-http:header": [
+"apiContract:header": [
 {
-"@id": "#350",
+"@id": "#365",
 "@type": [
-"raml-http:Parameter",
+"apiContract:Parameter",
 "doc:DomainElement"
 ],
-"schema-org:name": [
+"core:name": [
 {
 "@value": "x-test"
 }
 ],
-"raml-http:paramName": [
+"apiContract:paramName": [
 {
 "@value": "x-test"
 }
 ],
-"hydra:required": [
+"apiContract:required": [
 {
 "@value": true
 }
 ],
-"raml-http:binding": [
+"apiContract:binding": [
 {
 "@value": "header"
 }
 ],
-"raml-http:schema": [
+"apiContract:schema": [
 {
-"@id": "#351",
+"@id": "#366",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -7782,7 +7817,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#350/source-map",
+"@id": "#365/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -7790,7 +7825,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#350"
+"@value": "amf://id#365"
 }
 ],
 "sourcemaps:value": [
@@ -7804,10 +7839,10 @@
 ]
 }
 ],
-"raml-http:payload": [],
+"apiContract:payload": [],
 "sourcemaps:sources": [
 {
-"@id": "#347/source-map",
+"@id": "#362/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -7815,7 +7850,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "raml-http:header"
+"@value": "apiContract:header"
 }
 ],
 "sourcemaps:value": [
@@ -7827,7 +7862,19 @@
 {
 "sourcemaps:element": [
 {
-"@value": "raml-http:parameter"
+"@value": "amf://id#362"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(319,0)-(332,0)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "apiContract:parameter"
 }
 ],
 "sourcemaps:value": [
@@ -7843,7 +7890,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#346/source-map",
+"@id": "#361/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -7851,7 +7898,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -7863,7 +7910,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#346"
+"@value": "amf://id#361"
 }
 ],
 "sourcemaps:value": [
@@ -7877,24 +7924,24 @@
 ]
 },
 {
-"@id": "#352",
+"@id": "#367",
 "@type": [
-"hydra:Operation",
+"apiContract:Operation",
 "doc:DomainElement"
 ],
-"hydra:method": [
+"apiContract:method": [
 {
 "@value": "get"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "Dummy function"
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#352/source-map",
+"@id": "#367/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -7902,7 +7949,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -7914,7 +7961,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#352"
+"@value": "amf://id#367"
 }
 ],
 "sourcemaps:value": [
@@ -7930,7 +7977,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#345/source-map",
+"@id": "#360/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -7938,7 +7985,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#345"
+"@value": "amf://id#360"
 }
 ],
 "sourcemaps:value": [
@@ -7952,7 +7999,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#345"
+"@value": "amf://id#360"
 }
 ],
 "sourcemaps:value": [
@@ -7966,36 +8013,36 @@
 ]
 },
 {
-"@id": "#353",
+"@id": "#368",
 "@type": [
-"raml-http:EndPoint",
+"apiContract:EndPoint",
 "doc:DomainElement"
 ],
-"raml-http:path": [
+"apiContract:path": [
 {
 "@value": "/permissionIds/{email}"
 }
 ],
-"hydra:supportedOperation": [
+"apiContract:supportedOperation": [
 {
-"@id": "#354",
+"@id": "#369",
 "@type": [
-"hydra:Operation",
+"apiContract:Operation",
 "doc:DomainElement"
 ],
-"hydra:method": [
+"apiContract:method": [
 {
 "@value": "get"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "Returns the permission ID for an email address."
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#354/source-map",
+"@id": "#369/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -8003,7 +8050,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -8015,7 +8062,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#354"
+"@value": "amf://id#369"
 }
 ],
 "sourcemaps:value": [
@@ -8029,41 +8076,41 @@
 ]
 }
 ],
-"raml-http:parameter": [
+"apiContract:parameter": [
 {
-"@id": "#355",
+"@id": "#370",
 "@type": [
-"raml-http:Parameter",
+"apiContract:Parameter",
 "doc:DomainElement"
 ],
-"schema-org:name": [
+"core:name": [
 {
 "@value": "email"
 }
 ],
-"raml-http:paramName": [
+"apiContract:paramName": [
 {
 "@value": "email"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "The email address for which to return a permission ID"
 }
 ],
-"hydra:required": [
+"apiContract:required": [
 {
 "@value": true
 }
 ],
-"raml-http:binding": [
+"apiContract:binding": [
 {
 "@value": "path"
 }
 ],
-"raml-http:schema": [
+"apiContract:schema": [
 {
-"@id": "#356",
+"@id": "#371",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -8080,14 +8127,14 @@
 "@value": "schema"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "The email address for which to return a permission ID"
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#356/source-map",
+"@id": "#371/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -8095,7 +8142,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#356"
+"@value": "amf://id#371"
 }
 ],
 "sourcemaps:value": [
@@ -8109,7 +8156,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -8121,7 +8168,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#356"
+"@value": "amf://id#371"
 }
 ],
 "sourcemaps:value": [
@@ -8149,7 +8196,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#355/source-map",
+"@id": "#370/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -8157,7 +8204,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -8169,7 +8216,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#355"
+"@value": "amf://id#370"
 }
 ],
 "sourcemaps:value": [
@@ -8185,7 +8232,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#353/source-map",
+"@id": "#368/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -8193,7 +8240,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "raml-http:parameter"
+"@value": "apiContract:parameter"
 }
 ],
 "sourcemaps:value": [
@@ -8205,7 +8252,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#353"
+"@value": "amf://id#368"
 }
 ],
 "sourcemaps:value": [
@@ -8219,41 +8266,41 @@
 ]
 },
 {
-"@id": "#357",
+"@id": "#372",
 "@type": [
-"raml-http:EndPoint",
+"apiContract:EndPoint",
 "doc:DomainElement"
 ],
-"raml-http:path": [
+"apiContract:path": [
 {
 "@value": "/apps"
 }
 ],
-"schema-org:name": [
+"core:name": [
 {
 "@value": "Apps"
 }
 ],
-"hydra:supportedOperation": [
+"apiContract:supportedOperation": [
 {
-"@id": "#358",
+"@id": "#373",
 "@type": [
-"hydra:Operation",
+"apiContract:Operation",
 "doc:DomainElement"
 ],
-"hydra:method": [
+"apiContract:method": [
 {
 "@value": "get"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "Lists a user's installed apps."
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#358/source-map",
+"@id": "#373/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -8261,7 +8308,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -8273,7 +8320,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#358"
+"@value": "amf://id#373"
 }
 ],
 "sourcemaps:value": [
@@ -8289,7 +8336,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#357/source-map",
+"@id": "#372/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -8297,7 +8344,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:name"
+"@value": "core:name"
 }
 ],
 "sourcemaps:value": [
@@ -8309,7 +8356,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#357"
+"@value": "amf://id#372"
 }
 ],
 "sourcemaps:value": [
@@ -8323,36 +8370,36 @@
 ]
 },
 {
-"@id": "#359",
+"@id": "#374",
 "@type": [
-"raml-http:EndPoint",
+"apiContract:EndPoint",
 "doc:DomainElement"
 ],
-"raml-http:path": [
+"apiContract:path": [
 {
 "@value": "/apps/{appId}"
 }
 ],
-"hydra:supportedOperation": [
+"apiContract:supportedOperation": [
 {
-"@id": "#360",
+"@id": "#375",
 "@type": [
-"hydra:Operation",
+"apiContract:Operation",
 "doc:DomainElement"
 ],
-"hydra:method": [
+"apiContract:method": [
 {
 "@value": "get"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "Gets a specific app."
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#360/source-map",
+"@id": "#375/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -8360,7 +8407,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -8372,7 +8419,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#360"
+"@value": "amf://id#375"
 }
 ],
 "sourcemaps:value": [
@@ -8386,41 +8433,41 @@
 ]
 }
 ],
-"raml-http:parameter": [
+"apiContract:parameter": [
 {
-"@id": "#361",
+"@id": "#376",
 "@type": [
-"raml-http:Parameter",
+"apiContract:Parameter",
 "doc:DomainElement"
 ],
-"schema-org:name": [
+"core:name": [
 {
 "@value": "appId"
 }
 ],
-"raml-http:paramName": [
+"apiContract:paramName": [
 {
 "@value": "appId"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "The ID of the app."
 }
 ],
-"hydra:required": [
+"apiContract:required": [
 {
 "@value": true
 }
 ],
-"raml-http:binding": [
+"apiContract:binding": [
 {
 "@value": "path"
 }
 ],
-"raml-http:schema": [
+"apiContract:schema": [
 {
-"@id": "#362",
+"@id": "#377",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -8437,14 +8484,14 @@
 "@value": "schema"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "The ID of the app."
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#362/source-map",
+"@id": "#377/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -8452,7 +8499,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#362"
+"@value": "amf://id#377"
 }
 ],
 "sourcemaps:value": [
@@ -8466,7 +8513,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -8478,7 +8525,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#362"
+"@value": "amf://id#377"
 }
 ],
 "sourcemaps:value": [
@@ -8506,7 +8553,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#361/source-map",
+"@id": "#376/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -8514,7 +8561,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -8526,7 +8573,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#361"
+"@value": "amf://id#376"
 }
 ],
 "sourcemaps:value": [
@@ -8542,7 +8589,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#359/source-map",
+"@id": "#374/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -8550,7 +8597,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#359"
+"@value": "amf://id#374"
 }
 ],
 "sourcemaps:value": [
@@ -8564,7 +8611,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "raml-http:parameter"
+"@value": "apiContract:parameter"
 }
 ],
 "sourcemaps:value": [
@@ -8576,7 +8623,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#359"
+"@value": "amf://id#374"
 }
 ],
 "sourcemaps:value": [
@@ -8590,36 +8637,36 @@
 ]
 },
 {
-"@id": "#363",
+"@id": "#378",
 "@type": [
-"raml-http:EndPoint",
+"apiContract:EndPoint",
 "doc:DomainElement"
 ],
-"raml-http:path": [
+"apiContract:path": [
 {
 "@value": "/channels/stop"
 }
 ],
-"hydra:supportedOperation": [
+"apiContract:supportedOperation": [
 {
-"@id": "#364",
+"@id": "#379",
 "@type": [
-"hydra:Operation",
+"apiContract:Operation",
 "doc:DomainElement"
 ],
-"hydra:method": [
+"apiContract:method": [
 {
 "@value": "post"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "Stop watching for changes to a resource.\nIf successful, this method returns an empty response body.\n"
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#364/source-map",
+"@id": "#379/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -8627,7 +8674,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -8639,7 +8686,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#364"
+"@value": "amf://id#379"
 }
 ],
 "sourcemaps:value": [
@@ -8655,668 +8702,6 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#363/source-map",
-"@type": [
-"sourcemaps:SourceMap"
-],
-"sourcemaps:lexical": [
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#363"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(353,0)-(358,0)]"
-}
-]
-}
-]
-}
-]
-},
-{
-"@id": "#365",
-"@type": [
-"raml-http:EndPoint",
-"doc:DomainElement"
-],
-"raml-http:path": [
-{
-"@value": "/teamdrives"
-}
-],
-"schema-org:name": [
-{
-"@value": "Teamdrives"
-}
-],
-"hydra:supportedOperation": [
-{
-"@id": "#366",
-"@type": [
-"hydra:Operation",
-"doc:DomainElement"
-],
-"hydra:method": [
-{
-"@value": "post"
-}
-],
-"schema-org:name": [
-{
-"@value": "insert"
-}
-],
-"schema-org:description": [
-{
-"@value": "Creates a new Team Drive."
-}
-],
-"sourcemaps:sources": [
-{
-"@id": "#366/source-map",
-"@type": [
-"sourcemaps:SourceMap"
-],
-"sourcemaps:lexical": [
-{
-"sourcemaps:element": [
-{
-"@value": "schema-org:description"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(362,4)-(364,0)]"
-}
-]
-},
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#366"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(360,2)-(364,0)]"
-}
-]
-},
-{
-"sourcemaps:element": [
-{
-"@value": "schema-org:name"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(361,4)-(362,0)]"
-}
-]
-}
-]
-}
-]
-},
-{
-"@id": "#367",
-"@type": [
-"hydra:Operation",
-"doc:DomainElement"
-],
-"hydra:method": [
-{
-"@value": "get"
-}
-],
-"schema-org:name": [
-{
-"@value": "list"
-}
-],
-"schema-org:description": [
-{
-"@value": "Lists the user's Team Drives."
-}
-],
-"sourcemaps:sources": [
-{
-"@id": "#367/source-map",
-"@type": [
-"sourcemaps:SourceMap"
-],
-"sourcemaps:lexical": [
-{
-"sourcemaps:element": [
-{
-"@value": "schema-org:description"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(366,4)-(367,0)]"
-}
-]
-},
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#367"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(364,2)-(367,0)]"
-}
-]
-},
-{
-"sourcemaps:element": [
-{
-"@value": "schema-org:name"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(365,4)-(366,0)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"sourcemaps:sources": [
-{
-"@id": "#365/source-map",
-"@type": [
-"sourcemaps:SourceMap"
-],
-"sourcemaps:lexical": [
-{
-"sourcemaps:element": [
-{
-"@value": "schema-org:name"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(359,2)-(360,0)]"
-}
-]
-},
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#365"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(358,0)-(378,0)]"
-}
-]
-}
-]
-}
-]
-},
-{
-"@id": "#368",
-"@type": [
-"raml-http:EndPoint",
-"doc:DomainElement"
-],
-"raml-http:path": [
-{
-"@value": "/teamdrives/{teamDriveId}"
-}
-],
-"hydra:supportedOperation": [
-{
-"@id": "#369",
-"@type": [
-"hydra:Operation",
-"doc:DomainElement"
-],
-"hydra:method": [
-{
-"@value": "delete"
-}
-],
-"schema-org:description": [
-{
-"@value": "Permanently deletes a Team Drive for which the user is an organizer. The Team Drive cannot contain any untrashed items.\n"
-}
-],
-"sourcemaps:sources": [
-{
-"@id": "#369/source-map",
-"@type": [
-"sourcemaps:SourceMap"
-],
-"sourcemaps:lexical": [
-{
-"sourcemaps:element": [
-{
-"@value": "schema-org:description"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(372,6)-(374,0)]"
-}
-]
-},
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#369"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(371,4)-(374,0)]"
-}
-]
-}
-]
-}
-]
-},
-{
-"@id": "#370",
-"@type": [
-"hydra:Operation",
-"doc:DomainElement"
-],
-"hydra:method": [
-{
-"@value": "get"
-}
-],
-"schema-org:description": [
-{
-"@value": "Gets a Team Drive's metadata by ID."
-}
-],
-"sourcemaps:sources": [
-{
-"@id": "#370/source-map",
-"@type": [
-"sourcemaps:SourceMap"
-],
-"sourcemaps:lexical": [
-{
-"sourcemaps:element": [
-{
-"@value": "schema-org:description"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(375,6)-(376,0)]"
-}
-]
-},
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#370"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(374,4)-(376,0)]"
-}
-]
-}
-]
-}
-]
-},
-{
-"@id": "#371",
-"@type": [
-"hydra:Operation",
-"doc:DomainElement"
-],
-"hydra:method": [
-{
-"@value": "put"
-}
-],
-"schema-org:description": [
-{
-"@value": "Updates a Team Drive's metadata"
-}
-],
-"sourcemaps:sources": [
-{
-"@id": "#371/source-map",
-"@type": [
-"sourcemaps:SourceMap"
-],
-"sourcemaps:lexical": [
-{
-"sourcemaps:element": [
-{
-"@value": "schema-org:description"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(377,6)-(378,0)]"
-}
-]
-},
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#371"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(376,4)-(378,0)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"raml-http:parameter": [
-{
-"@id": "#372",
-"@type": [
-"raml-http:Parameter",
-"doc:DomainElement"
-],
-"schema-org:name": [
-{
-"@value": "teamDriveId"
-}
-],
-"raml-http:paramName": [
-{
-"@value": "teamDriveId"
-}
-],
-"schema-org:description": [
-{
-"@value": "The ID of the Team Drive"
-}
-],
-"hydra:required": [
-{
-"@value": true
-}
-],
-"raml-http:binding": [
-{
-"@value": "path"
-}
-],
-"raml-http:schema": [
-{
-"@id": "#373",
-"@type": [
-"raml-shapes:ScalarShape",
-"shacl:Shape",
-"raml-shapes:Shape",
-"doc:DomainElement"
-],
-"shacl:datatype": [
-{
-"@id": "http://www.w3.org/2001/XMLSchema#string"
-}
-],
-"shacl:name": [
-{
-"@value": "schema"
-}
-],
-"schema-org:description": [
-{
-"@value": "The ID of the Team Drive"
-}
-],
-"sourcemaps:sources": [
-{
-"@id": "#373/source-map",
-"@type": [
-"sourcemaps:SourceMap"
-],
-"sourcemaps:lexical": [
-{
-"sourcemaps:element": [
-{
-"@value": "schema-org:description"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(370,8)-(371,0)]"
-}
-]
-},
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#373"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(369,6)-(371,0)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"sourcemaps:sources": [
-{
-"@id": "#372/source-map",
-"@type": [
-"sourcemaps:SourceMap"
-],
-"sourcemaps:lexical": [
-{
-"sourcemaps:element": [
-{
-"@value": "schema-org:description"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(370,8)-(371,0)]"
-}
-]
-},
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#372"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(369,6)-(371,0)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"sourcemaps:sources": [
-{
-"@id": "#368/source-map",
-"@type": [
-"sourcemaps:SourceMap"
-],
-"sourcemaps:parent-end-point": [
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#368"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "file://test/demo-api/demo-api.raml#/web-api/end-points/%2Fteamdrives"
-}
-]
-}
-],
-"sourcemaps:lexical": [
-{
-"sourcemaps:element": [
-{
-"@value": "raml-http:parameter"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(368,18)-(371,0)]"
-}
-]
-},
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#368"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(367,2)-(378,0)]"
-}
-]
-}
-]
-}
-]
-},
-{
-"@id": "#374",
-"@type": [
-"raml-http:EndPoint",
-"doc:DomainElement"
-],
-"raml-http:path": [
-{
-"@value": "/typeFromLibraryEndpoint"
-}
-],
-"hydra:supportedOperation": [
-{
-"@id": "#375",
-"@type": [
-"hydra:Operation",
-"doc:DomainElement"
-],
-"hydra:method": [
-{
-"@value": "post"
-}
-],
-"hydra:expects": [
-{
-"@id": "#376",
-"@type": [
-"raml-http:Request",
-"doc:DomainElement"
-],
-"raml-http:payload": [
-{
-"@id": "#377",
-"@type": [
-"raml-http:Payload",
-"doc:DomainElement"
-],
-"raml-http:mediaType": [
-{
-"@value": "application/json"
-}
-],
-"raml-http:schema": [
-{
-"@id": "#27/linked_4",
-"@type": [
-"shacl:NodeShape",
-"shacl:Shape",
-"raml-shapes:Shape",
-"doc:DomainElement"
-],
-"doc:link-target": [
-{
-"@id": "#27"
-}
-],
-"doc:link-label": [
-{
-"@value": "TypeFromLibray"
-}
-]
-}
-],
-"sourcemaps:sources": [
-{
-"@id": "#377/source-map",
-"@type": [
-"sourcemaps:SourceMap"
-],
-"sourcemaps:lexical": [
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#377"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(380,4)-(382,0)]"
-}
-]
-}
-]
-}
-]
-}
-]
-}
-],
-"hydra:returns": [
-{
-"@id": "#378",
-"@type": [
-"raml-http:Response",
-"doc:DomainElement"
-],
-"schema-org:name": [
-{
-"@value": "200"
-}
-],
-"hydra:statusCode": [
-{
-"@value": "200"
-}
-],
-"raml-http:payload": [],
-"sourcemaps:sources": [
-{
 "@id": "#378/source-map",
 "@type": [
 "sourcemaps:SourceMap"
@@ -9330,67 +8715,7 @@
 ],
 "sourcemaps:value": [
 {
-"@value": "[(383,6)-(384,0)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"sourcemaps:sources": [
-{
-"@id": "#375/source-map",
-"@type": [
-"sourcemaps:SourceMap"
-],
-"sourcemaps:lexical": [
-{
-"sourcemaps:element": [
-{
-"@value": "hydra:returns"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(382,4)-(384,0)]"
-}
-]
-},
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#375"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(379,2)-(384,0)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"sourcemaps:sources": [
-{
-"@id": "#374/source-map",
-"@type": [
-"sourcemaps:SourceMap"
-],
-"sourcemaps:lexical": [
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#374"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(378,0)-(384,0)]"
+"@value": "[(353,0)-(358,0)]"
 }
 ]
 }
@@ -9398,67 +8723,110 @@
 }
 ]
 },
-{
-"@id": "#379",
-"@type": [
-"raml-http:EndPoint",
-"doc:DomainElement"
-],
-"raml-http:path": [
-{
-"@value": "/referenceId"
-}
-],
-"hydra:supportedOperation": [
 {
 "@id": "#380",
 "@type": [
-"hydra:Operation",
+"apiContract:EndPoint",
 "doc:DomainElement"
 ],
-"hydra:method": [
+"apiContract:path": [
+{
+"@value": "/teamdrives"
+}
+],
+"core:name": [
+{
+"@value": "Teamdrives"
+}
+],
+"apiContract:supportedOperation": [
+{
+"@id": "#381",
+"@type": [
+"apiContract:Operation",
+"doc:DomainElement"
+],
+"apiContract:method": [
 {
 "@value": "post"
 }
 ],
-"hydra:expects": [
+"core:name": [
 {
-"@id": "#381",
-"@type": [
-"raml-http:Request",
-"doc:DomainElement"
+"@value": "insert"
+}
 ],
-"raml-http:payload": [
+"core:description": [
+{
+"@value": "Creates a new Team Drive."
+}
+],
+"sourcemaps:sources": [
+{
+"@id": "#381/source-map",
+"@type": [
+"sourcemaps:SourceMap"
+],
+"sourcemaps:lexical": [
+{
+"sourcemaps:element": [
+{
+"@value": "core:description"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(362,4)-(364,0)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#381"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(360,2)-(364,0)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "core:name"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(361,4)-(362,0)]"
+}
+]
+}
+]
+}
+]
+},
 {
 "@id": "#382",
 "@type": [
-"raml-http:Payload",
+"apiContract:Operation",
 "doc:DomainElement"
 ],
-"raml-http:mediaType": [
+"apiContract:method": [
 {
-"@value": "application/json"
+"@value": "get"
 }
 ],
-"raml-http:schema": [
+"core:name": [
 {
-"@id": "#128/linked_4",
-"@type": [
-"shacl:NodeShape",
-"shacl:Shape",
-"raml-shapes:Shape",
-"doc:DomainElement"
-],
-"doc:link-target": [
-{
-"@id": "#128"
+"@value": "list"
 }
 ],
-"doc:link-label": [
+"core:description": [
 {
-"@value": "SchemaPerson"
-}
-]
+"@value": "Lists the user's Team Drives."
 }
 ],
 "sourcemaps:sources": [
@@ -9471,14 +8839,36 @@
 {
 "sourcemaps:element": [
 {
+"@value": "core:description"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(366,4)-(367,0)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
 "@value": "amf://id#382"
 }
 ],
 "sourcemaps:value": [
 {
-"@value": "[(387,6)-(389,0)]"
+"@value": "[(364,2)-(367,0)]"
 }
 ]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "core:name"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(365,4)-(366,0)]"
 }
 ]
 }
@@ -9497,7 +8887,708 @@
 {
 "sourcemaps:element": [
 {
+"@value": "core:name"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(359,2)-(360,0)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
 "@value": "amf://id#380"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(358,0)-(378,0)]"
+}
+]
+}
+]
+}
+]
+},
+{
+"@id": "#383",
+"@type": [
+"apiContract:EndPoint",
+"doc:DomainElement"
+],
+"apiContract:path": [
+{
+"@value": "/teamdrives/{teamDriveId}"
+}
+],
+"apiContract:supportedOperation": [
+{
+"@id": "#384",
+"@type": [
+"apiContract:Operation",
+"doc:DomainElement"
+],
+"apiContract:method": [
+{
+"@value": "delete"
+}
+],
+"core:description": [
+{
+"@value": "Permanently deletes a Team Drive for which the user is an organizer. The Team Drive cannot contain any untrashed items.\n"
+}
+],
+"sourcemaps:sources": [
+{
+"@id": "#384/source-map",
+"@type": [
+"sourcemaps:SourceMap"
+],
+"sourcemaps:lexical": [
+{
+"sourcemaps:element": [
+{
+"@value": "core:description"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(372,6)-(374,0)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#384"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(371,4)-(374,0)]"
+}
+]
+}
+]
+}
+]
+},
+{
+"@id": "#385",
+"@type": [
+"apiContract:Operation",
+"doc:DomainElement"
+],
+"apiContract:method": [
+{
+"@value": "get"
+}
+],
+"core:description": [
+{
+"@value": "Gets a Team Drive's metadata by ID."
+}
+],
+"sourcemaps:sources": [
+{
+"@id": "#385/source-map",
+"@type": [
+"sourcemaps:SourceMap"
+],
+"sourcemaps:lexical": [
+{
+"sourcemaps:element": [
+{
+"@value": "core:description"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(375,6)-(376,0)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#385"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(374,4)-(376,0)]"
+}
+]
+}
+]
+}
+]
+},
+{
+"@id": "#386",
+"@type": [
+"apiContract:Operation",
+"doc:DomainElement"
+],
+"apiContract:method": [
+{
+"@value": "put"
+}
+],
+"core:description": [
+{
+"@value": "Updates a Team Drive's metadata"
+}
+],
+"sourcemaps:sources": [
+{
+"@id": "#386/source-map",
+"@type": [
+"sourcemaps:SourceMap"
+],
+"sourcemaps:lexical": [
+{
+"sourcemaps:element": [
+{
+"@value": "core:description"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(377,6)-(378,0)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#386"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(376,4)-(378,0)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"apiContract:parameter": [
+{
+"@id": "#387",
+"@type": [
+"apiContract:Parameter",
+"doc:DomainElement"
+],
+"core:name": [
+{
+"@value": "teamDriveId"
+}
+],
+"apiContract:paramName": [
+{
+"@value": "teamDriveId"
+}
+],
+"core:description": [
+{
+"@value": "The ID of the Team Drive"
+}
+],
+"apiContract:required": [
+{
+"@value": true
+}
+],
+"apiContract:binding": [
+{
+"@value": "path"
+}
+],
+"apiContract:schema": [
+{
+"@id": "#388",
+"@type": [
+"raml-shapes:ScalarShape",
+"shacl:Shape",
+"raml-shapes:Shape",
+"doc:DomainElement"
+],
+"shacl:datatype": [
+{
+"@id": "http://www.w3.org/2001/XMLSchema#string"
+}
+],
+"shacl:name": [
+{
+"@value": "schema"
+}
+],
+"core:description": [
+{
+"@value": "The ID of the Team Drive"
+}
+],
+"sourcemaps:sources": [
+{
+"@id": "#388/source-map",
+"@type": [
+"sourcemaps:SourceMap"
+],
+"sourcemaps:lexical": [
+{
+"sourcemaps:element": [
+{
+"@value": "core:description"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(370,8)-(371,0)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#388"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(369,6)-(371,0)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"sourcemaps:sources": [
+{
+"@id": "#387/source-map",
+"@type": [
+"sourcemaps:SourceMap"
+],
+"sourcemaps:lexical": [
+{
+"sourcemaps:element": [
+{
+"@value": "core:description"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(370,8)-(371,0)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#387"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(369,6)-(371,0)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"sourcemaps:sources": [
+{
+"@id": "#383/source-map",
+"@type": [
+"sourcemaps:SourceMap"
+],
+"sourcemaps:parent-end-point": [
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#383"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "file://test/demo-api/demo-api.raml#/web-api/end-points/%2Fteamdrives"
+}
+]
+}
+],
+"sourcemaps:lexical": [
+{
+"sourcemaps:element": [
+{
+"@value": "apiContract:parameter"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(368,18)-(371,0)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#383"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(367,2)-(378,0)]"
+}
+]
+}
+]
+}
+]
+},
+{
+"@id": "#389",
+"@type": [
+"apiContract:EndPoint",
+"doc:DomainElement"
+],
+"apiContract:path": [
+{
+"@value": "/typeFromLibraryEndpoint"
+}
+],
+"apiContract:supportedOperation": [
+{
+"@id": "#390",
+"@type": [
+"apiContract:Operation",
+"doc:DomainElement"
+],
+"apiContract:method": [
+{
+"@value": "post"
+}
+],
+"apiContract:expects": [
+{
+"@id": "#391",
+"@type": [
+"apiContract:Request",
+"doc:DomainElement"
+],
+"apiContract:payload": [
+{
+"@id": "#392",
+"@type": [
+"apiContract:Payload",
+"doc:DomainElement"
+],
+"apiContract:mediaType": [
+{
+"@value": "application/json"
+}
+],
+"apiContract:schema": [
+{
+"@id": "#29/linked_4",
+"@type": [
+"shacl:NodeShape",
+"shacl:Shape",
+"raml-shapes:Shape",
+"doc:DomainElement"
+],
+"doc:link-target": [
+{
+"@id": "#29"
+}
+],
+"doc:link-label": [
+{
+"@value": "TypeFromLibray"
+}
+]
+}
+],
+"sourcemaps:sources": [
+{
+"@id": "#392/source-map",
+"@type": [
+"sourcemaps:SourceMap"
+],
+"sourcemaps:lexical": [
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#392"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(380,4)-(382,0)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"sourcemaps:sources": [
+{
+"@id": "#391/source-map",
+"@type": [
+"sourcemaps:SourceMap"
+],
+"sourcemaps:lexical": [
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#391"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(380,0)-(384,0)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"apiContract:returns": [
+{
+"@id": "#393",
+"@type": [
+"apiContract:Response",
+"doc:DomainElement"
+],
+"core:name": [
+{
+"@value": "200"
+}
+],
+"apiContract:statusCode": [
+{
+"@value": "200"
+}
+],
+"apiContract:payload": [],
+"sourcemaps:sources": [
+{
+"@id": "#393/source-map",
+"@type": [
+"sourcemaps:SourceMap"
+],
+"sourcemaps:lexical": [
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#393"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(383,6)-(384,0)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"sourcemaps:sources": [
+{
+"@id": "#390/source-map",
+"@type": [
+"sourcemaps:SourceMap"
+],
+"sourcemaps:lexical": [
+{
+"sourcemaps:element": [
+{
+"@value": "apiContract:returns"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(382,4)-(384,0)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#390"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(379,2)-(384,0)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"sourcemaps:sources": [
+{
+"@id": "#389/source-map",
+"@type": [
+"sourcemaps:SourceMap"
+],
+"sourcemaps:lexical": [
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#389"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(378,0)-(384,0)]"
+}
+]
+}
+]
+}
+]
+},
+{
+"@id": "#394",
+"@type": [
+"apiContract:EndPoint",
+"doc:DomainElement"
+],
+"apiContract:path": [
+{
+"@value": "/referenceId"
+}
+],
+"apiContract:supportedOperation": [
+{
+"@id": "#395",
+"@type": [
+"apiContract:Operation",
+"doc:DomainElement"
+],
+"apiContract:method": [
+{
+"@value": "post"
+}
+],
+"apiContract:expects": [
+{
+"@id": "#396",
+"@type": [
+"apiContract:Request",
+"doc:DomainElement"
+],
+"apiContract:payload": [
+{
+"@id": "#397",
+"@type": [
+"apiContract:Payload",
+"doc:DomainElement"
+],
+"apiContract:mediaType": [
+{
+"@value": "application/json"
+}
+],
+"apiContract:schema": [
+{
+"@id": "#141/linked_4",
+"@type": [
+"shacl:NodeShape",
+"shacl:Shape",
+"raml-shapes:Shape",
+"doc:DomainElement"
+],
+"doc:link-target": [
+{
+"@id": "#141"
+}
+],
+"doc:link-label": [
+{
+"@value": "SchemaPerson"
+}
+]
+}
+],
+"sourcemaps:sources": [
+{
+"@id": "#397/source-map",
+"@type": [
+"sourcemaps:SourceMap"
+],
+"sourcemaps:lexical": [
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#397"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(387,6)-(389,0)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"sourcemaps:sources": [
+{
+"@id": "#396/source-map",
+"@type": [
+"sourcemaps:SourceMap"
+],
+"sourcemaps:lexical": [
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#396"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(386,0)-(389,0)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"sourcemaps:sources": [
+{
+"@id": "#395/source-map",
+"@type": [
+"sourcemaps:SourceMap"
+],
+"sourcemaps:lexical": [
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#395"
 }
 ],
 "sourcemaps:value": [
@@ -9513,7 +9604,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#379/source-map",
+"@id": "#394/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -9521,7 +9612,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#379"
+"@value": "amf://id#394"
 }
 ],
 "sourcemaps:value": [
@@ -9537,7 +9628,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#202/source-map",
+"@id": "#216/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -9545,7 +9636,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#202"
+"@value": "amf://id#216"
 }
 ],
 "sourcemaps:value": [
@@ -9559,7 +9650,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:documentation"
+"@value": "core:documentation"
 }
 ],
 "sourcemaps:value": [
@@ -9571,7 +9662,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "raml-http:scheme"
+"@value": "apiContract:scheme"
 }
 ],
 "sourcemaps:value": [
@@ -9583,7 +9674,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:name"
+"@value": "core:name"
 }
 ],
 "sourcemaps:value": [
@@ -9595,7 +9686,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#202"
+"@value": "amf://id#216"
 }
 ],
 "sourcemaps:value": [
@@ -9607,7 +9698,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "raml-http:server"
+"@value": "apiContract:server"
 }
 ],
 "sourcemaps:value": [
@@ -9619,7 +9710,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:version"
+"@value": "core:version"
 }
 ],
 "sourcemaps:value": [
@@ -9687,7 +9778,7 @@
 "@value": "width"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "Width of the shape.\n"
 }
@@ -9716,7 +9807,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -9818,7 +9909,7 @@
 "@value": "height"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "Height of the shape.\n"
 }
@@ -9847,7 +9938,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -9949,7 +10040,7 @@
 "@value": "unit?"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "A unit that describes the dimension. It can be, for example, `px` for\npixels, `pt` for points, `%` for percentage.\n"
 }
@@ -9958,7 +10049,9 @@
 {
 "@id": "#9",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -10055,7 +10148,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -10108,16 +10201,23 @@
 "@value": "dimension"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "A dimmensions of an object like image.\n"
 }
 ],
-"doc:examples": [
+"apiContract:examples": [
 {
 "@id": "#10",
 "@type": [
-"doc:Example",
+"apiContract:NamedExamples",
+"doc:DomainElement"
+],
+"apiContract:examples": [
+{
+"@id": "#11",
+"@type": [
+"apiContract:Example",
 "doc:DomainElement"
 ],
 "doc:strict": [
@@ -10127,55 +10227,23 @@
 ],
 "doc:structuredValue": [
 {
-"@id": "#10",
+"@id": "#11",
 "@type": [
-"data:Object"
+"data:Object",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:height": [
 {
-"@id": "#11",
+"@id": "#12",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
 "@value": "160",
-"@type": "xsd:integer"
-}
-],
-"sourcemaps:sources": [
-{
-"@id": "#11/source-map",
-"@type": [
-"sourcemaps:SourceMap"
-],
-"sourcemaps:lexical": [
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#11"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(24,10)-(24,13)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"data:width": [
-{
-"@id": "#12",
-"@type": [
-"data:Scalar"
-],
-"data:value": [
-{
-"@value": "200",
 "@type": "xsd:integer"
 }
 ],
@@ -10194,6 +10262,44 @@
 ],
 "sourcemaps:value": [
 {
+"@value": "[(24,10)-(24,13)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"data:width": [
+{
+"@id": "#13",
+"@type": [
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
+],
+"data:value": [
+{
+"@value": "200",
+"@type": "xsd:integer"
+}
+],
+"sourcemaps:sources": [
+{
+"@id": "#13/source-map",
+"@type": [
+"sourcemaps:SourceMap"
+],
+"sourcemaps:lexical": [
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#13"
+}
+],
+"sourcemaps:value": [
+{
 "@value": "[(23,9)-(23,12)]"
 }
 ]
@@ -10205,7 +10311,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#10/source-map",
+"@id": "#11/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -10213,12 +10319,36 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#10"
+"@value": "data:width"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(23,9)-(23,12)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#11"
 }
 ],
 "sourcemaps:value": [
 {
 "@value": "[(23,0)-(25,0)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "data:height"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(24,10)-(24,13)]"
 }
 ]
 }
@@ -10227,7 +10357,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#10"
+"@value": "amf://id#11"
 }
 ],
 "sourcemaps:value": [
@@ -10248,7 +10378,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#10/source-map",
+"@id": "#11/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -10282,12 +10412,14 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#10"
+"@value": "amf://id#11"
 }
 ],
 "sourcemaps:value": [
 {
 "@value": "[(22,0)-(25,0)]"
+}
+]
 }
 ]
 }
@@ -10320,7 +10452,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -10384,7 +10516,7 @@
 ]
 },
 {
-"@id": "#13",
+"@id": "#14",
 "@type": [
 "doc:ExternalFragment",
 "doc:Fragment",
@@ -10392,7 +10524,7 @@
 ],
 "doc:encodes": [
 {
-"@id": "#14",
+"@id": "#15",
 "@type": [
 "doc:ExternalDomainElement",
 "doc:DomainElement"
@@ -10402,7 +10534,7 @@
 "@value": "{\n  \"$id\": \"http://example.com/example.json\",\n  \"type\": \"object\",\n  \"definitions\": {},\n  \"$schema\": \"http://json-schema.org/draft-07/schema#\",\n  \"properties\": {\n    \"id\": {\n      \"$id\": \"/properties/id\",\n      \"type\": \"string\",\n      \"title\": \"The Id Schema \",\n      \"default\": \"\",\n      \"examples\": [\n        \"R34fg663H9KW9MMSKISI\"\n      ]\n    },\n    \"name\": {\n      \"$id\": \"/properties/name\",\n      \"type\": \"string\",\n      \"title\": \"The Name Schema \",\n      \"default\": \"\",\n      \"examples\": [\n        \"Pawel Psztyc\"\n      ]\n    },\n    \"birthday\": {\n      \"$id\": \"/properties/birthday\",\n      \"type\": \"string\",\n      \"title\": \"The Birthday Schema \",\n      \"default\": \"\",\n      \"examples\": [\n        \"1983-10-20\"\n      ]\n    },\n    \"gender\": {\n      \"$id\": \"/properties/gender\",\n      \"type\": \"string\",\n      \"title\": \"The Gender Schema \",\n      \"default\": \"\",\n      \"examples\": [\n        \"male\"\n      ]\n    },\n    \"url\": {\n      \"$id\": \"/properties/url\",\n      \"type\": \"string\",\n      \"title\": \"The Url Schema \",\n      \"default\": \"\",\n      \"examples\": [\n        \"https://domain.com/profile/pawel.psztyc\"\n      ]\n    },\n    \"image\": {\n      \"$id\": \"/properties/image\",\n      \"type\": \"object\",\n      \"properties\": {\n        \"url\": {\n          \"$id\": \"/properties/image/properties/url\",\n          \"type\": \"string\",\n          \"title\": \"The Url Schema \",\n          \"default\": \"\",\n          \"examples\": [\n            \"https://domain.com/profile/pawel.psztyc/image\"\n          ]\n        },\n        \"thumb\": {\n          \"$id\": \"/properties/image/properties/thumb\",\n          \"type\": \"string\",\n          \"title\": \"The Thumb Schema \",\n          \"default\": \"\",\n          \"examples\": [\n            \"https://domain.com/profile/pawel.psztyc/image/thumb\"\n          ]\n        }\n      }\n    },\n    \"tagline\": {\n      \"$id\": \"/properties/tagline\",\n      \"type\": \"string\",\n      \"title\": \"The Tagline Schema \",\n      \"default\": \"\",\n      \"examples\": [\n        \"Some text about me.\"\n      ]\n    },\n    \"language\": {\n      \"$id\": \"/properties/language\",\n      \"type\": \"string\",\n      \"title\": \"The Language Schema \",\n      \"default\": \"\",\n      \"examples\": [\n        \"en_GB\"\n      ]\n    },\n    \"etag\": {\n      \"$id\": \"/properties/etag\",\n      \"type\": \"string\",\n      \"title\": \"The Etag Schema \",\n      \"default\": \"\",\n      \"examples\": [\n        \"W\\\\244m4n5kj3gbn2nj4k4n4\"\n      ]\n    }\n  }\n}\n"
 }
 ],
-"raml-http:mediaType": [
+"core:mediaType": [
 {
 "@value": "application/json"
 }
@@ -10411,7 +10543,7 @@
 ]
 },
 {
-"@id": "#15",
+"@id": "#16",
 "@type": [
 "doc:ExternalFragment",
 "doc:Fragment",
@@ -10419,7 +10551,7 @@
 ],
 "doc:encodes": [
 {
-"@id": "#16",
+"@id": "#17",
 "@type": [
 "doc:ExternalDomainElement",
 "doc:DomainElement"
@@ -10429,7 +10561,7 @@
 "@value": "{\n  \"id\": \"R34fg663H9KW9MMSKISI\",\n  \"name\": \"Pawel Psztyc\",\n  \"birthday\": \"1983-10-20\",\n  \"gender\": \"male\",\n  \"url\": \"https://domain.com/profile/pawel.psztyc\",\n  \"image\": {\n    \"url\": \"https://domain.com/profile/pawel.psztyc/image\",\n    \"thumb\": \"https://domain.com/profile/pawel.psztyc/image/thumb\"\n  },\n  \"tagline\": \"Some text about me.\",\n  \"language\": \"en_GB\",\n  \"etag\": \"W\\\\244m4n5kj3gbn2nj4k4n4\"\n}\n"
 }
 ],
-"raml-http:mediaType": [
+"core:mediaType": [
 {
 "@value": "application/json"
 }
@@ -10438,7 +10570,7 @@
 ]
 },
 {
-"@id": "#17",
+"@id": "#18",
 "@type": [
 "doc:DataType",
 "doc:Fragment",
@@ -10446,7 +10578,7 @@
 ],
 "doc:encodes": [
 {
-"@id": "#18",
+"@id": "#19",
 "@type": [
 "shacl:NodeShape",
 "shacl:Shape",
@@ -10460,7 +10592,7 @@
 ],
 "shacl:property": [
 {
-"@id": "#19",
+"@id": "#20",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -10473,7 +10605,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#20",
+"@id": "#21",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -10490,14 +10622,14 @@
 "@value": "url"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "The URL of the image.\nTo resize the image and crop it to a square, append the query string **?sz=x**, where x is the dimension in pixels of each side.\n"
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#20/source-map",
+"@id": "#21/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -10505,7 +10637,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#20"
+"@value": "amf://id#21"
 }
 ],
 "sourcemaps:value": [
@@ -10519,7 +10651,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -10531,7 +10663,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#20"
+"@value": "amf://id#21"
 }
 ],
 "sourcemaps:value": [
@@ -10569,7 +10701,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#19/source-map",
+"@id": "#20/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -10577,7 +10709,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#19"
+"@value": "amf://id#20"
 }
 ],
 "sourcemaps:value": [
@@ -10591,7 +10723,7 @@
 ]
 },
 {
-"@id": "#21",
+"@id": "#22",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -10604,7 +10736,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#22",
+"@id": "#23",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -10621,19 +10753,19 @@
 "@value": "thumb"
 }
 ],
-"schema-org:name": [
+"core:name": [
 {
 "@value": "Thumbnail"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "An URL to the thumbnail of the image. Thumbnails are 60x60px cropped images of the original image.\n"
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#22/source-map",
+"@id": "#23/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -10641,7 +10773,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#22"
+"@value": "amf://id#23"
 }
 ],
 "sourcemaps:value": [
@@ -10655,7 +10787,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -10679,7 +10811,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#22"
+"@value": "amf://id#23"
 }
 ],
 "sourcemaps:value": [
@@ -10691,7 +10823,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:name"
+"@value": "core:name"
 }
 ],
 "sourcemaps:value": [
@@ -10717,7 +10849,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#21/source-map",
+"@id": "#22/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -10725,7 +10857,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#21"
+"@value": "amf://id#22"
 }
 ],
 "sourcemaps:value": [
@@ -10744,16 +10876,23 @@
 "@value": "amf_inline_type_2"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "An image object representing an image object strored in the file store.\nThe image can be only included in the response. It has no effect if the Image appear in the\nrequest. Endpoint handles image creation on it's own and clients can't process images\nexcept of sending image data.\n"
 }
 ],
-"doc:examples": [
+"apiContract:examples": [
 {
-"@id": "#23",
+"@id": "#24",
 "@type": [
-"doc:Example",
+"apiContract:NamedExamples",
+"doc:DomainElement"
+],
+"apiContract:examples": [
+{
+"@id": "#25",
+"@type": [
+"apiContract:Example",
 "doc:DomainElement"
 ],
 "doc:strict": [
@@ -10763,15 +10902,19 @@
 ],
 "doc:structuredValue": [
 {
-"@id": "#23",
+"@id": "#25",
 "@type": [
-"data:Object"
+"data:Object",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:thumb": [
 {
-"@id": "#24",
+"@id": "#26",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -10781,7 +10924,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#24/source-map",
+"@id": "#26/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -10789,7 +10932,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#24"
+"@value": "amf://id#26"
 }
 ],
 "sourcemaps:value": [
@@ -10805,9 +10948,11 @@
 ],
 "data:url": [
 {
-"@id": "#25",
+"@id": "#27",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -10817,7 +10962,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#25/source-map",
+"@id": "#27/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -10825,7 +10970,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#25"
+"@value": "amf://id#27"
 }
 ],
 "sourcemaps:value": [
@@ -10841,7 +10986,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#23/source-map",
+"@id": "#25/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -10849,12 +10994,36 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#23"
+"@value": "data:url"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(22,7)-(22,52)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#25"
 }
 ],
 "sourcemaps:value": [
 {
 "@value": "[(22,0)-(24,0)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "data:thumb"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(23,9)-(23,60)]"
 }
 ]
 }
@@ -10863,7 +11032,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#23"
+"@value": "amf://id#25"
 }
 ],
 "sourcemaps:value": [
@@ -10884,7 +11053,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#23/source-map",
+"@id": "#25/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -10918,7 +11087,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#23"
+"@value": "amf://id#25"
 }
 ],
 "sourcemaps:value": [
@@ -10931,10 +11100,12 @@
 }
 ]
 }
+]
+}
 ],
 "sourcemaps:sources": [
 {
-"@id": "#18/source-map",
+"@id": "#19/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -10942,7 +11113,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#18"
+"@value": "amf://id#19"
 }
 ],
 "sourcemaps:value": [
@@ -10956,7 +11127,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#18"
+"@value": "amf://id#19"
 }
 ],
 "sourcemaps:value": [
@@ -10970,7 +11141,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -10982,7 +11153,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#18"
+"@value": "amf://id#19"
 }
 ],
 "sourcemaps:value": [
@@ -10996,7 +11167,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#18"
+"@value": "amf://id#19"
 }
 ],
 "sourcemaps:value": [
@@ -11012,7 +11183,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#17/source-map",
+"@id": "#18/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -11020,7 +11191,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#17"
+"@value": "amf://id#18"
 }
 ],
 "sourcemaps:value": [
@@ -11034,7 +11205,7 @@
 ]
 },
 {
-"@id": "#26",
+"@id": "#28",
 "@type": [
 "doc:Module",
 "doc:Unit"
@@ -11042,7 +11213,7 @@
 "doc:declares": [
 [
 {
-"@id": "#27/linked_5",
+"@id": "#29/linked_5",
 "@type": [
 "shacl:NodeShape",
 "shacl:Shape",
@@ -11051,7 +11222,7 @@
 ],
 "doc:link-target": [
 {
-"@id": "#27"
+"@id": "#29"
 }
 ],
 "doc:link-label": [
@@ -11069,7 +11240,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#26/source-map",
+"@id": "#28/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -11077,7 +11248,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#26"
+"@value": "amf://id#28"
 }
 ],
 "sourcemaps:value": [
@@ -11103,7 +11274,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#26"
+"@value": "amf://id#28"
 }
 ],
 "sourcemaps:value": [
@@ -11117,7 +11288,7 @@
 ]
 },
 {
-"@id": "#30",
+"@id": "#32",
 "@type": [
 "doc:DataType",
 "doc:Fragment",
@@ -11125,7 +11296,7 @@
 ],
 "doc:encodes": [
 {
-"@id": "#31",
+"@id": "#37",
 "@type": [
 "shacl:NodeShape",
 "shacl:Shape",
@@ -11139,7 +11310,7 @@
 ],
 "shacl:property": [
 {
-"@id": "#32",
+"@id": "#38",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -11152,7 +11323,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#33",
+"@id": "#39",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -11169,14 +11340,14 @@
 "@value": "favouriteTime"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "The person's favourite time of day"
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#33/source-map",
+"@id": "#39/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -11184,7 +11355,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#33"
+"@value": "amf://id#39"
 }
 ],
 "sourcemaps:value": [
@@ -11198,7 +11369,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -11210,7 +11381,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#33"
+"@value": "amf://id#39"
 }
 ],
 "sourcemaps:value": [
@@ -11248,7 +11419,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#32/source-map",
+"@id": "#38/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -11256,7 +11427,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#32"
+"@value": "amf://id#38"
 }
 ],
 "sourcemaps:value": [
@@ -11270,7 +11441,7 @@
 ]
 },
 {
-"@id": "#34",
+"@id": "#40",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -11283,7 +11454,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#35",
+"@id": "#41",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -11315,16 +11486,23 @@
 "@value": "favouriteNumber"
 }
 ],
-"schema-org:name": [
+"core:name": [
 {
 "@value": "Favourite number"
 }
 ],
-"doc:examples": [
+"apiContract:examples": [
 {
-"@id": "#36",
+"@id": "#42",
 "@type": [
-"doc:Example",
+"apiContract:NamedExamples",
+"doc:DomainElement"
+],
+"apiContract:examples": [
+{
+"@id": "#43",
+"@type": [
+"apiContract:Example",
 "doc:DomainElement"
 ],
 "doc:strict": [
@@ -11334,9 +11512,11 @@
 ],
 "doc:structuredValue": [
 {
-"@id": "#36",
+"@id": "#43",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -11346,7 +11526,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#36/source-map",
+"@id": "#43/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -11354,7 +11534,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#36"
+"@value": "amf://id#43"
 }
 ],
 "sourcemaps:value": [
@@ -11375,7 +11555,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#36/source-map",
+"@id": "#43/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -11409,7 +11589,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#36"
+"@value": "amf://id#43"
 }
 ],
 "sourcemaps:value": [
@@ -11422,10 +11602,12 @@
 }
 ]
 }
+]
+}
 ],
 "sourcemaps:sources": [
 {
-"@id": "#35/source-map",
+"@id": "#41/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -11433,7 +11615,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#35"
+"@value": "amf://id#41"
 }
 ],
 "sourcemaps:value": [
@@ -11447,7 +11629,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:name"
+"@value": "core:name"
 }
 ],
 "sourcemaps:value": [
@@ -11483,7 +11665,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#35"
+"@value": "amf://id#41"
 }
 ],
 "sourcemaps:value": [
@@ -11533,7 +11715,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#34/source-map",
+"@id": "#40/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -11553,7 +11735,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#34"
+"@value": "amf://id#40"
 }
 ],
 "sourcemaps:value": [
@@ -11567,7 +11749,7 @@
 ]
 },
 {
-"@id": "#37",
+"@id": "#44",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -11580,7 +11762,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#38",
+"@id": "#45",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -11599,9 +11781,11 @@
 ],
 "shacl:defaultValue": [
 {
-"@id": "#39",
+"@id": "#46",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -11611,7 +11795,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#39/source-map",
+"@id": "#46/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -11619,7 +11803,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#39"
+"@value": "amf://id#46"
 }
 ],
 "sourcemaps:value": [
@@ -11640,7 +11824,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#38/source-map",
+"@id": "#45/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -11648,7 +11832,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#38"
+"@value": "amf://id#45"
 }
 ],
 "sourcemaps:value": [
@@ -11674,7 +11858,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#38"
+"@value": "amf://id#45"
 }
 ],
 "sourcemaps:value": [
@@ -11712,7 +11896,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#37/source-map",
+"@id": "#44/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -11732,7 +11916,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#37"
+"@value": "amf://id#44"
 }
 ],
 "sourcemaps:value": [
@@ -11746,7 +11930,7 @@
 ]
 },
 {
-"@id": "#40",
+"@id": "#47",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -11759,7 +11943,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#41",
+"@id": "#48",
 "@type": [
 "raml-shapes:FileShape",
 "shacl:Shape",
@@ -11791,7 +11975,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#41/source-map",
+"@id": "#48/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -11799,7 +11983,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#41"
+"@value": "amf://id#48"
 }
 ],
 "sourcemaps:value": [
@@ -11837,7 +12021,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#41"
+"@value": "amf://id#48"
 }
 ],
 "sourcemaps:value": [
@@ -11875,7 +12059,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#40/source-map",
+"@id": "#47/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -11895,7 +12079,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#40"
+"@value": "amf://id#47"
 }
 ],
 "sourcemaps:value": [
@@ -11909,7 +12093,7 @@
 ]
 },
 {
-"@id": "#42",
+"@id": "#35",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -11922,7 +12106,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#43",
+"@id": "#36",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -11939,14 +12123,14 @@
 "@value": "etag"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "ETag of this resource for caching purposes.\n__This property will be ignored when creating an object.__\n"
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#43/source-map",
+"@id": "#36/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -11954,7 +12138,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#43"
+"@value": "amf://id#36"
 }
 ],
 "sourcemaps:value": [
@@ -11968,7 +12152,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -11980,7 +12164,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#43"
+"@value": "amf://id#36"
 }
 ],
 "sourcemaps:value": [
@@ -12018,7 +12202,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#42/source-map",
+"@id": "#35/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -12026,7 +12210,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#42"
+"@value": "amf://id#35"
 }
 ],
 "sourcemaps:value": [
@@ -12040,7 +12224,7 @@
 ]
 },
 {
-"@id": "#44",
+"@id": "#49",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -12053,7 +12237,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#45",
+"@id": "#50",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -12070,14 +12254,14 @@
 "@value": "tagline"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "The brief description (tagline) of this person."
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#45/source-map",
+"@id": "#50/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -12085,7 +12269,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#45"
+"@value": "amf://id#50"
 }
 ],
 "sourcemaps:value": [
@@ -12099,7 +12283,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -12111,7 +12295,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#45"
+"@value": "amf://id#50"
 }
 ],
 "sourcemaps:value": [
@@ -12149,7 +12333,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#44/source-map",
+"@id": "#49/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -12157,7 +12341,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#44"
+"@value": "amf://id#49"
 }
 ],
 "sourcemaps:value": [
@@ -12171,7 +12355,7 @@
 ]
 },
 {
-"@id": "#46",
+"@id": "#51",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -12184,7 +12368,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#47",
+"@id": "#52",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -12206,16 +12390,23 @@
 "@value": "name"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "Person full name. The input will be rejected if this property is not set while creating new object."
 }
 ],
-"doc:examples": [
+"apiContract:examples": [
 {
-"@id": "#48",
+"@id": "#53",
 "@type": [
-"doc:Example",
+"apiContract:NamedExamples",
+"doc:DomainElement"
+],
+"apiContract:examples": [
+{
+"@id": "#54",
+"@type": [
+"apiContract:Example",
 "doc:DomainElement"
 ],
 "doc:strict": [
@@ -12225,9 +12416,11 @@
 ],
 "doc:structuredValue": [
 {
-"@id": "#48",
+"@id": "#54",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -12237,7 +12430,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#48/source-map",
+"@id": "#54/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -12245,7 +12438,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#48"
+"@value": "amf://id#54"
 }
 ],
 "sourcemaps:value": [
@@ -12266,7 +12459,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#48/source-map",
+"@id": "#54/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -12300,7 +12493,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#48"
+"@value": "amf://id#54"
 }
 ],
 "sourcemaps:value": [
@@ -12313,10 +12506,12 @@
 }
 ]
 }
+]
+}
 ],
 "sourcemaps:sources": [
 {
-"@id": "#47/source-map",
+"@id": "#52/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -12324,7 +12519,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#47"
+"@value": "amf://id#52"
 }
 ],
 "sourcemaps:value": [
@@ -12338,7 +12533,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -12362,7 +12557,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#47"
+"@value": "amf://id#52"
 }
 ],
 "sourcemaps:value": [
@@ -12400,7 +12595,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#46/source-map",
+"@id": "#51/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -12420,7 +12615,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#46"
+"@value": "amf://id#51"
 }
 ],
 "sourcemaps:value": [
@@ -12434,7 +12629,7 @@
 ]
 },
 {
-"@id": "#49",
+"@id": "#55",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -12447,7 +12642,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#50",
+"@id": "#56",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -12464,11 +12659,18 @@
 "@value": "created"
 }
 ],
-"doc:examples": [
+"apiContract:examples": [
 {
-"@id": "#51",
+"@id": "#57",
 "@type": [
-"doc:Example",
+"apiContract:NamedExamples",
+"doc:DomainElement"
+],
+"apiContract:examples": [
+{
+"@id": "#58",
+"@type": [
+"apiContract:Example",
 "doc:DomainElement"
 ],
 "doc:strict": [
@@ -12478,9 +12680,11 @@
 ],
 "doc:structuredValue": [
 {
-"@id": "#51",
+"@id": "#58",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -12490,7 +12694,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#51/source-map",
+"@id": "#58/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -12498,7 +12702,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#51"
+"@value": "amf://id#58"
 }
 ],
 "sourcemaps:value": [
@@ -12519,7 +12723,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#51/source-map",
+"@id": "#58/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -12553,7 +12757,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#51"
+"@value": "amf://id#58"
 }
 ],
 "sourcemaps:value": [
@@ -12566,10 +12770,12 @@
 }
 ]
 }
+]
+}
 ],
 "sourcemaps:sources": [
 {
-"@id": "#50/source-map",
+"@id": "#56/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -12577,7 +12783,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#50"
+"@value": "amf://id#56"
 }
 ],
 "sourcemaps:value": [
@@ -12603,7 +12809,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#50"
+"@value": "amf://id#56"
 }
 ],
 "sourcemaps:value": [
@@ -12629,7 +12835,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#49/source-map",
+"@id": "#55/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -12649,7 +12855,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#49"
+"@value": "amf://id#55"
 }
 ],
 "sourcemaps:value": [
@@ -12663,7 +12869,7 @@
 ]
 },
 {
-"@id": "#52",
+"@id": "#59",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -12676,7 +12882,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#53",
+"@id": "#60",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -12693,14 +12899,14 @@
 "@value": "url"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "The URL of this person's profile."
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#53/source-map",
+"@id": "#60/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -12708,7 +12914,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#53"
+"@value": "amf://id#60"
 }
 ],
 "sourcemaps:value": [
@@ -12722,7 +12928,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -12734,7 +12940,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#53"
+"@value": "amf://id#60"
 }
 ],
 "sourcemaps:value": [
@@ -12772,7 +12978,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#52/source-map",
+"@id": "#59/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -12780,7 +12986,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#52"
+"@value": "amf://id#59"
 }
 ],
 "sourcemaps:value": [
@@ -12794,7 +13000,7 @@
 ]
 },
 {
-"@id": "#54",
+"@id": "#61",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -12807,7 +13013,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#55",
+"@id": "#62",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -12839,14 +13045,14 @@
 "@value": "id"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "A unique identifier of a person.\n\nIt is a 32 bit string containing alphanumeric characters.\n"
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#55/source-map",
+"@id": "#62/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -12854,7 +13060,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -12878,7 +13084,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#55"
+"@value": "amf://id#62"
 }
 ],
 "sourcemaps:value": [
@@ -12928,7 +13134,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#54/source-map",
+"@id": "#61/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -12936,7 +13142,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#54"
+"@value": "amf://id#61"
 }
 ],
 "sourcemaps:value": [
@@ -12950,7 +13156,7 @@
 ]
 },
 {
-"@id": "#56",
+"@id": "#63",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -12963,7 +13169,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#57",
+"@id": "#64",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -12980,14 +13186,14 @@
 "@value": "language"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "The user's preferred language for rendering."
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#57/source-map",
+"@id": "#64/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -12995,7 +13201,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#57"
+"@value": "amf://id#64"
 }
 ],
 "sourcemaps:value": [
@@ -13009,7 +13215,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -13021,7 +13227,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#57"
+"@value": "amf://id#64"
 }
 ],
 "sourcemaps:value": [
@@ -13059,7 +13265,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#56/source-map",
+"@id": "#63/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -13067,7 +13273,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#56"
+"@value": "amf://id#63"
 }
 ],
 "sourcemaps:value": [
@@ -13081,7 +13287,7 @@
 ]
 },
 {
-"@id": "#58",
+"@id": "#65",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -13094,7 +13300,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#59",
+"@id": "#66",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -13111,14 +13317,14 @@
 "@value": "age"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "Very unpractical property to have in a data store.\n"
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#59/source-map",
+"@id": "#66/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -13126,7 +13332,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#59"
+"@value": "amf://id#66"
 }
 ],
 "sourcemaps:value": [
@@ -13140,7 +13346,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -13152,7 +13358,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#59"
+"@value": "amf://id#66"
 }
 ],
 "sourcemaps:value": [
@@ -13190,7 +13396,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#58/source-map",
+"@id": "#65/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -13210,7 +13416,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#58"
+"@value": "amf://id#65"
 }
 ],
 "sourcemaps:value": [
@@ -13224,7 +13430,7 @@
 ]
 },
 {
-"@id": "#60",
+"@id": "#67",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -13237,7 +13443,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#61/linked_2",
+"@id": "#68/linked_2",
 "@type": [
 "raml-shapes:UnionShape",
 "shacl:Shape",
@@ -13245,7 +13451,7 @@
 ],
 "doc:link-target": [
 {
-"@id": "#61"
+"@id": "#68"
 }
 ],
 "doc:link-label": [
@@ -13267,7 +13473,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#60/source-map",
+"@id": "#67/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -13275,7 +13481,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#60"
+"@value": "amf://id#67"
 }
 ],
 "sourcemaps:value": [
@@ -13289,7 +13495,7 @@
 ]
 },
 {
-"@id": "#64",
+"@id": "#71",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -13302,7 +13508,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#65",
+"@id": "#72",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -13319,14 +13525,14 @@
 "@value": "birthday"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "The person's date of birth, represented as YYYY-MM-DD."
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#65/source-map",
+"@id": "#72/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -13334,7 +13540,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#65"
+"@value": "amf://id#72"
 }
 ],
 "sourcemaps:value": [
@@ -13348,7 +13554,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -13360,7 +13566,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#65"
+"@value": "amf://id#72"
 }
 ],
 "sourcemaps:value": [
@@ -13398,7 +13604,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#64/source-map",
+"@id": "#71/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -13406,7 +13612,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#64"
+"@value": "amf://id#71"
 }
 ],
 "sourcemaps:value": [
@@ -13420,7 +13626,7 @@
 ]
 },
 {
-"@id": "#66",
+"@id": "#73",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -13433,7 +13639,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#18/linked_4",
+"@id": "#19/linked_4",
 "@type": [
 "shacl:NodeShape",
 "shacl:Shape",
@@ -13442,7 +13648,7 @@
 ],
 "doc:link-target": [
 {
-"@id": "#18"
+"@id": "#19"
 }
 ],
 "doc:link-label": [
@@ -13464,7 +13670,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#66/source-map",
+"@id": "#73/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -13472,7 +13678,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#66"
+"@value": "amf://id#73"
 }
 ],
 "sourcemaps:value": [
@@ -13486,7 +13692,7 @@
 ]
 },
 {
-"@id": "#67",
+"@id": "#74",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -13499,7 +13705,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#68",
+"@id": "#75",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -13516,20 +13722,22 @@
 "@value": "gender?"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "The person's gender. Possible values includes, but are not limited to, the following values:\n* \"male\" - Male gender.\n* \"female\" - Female gender.\n* \"other\" - Other.\n"
 }
 ],
 "shacl:in": [
 {
-"@id": "#68/list",
+"@id": "#75/list",
 "@type": "rdfs:Seq",
 "rdfs:_1": [
 {
-"@id": "#69",
+"@id": "#76",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -13539,7 +13747,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#69/source-map",
+"@id": "#76/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -13547,7 +13755,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#69"
+"@value": "amf://id#76"
 }
 ],
 "sourcemaps:value": [
@@ -13563,9 +13771,11 @@
 ],
 "rdfs:_2": [
 {
-"@id": "#70",
+"@id": "#77",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -13575,7 +13785,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#70/source-map",
+"@id": "#77/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -13583,7 +13793,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#70"
+"@value": "amf://id#77"
 }
 ],
 "sourcemaps:value": [
@@ -13599,9 +13809,11 @@
 ],
 "rdfs:_3": [
 {
-"@id": "#71",
+"@id": "#78",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -13611,7 +13823,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#71/source-map",
+"@id": "#78/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -13619,7 +13831,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#71"
+"@value": "amf://id#78"
 }
 ],
 "sourcemaps:value": [
@@ -13635,14 +13847,21 @@
 ]
 }
 ],
-"doc:examples": [
+"apiContract:examples": [
 {
-"@id": "#72",
+"@id": "#79",
 "@type": [
-"doc:Example",
+"apiContract:NamedExamples",
 "doc:DomainElement"
 ],
-"schema-org:name": [
+"apiContract:examples": [
+{
+"@id": "#80",
+"@type": [
+"apiContract:Example",
+"doc:DomainElement"
+],
+"core:name": [
 {
 "@value": "Women"
 }
@@ -13654,9 +13873,11 @@
 ],
 "doc:structuredValue": [
 {
-"@id": "#72",
+"@id": "#80",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -13666,7 +13887,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#72/source-map",
+"@id": "#80/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -13674,7 +13895,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#72"
+"@value": "amf://id#80"
 }
 ],
 "sourcemaps:value": [
@@ -13695,7 +13916,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#72/source-map",
+"@id": "#80/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -13729,7 +13950,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#72"
+"@value": "amf://id#80"
 }
 ],
 "sourcemaps:value": [
@@ -13741,7 +13962,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:name"
+"@value": "core:name"
 }
 ],
 "sourcemaps:value": [
@@ -13755,12 +13976,12 @@
 ]
 },
 {
-"@id": "#73",
+"@id": "#81",
 "@type": [
-"doc:Example",
+"apiContract:Example",
 "doc:DomainElement"
 ],
-"schema-org:name": [
+"core:name": [
 {
 "@value": "Man"
 }
@@ -13772,9 +13993,11 @@
 ],
 "doc:structuredValue": [
 {
-"@id": "#73",
+"@id": "#81",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -13784,7 +14007,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#73/source-map",
+"@id": "#81/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -13792,7 +14015,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#73"
+"@value": "amf://id#81"
 }
 ],
 "sourcemaps:value": [
@@ -13813,7 +14036,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#73/source-map",
+"@id": "#81/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -13847,7 +14070,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#73"
+"@value": "amf://id#81"
 }
 ],
 "sourcemaps:value": [
@@ -13859,7 +14082,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:name"
+"@value": "core:name"
 }
 ],
 "sourcemaps:value": [
@@ -13873,12 +14096,12 @@
 ]
 },
 {
-"@id": "#74",
+"@id": "#82",
 "@type": [
-"doc:Example",
+"apiContract:Example",
 "doc:DomainElement"
 ],
-"schema-org:name": [
+"core:name": [
 {
 "@value": "Elmo"
 }
@@ -13890,9 +14113,11 @@
 ],
 "doc:structuredValue": [
 {
-"@id": "#74",
+"@id": "#82",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -13902,7 +14127,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#74/source-map",
+"@id": "#82/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -13910,7 +14135,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#74"
+"@value": "amf://id#82"
 }
 ],
 "sourcemaps:value": [
@@ -13931,7 +14156,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#74/source-map",
+"@id": "#82/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -13965,7 +14190,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#74"
+"@value": "amf://id#82"
 }
 ],
 "sourcemaps:value": [
@@ -13977,7 +14202,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:name"
+"@value": "core:name"
 }
 ],
 "sourcemaps:value": [
@@ -13990,10 +14215,12 @@
 }
 ]
 }
+]
+}
 ],
 "sourcemaps:sources": [
 {
-"@id": "#68/source-map",
+"@id": "#75/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -14001,7 +14228,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#68"
+"@value": "amf://id#75"
 }
 ],
 "sourcemaps:value": [
@@ -14039,7 +14266,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#68"
+"@value": "amf://id#75"
 }
 ],
 "sourcemaps:value": [
@@ -14051,7 +14278,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -14077,7 +14304,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#67/source-map",
+"@id": "#74/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -14085,7 +14312,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#67"
+"@value": "amf://id#74"
 }
 ],
 "sourcemaps:value": [
@@ -14104,21 +14331,28 @@
 "@value": "type"
 }
 ],
-"schema-org:name": [
+"core:name": [
 {
 "@value": "A person resource"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "An object representing a person in the API.\nThis object will be used in all methods returning a Person or list of people.\n"
 }
 ],
-"doc:examples": [
+"apiContract:examples": [
 {
-"@id": "#75",
+"@id": "#83",
 "@type": [
-"doc:Example",
+"apiContract:NamedExamples",
+"doc:DomainElement"
+],
+"apiContract:examples": [
+{
+"@id": "#84",
+"@type": [
+"apiContract:Example",
 "doc:DomainElement"
 ],
 "doc:strict": [
@@ -14128,351 +14362,23 @@
 ],
 "doc:structuredValue": [
 {
-"@id": "#75",
+"@id": "#84",
 "@type": [
-"data:Object"
+"data:Object",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:birthday": [
 {
-"@id": "#76",
+"@id": "#85",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
 "@value": "1983-10-20",
-"@type": "xsd:string"
-}
-],
-"sourcemaps:sources": [
-{
-"@id": "#76/source-map",
-"@type": [
-"sourcemaps:SourceMap"
-],
-"sourcemaps:lexical": [
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#76"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(12,12)-(12,24)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"data:etag": [
-{
-"@id": "#77",
-"@type": [
-"data:Scalar"
-],
-"data:value": [
-{
-"@value": "W\\244m4n5kj3gbn2nj4k4n4",
-"@type": "xsd:string"
-}
-],
-"sourcemaps:sources": [
-{
-"@id": "#77/source-map",
-"@type": [
-"sourcemaps:SourceMap"
-],
-"sourcemaps:lexical": [
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#77"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(20,8)-(20,34)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"data:favouriteNumber": [
-{
-"@id": "#78",
-"@type": [
-"data:Scalar"
-],
-"data:value": [
-{
-"@value": "10",
-"@type": "xsd:integer"
-}
-],
-"sourcemaps:sources": [
-{
-"@id": "#78/source-map",
-"@type": [
-"sourcemaps:SourceMap"
-],
-"sourcemaps:lexical": [
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#78"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(21,19)-(21,21)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"data:favouriteTime": [
-{
-"@id": "#79",
-"@type": [
-"data:Scalar"
-],
-"data:value": [
-{
-"@value": "10:29:52",
-"@type": "xsd:string"
-}
-],
-"sourcemaps:sources": [
-{
-"@id": "#79/source-map",
-"@type": [
-"sourcemaps:SourceMap"
-],
-"sourcemaps:lexical": [
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#79"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(22,17)-(22,25)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"data:gender": [
-{
-"@id": "#80",
-"@type": [
-"data:Scalar"
-],
-"data:value": [
-{
-"@value": "male",
-"@type": "xsd:string"
-}
-],
-"sourcemaps:sources": [
-{
-"@id": "#80/source-map",
-"@type": [
-"sourcemaps:SourceMap"
-],
-"sourcemaps:lexical": [
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#80"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(13,10)-(13,14)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"data:id": [
-{
-"@id": "#81",
-"@type": [
-"data:Scalar"
-],
-"data:value": [
-{
-"@value": "R34fg663H9KW9MMSKISIhTs1dR7Hss7e",
-"@type": "xsd:string"
-}
-],
-"sourcemaps:sources": [
-{
-"@id": "#81/source-map",
-"@type": [
-"sourcemaps:SourceMap"
-],
-"sourcemaps:lexical": [
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#81"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(10,6)-(10,40)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"data:image": [
-{
-"@id": "#82",
-"@type": [
-"data:Object"
-],
-"data:thumb": [
-{
-"@id": "#83",
-"@type": [
-"data:Scalar"
-],
-"data:value": [
-{
-"@value": "https://domain.com/profile/pawel.psztyc/image/thumb",
-"@type": "xsd:string"
-}
-],
-"sourcemaps:sources": [
-{
-"@id": "#83/source-map",
-"@type": [
-"sourcemaps:SourceMap"
-],
-"sourcemaps:lexical": [
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#83"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(17,11)-(17,62)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"data:url": [
-{
-"@id": "#84",
-"@type": [
-"data:Scalar"
-],
-"data:value": [
-{
-"@value": "https://domain.com/profile/pawel.psztyc/image",
-"@type": "xsd:string"
-}
-],
-"sourcemaps:sources": [
-{
-"@id": "#84/source-map",
-"@type": [
-"sourcemaps:SourceMap"
-],
-"sourcemaps:lexical": [
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#84"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(16,9)-(16,54)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"sourcemaps:sources": [
-{
-"@id": "#82/source-map",
-"@type": [
-"sourcemaps:SourceMap"
-],
-"sourcemaps:data-node-properties": [
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#82"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "url->[(16,4)-(17,0)]#thumb->[(17,4)-(18,0)]"
-}
-]
-}
-],
-"sourcemaps:lexical": [
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#82"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(16,0)-(18,0)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"data:language": [
-{
-"@id": "#85",
-"@type": [
-"data:Scalar"
-],
-"data:value": [
-{
-"@value": "en_GB",
 "@type": "xsd:string"
 }
 ],
@@ -14491,7 +14397,7 @@
 ],
 "sourcemaps:value": [
 {
-"@value": "[(19,12)-(19,17)]"
+"@value": "[(12,12)-(12,24)]"
 }
 ]
 }
@@ -14500,15 +14406,17 @@
 ]
 }
 ],
-"data:name": [
+"data:etag": [
 {
 "@id": "#86",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
-"@value": "Pawel Psztyc",
+"@value": "W\\244m4n5kj3gbn2nj4k4n4",
 "@type": "xsd:string"
 }
 ],
@@ -14527,7 +14435,7 @@
 ],
 "sourcemaps:value": [
 {
-"@value": "[(11,8)-(11,22)]"
+"@value": "[(20,8)-(20,34)]"
 }
 ]
 }
@@ -14536,16 +14444,18 @@
 ]
 }
 ],
-"data:nillable": [
+"data:favouriteNumber": [
 {
 "@id": "#87",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
-"@value": "null",
-"@type": "xsd:nil"
+"@value": "10",
+"@type": "xsd:integer"
 }
 ],
 "sourcemaps:sources": [
@@ -14563,7 +14473,7 @@
 ],
 "sourcemaps:value": [
 {
-"@value": "[(23,12)-(23,16)]"
+"@value": "[(21,19)-(21,21)]"
 }
 ]
 }
@@ -14572,15 +14482,17 @@
 ]
 }
 ],
-"data:tagline": [
+"data:favouriteTime": [
 {
 "@id": "#88",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
-"@value": "Some text about me.",
+"@value": "10:29:52",
 "@type": "xsd:string"
 }
 ],
@@ -14599,7 +14511,7 @@
 ],
 "sourcemaps:value": [
 {
-"@value": "[(18,11)-(18,30)]"
+"@value": "[(22,17)-(22,25)]"
 }
 ]
 }
@@ -14608,15 +14520,17 @@
 ]
 }
 ],
-"data:url": [
+"data:gender": [
 {
 "@id": "#89",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
-"@value": "https://domain.com/profile/pawel.psztyc",
+"@value": "male",
 "@type": "xsd:string"
 }
 ],
@@ -14635,6 +14549,380 @@
 ],
 "sourcemaps:value": [
 {
+"@value": "[(13,10)-(13,14)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"data:id": [
+{
+"@id": "#90",
+"@type": [
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
+],
+"data:value": [
+{
+"@value": "R34fg663H9KW9MMSKISIhTs1dR7Hss7e",
+"@type": "xsd:string"
+}
+],
+"sourcemaps:sources": [
+{
+"@id": "#90/source-map",
+"@type": [
+"sourcemaps:SourceMap"
+],
+"sourcemaps:lexical": [
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#90"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(10,6)-(10,40)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"data:image": [
+{
+"@id": "#91",
+"@type": [
+"data:Object",
+"data:Node",
+"doc:DomainElement"
+],
+"data:thumb": [
+{
+"@id": "#92",
+"@type": [
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
+],
+"data:value": [
+{
+"@value": "https://domain.com/profile/pawel.psztyc/image/thumb",
+"@type": "xsd:string"
+}
+],
+"sourcemaps:sources": [
+{
+"@id": "#92/source-map",
+"@type": [
+"sourcemaps:SourceMap"
+],
+"sourcemaps:lexical": [
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#92"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(17,11)-(17,62)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"data:url": [
+{
+"@id": "#93",
+"@type": [
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
+],
+"data:value": [
+{
+"@value": "https://domain.com/profile/pawel.psztyc/image",
+"@type": "xsd:string"
+}
+],
+"sourcemaps:sources": [
+{
+"@id": "#93/source-map",
+"@type": [
+"sourcemaps:SourceMap"
+],
+"sourcemaps:lexical": [
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#93"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(16,9)-(16,54)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"sourcemaps:sources": [
+{
+"@id": "#91/source-map",
+"@type": [
+"sourcemaps:SourceMap"
+],
+"sourcemaps:data-node-properties": [
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#91"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "url->[(16,4)-(17,0)]#thumb->[(17,4)-(18,0)]"
+}
+]
+}
+],
+"sourcemaps:lexical": [
+{
+"sourcemaps:element": [
+{
+"@value": "data:url"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(16,9)-(16,54)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#91"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(16,0)-(18,0)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "data:thumb"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(17,11)-(17,62)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"data:language": [
+{
+"@id": "#94",
+"@type": [
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
+],
+"data:value": [
+{
+"@value": "en_GB",
+"@type": "xsd:string"
+}
+],
+"sourcemaps:sources": [
+{
+"@id": "#94/source-map",
+"@type": [
+"sourcemaps:SourceMap"
+],
+"sourcemaps:lexical": [
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#94"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(19,12)-(19,17)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"data:name": [
+{
+"@id": "#95",
+"@type": [
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
+],
+"data:value": [
+{
+"@value": "Pawel Psztyc",
+"@type": "xsd:string"
+}
+],
+"sourcemaps:sources": [
+{
+"@id": "#95/source-map",
+"@type": [
+"sourcemaps:SourceMap"
+],
+"sourcemaps:lexical": [
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#95"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(11,8)-(11,22)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"data:nillable": [
+{
+"@id": "#96",
+"@type": [
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
+],
+"data:value": [
+{
+"@value": "null",
+"@type": "xsd:nil"
+}
+],
+"sourcemaps:sources": [
+{
+"@id": "#96/source-map",
+"@type": [
+"sourcemaps:SourceMap"
+],
+"sourcemaps:lexical": [
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#96"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(23,12)-(23,16)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"data:tagline": [
+{
+"@id": "#97",
+"@type": [
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
+],
+"data:value": [
+{
+"@value": "Some text about me.",
+"@type": "xsd:string"
+}
+],
+"sourcemaps:sources": [
+{
+"@id": "#97/source-map",
+"@type": [
+"sourcemaps:SourceMap"
+],
+"sourcemaps:lexical": [
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#97"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(18,11)-(18,30)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"data:url": [
+{
+"@id": "#98",
+"@type": [
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
+],
+"data:value": [
+{
+"@value": "https://domain.com/profile/pawel.psztyc",
+"@type": "xsd:string"
+}
+],
+"sourcemaps:sources": [
+{
+"@id": "#98/source-map",
+"@type": [
+"sourcemaps:SourceMap"
+],
+"sourcemaps:lexical": [
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#98"
+}
+],
+"sourcemaps:value": [
+{
 "@value": "[(14,7)-(14,48)]"
 }
 ]
@@ -14646,7 +14934,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#75/source-map",
+"@id": "#84/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -14654,12 +14942,156 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#75"
+"@value": "data:url"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(14,7)-(14,48)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "data:nillable"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(23,12)-(23,16)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "data:language"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(19,12)-(19,17)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "data:id"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(10,6)-(10,40)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "data:favouriteTime"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(22,17)-(22,25)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "data:etag"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(20,8)-(20,34)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#84"
 }
 ],
 "sourcemaps:value": [
 {
 "@value": "[(10,0)-(25,0)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "data:birthday"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(12,12)-(12,24)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "data:favouriteNumber"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(21,19)-(21,21)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "data:gender"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(13,10)-(13,14)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "data:image"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(16,0)-(18,0)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "data:name"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(11,8)-(11,22)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "data:tagline"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(18,11)-(18,30)]"
 }
 ]
 }
@@ -14668,7 +15100,19 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#75"
+"@value": "data:image"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "url->[(16,4)-(17,0)]#thumb->[(17,4)-(18,0)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#84"
 }
 ],
 "sourcemaps:value": [
@@ -14689,7 +15133,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#75/source-map",
+"@id": "#84/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -14723,7 +15167,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#75"
+"@value": "amf://id#84"
 }
 ],
 "sourcemaps:value": [
@@ -14736,10 +15180,12 @@
 }
 ]
 }
+]
+}
 ],
 "sourcemaps:sources": [
 {
-"@id": "#31/source-map",
+"@id": "#37/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -14747,7 +15193,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#31"
+"@value": "amf://id#37"
 }
 ],
 "sourcemaps:value": [
@@ -14761,7 +15207,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -14773,7 +15219,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#31"
+"@value": "amf://id#37"
 }
 ],
 "sourcemaps:value": [
@@ -14785,7 +15231,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:name"
+"@value": "core:name"
 }
 ],
 "sourcemaps:value": [
@@ -14799,7 +15245,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#31"
+"@value": "amf://id#37"
 }
 ],
 "sourcemaps:value": [
@@ -14815,7 +15261,7 @@
 ],
 "doc:references": [
 {
-"@id": "#17",
+"@id": "#18",
 "@type": [
 "doc:DataType",
 "doc:Fragment",
@@ -14823,7 +15269,7 @@
 ],
 "doc:encodes": [
 {
-"@id": "#18",
+"@id": "#19",
 "@type": [
 "shacl:NodeShape",
 "shacl:Shape",
@@ -14837,7 +15283,7 @@
 ],
 "shacl:property": [
 {
-"@id": "#19",
+"@id": "#20",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -14850,7 +15296,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#20",
+"@id": "#21",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -14867,14 +15313,14 @@
 "@value": "url"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "The URL of the image.\nTo resize the image and crop it to a square, append the query string **?sz=x**, where x is the dimension in pixels of each side.\n"
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#20/source-map",
+"@id": "#21/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -14882,7 +15328,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#20"
+"@value": "amf://id#21"
 }
 ],
 "sourcemaps:value": [
@@ -14896,7 +15342,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -14908,7 +15354,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#20"
+"@value": "amf://id#21"
 }
 ],
 "sourcemaps:value": [
@@ -14946,7 +15392,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#19/source-map",
+"@id": "#20/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -14954,7 +15400,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#19"
+"@value": "amf://id#20"
 }
 ],
 "sourcemaps:value": [
@@ -14968,7 +15414,7 @@
 ]
 },
 {
-"@id": "#21",
+"@id": "#22",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -14981,7 +15427,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#22",
+"@id": "#23",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -14998,19 +15444,19 @@
 "@value": "thumb"
 }
 ],
-"schema-org:name": [
+"core:name": [
 {
 "@value": "Thumbnail"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "An URL to the thumbnail of the image. Thumbnails are 60x60px cropped images of the original image.\n"
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#22/source-map",
+"@id": "#23/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -15018,7 +15464,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#22"
+"@value": "amf://id#23"
 }
 ],
 "sourcemaps:value": [
@@ -15032,7 +15478,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -15056,7 +15502,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#22"
+"@value": "amf://id#23"
 }
 ],
 "sourcemaps:value": [
@@ -15068,7 +15514,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:name"
+"@value": "core:name"
 }
 ],
 "sourcemaps:value": [
@@ -15094,7 +15540,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#21/source-map",
+"@id": "#22/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -15102,7 +15548,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#21"
+"@value": "amf://id#22"
 }
 ],
 "sourcemaps:value": [
@@ -15121,16 +15567,23 @@
 "@value": "amf_inline_type_2"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "An image object representing an image object strored in the file store.\nThe image can be only included in the response. It has no effect if the Image appear in the\nrequest. Endpoint handles image creation on it's own and clients can't process images\nexcept of sending image data.\n"
 }
 ],
-"doc:examples": [
+"apiContract:examples": [
 {
-"@id": "#23",
+"@id": "#24",
 "@type": [
-"doc:Example",
+"apiContract:NamedExamples",
+"doc:DomainElement"
+],
+"apiContract:examples": [
+{
+"@id": "#25",
+"@type": [
+"apiContract:Example",
 "doc:DomainElement"
 ],
 "doc:strict": [
@@ -15140,15 +15593,19 @@
 ],
 "doc:structuredValue": [
 {
-"@id": "#23",
+"@id": "#25",
 "@type": [
-"data:Object"
+"data:Object",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:thumb": [
 {
-"@id": "#24",
+"@id": "#26",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -15158,7 +15615,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#24/source-map",
+"@id": "#26/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -15166,7 +15623,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#24"
+"@value": "amf://id#26"
 }
 ],
 "sourcemaps:value": [
@@ -15182,9 +15639,11 @@
 ],
 "data:url": [
 {
-"@id": "#25",
+"@id": "#27",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -15194,7 +15653,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#25/source-map",
+"@id": "#27/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -15202,7 +15661,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#25"
+"@value": "amf://id#27"
 }
 ],
 "sourcemaps:value": [
@@ -15218,7 +15677,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#23/source-map",
+"@id": "#25/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -15226,12 +15685,36 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#23"
+"@value": "data:url"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(22,7)-(22,52)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#25"
 }
 ],
 "sourcemaps:value": [
 {
 "@value": "[(22,0)-(24,0)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "data:thumb"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(23,9)-(23,60)]"
 }
 ]
 }
@@ -15240,7 +15723,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#23"
+"@value": "amf://id#25"
 }
 ],
 "sourcemaps:value": [
@@ -15261,7 +15744,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#23/source-map",
+"@id": "#25/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -15295,7 +15778,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#23"
+"@value": "amf://id#25"
 }
 ],
 "sourcemaps:value": [
@@ -15308,10 +15791,12 @@
 }
 ]
 }
+]
+}
 ],
 "sourcemaps:sources": [
 {
-"@id": "#18/source-map",
+"@id": "#19/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -15319,7 +15804,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#18"
+"@value": "amf://id#19"
 }
 ],
 "sourcemaps:value": [
@@ -15333,7 +15818,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#18"
+"@value": "amf://id#19"
 }
 ],
 "sourcemaps:value": [
@@ -15347,7 +15832,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -15359,7 +15844,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#18"
+"@value": "amf://id#19"
 }
 ],
 "sourcemaps:value": [
@@ -15373,7 +15858,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#18"
+"@value": "amf://id#19"
 }
 ],
 "sourcemaps:value": [
@@ -15389,7 +15874,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#17/source-map",
+"@id": "#18/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -15397,7 +15882,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#17"
+"@value": "amf://id#18"
 }
 ],
 "sourcemaps:value": [
@@ -15411,7 +15896,7 @@
 ]
 },
 {
-"@id": "#90",
+"@id": "#33",
 "@type": [
 "doc:DataType",
 "doc:Fragment",
@@ -15419,7 +15904,7 @@
 ],
 "doc:encodes": [
 {
-"@id": "#91",
+"@id": "#34",
 "@type": [
 "shacl:NodeShape",
 "shacl:Shape",
@@ -15433,7 +15918,7 @@
 ],
 "shacl:property": [
 {
-"@id": "#42",
+"@id": "#35",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -15446,7 +15931,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#43",
+"@id": "#36",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -15463,14 +15948,14 @@
 "@value": "etag"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "ETag of this resource for caching purposes.\n__This property will be ignored when creating an object.__\n"
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#43/source-map",
+"@id": "#36/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -15478,7 +15963,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#43"
+"@value": "amf://id#36"
 }
 ],
 "sourcemaps:value": [
@@ -15492,7 +15977,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -15504,7 +15989,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#43"
+"@value": "amf://id#36"
 }
 ],
 "sourcemaps:value": [
@@ -15542,7 +16027,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#42/source-map",
+"@id": "#35/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -15550,7 +16035,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#42"
+"@value": "amf://id#35"
 }
 ],
 "sourcemaps:value": [
@@ -15569,14 +16054,14 @@
 "@value": "type"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "Common properties for all resources returned by the API.\n"
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#91/source-map",
+"@id": "#34/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -15584,7 +16069,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#91"
+"@value": "amf://id#34"
 }
 ],
 "sourcemaps:value": [
@@ -15598,7 +16083,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -15610,7 +16095,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#91"
+"@value": "amf://id#34"
 }
 ],
 "sourcemaps:value": [
@@ -15624,7 +16109,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#91"
+"@value": "amf://id#34"
 }
 ],
 "sourcemaps:value": [
@@ -15640,7 +16125,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#90/source-map",
+"@id": "#33/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -15648,7 +16133,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#90"
+"@value": "amf://id#33"
 }
 ],
 "sourcemaps:value": [
@@ -15664,7 +16149,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#30/source-map",
+"@id": "#32/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -15672,7 +16157,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#30"
+"@value": "amf://id#32"
 }
 ],
 "sourcemaps:value": [
@@ -15686,7 +16171,7 @@
 ]
 },
 {
-"@id": "#92",
+"@id": "#99",
 "@type": [
 "doc:DataType",
 "doc:Fragment",
@@ -15694,7 +16179,7 @@
 ],
 "doc:encodes": [
 {
-"@id": "#93",
+"@id": "#100",
 "@type": [
 "shacl:NodeShape",
 "shacl:Shape",
@@ -15708,7 +16193,7 @@
 ],
 "shacl:property": [
 {
-"@id": "#94",
+"@id": "#101",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -15721,7 +16206,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#95",
+"@id": "#102",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -15743,16 +16228,23 @@
 "@value": "upc"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "The Universal Produc Code. It consists of 12 numerical digits. However, because of the\ninteger precision limitation in JavaScript it is represented as a string.\n"
 }
 ],
-"doc:examples": [
+"apiContract:examples": [
 {
-"@id": "#96",
+"@id": "#103",
 "@type": [
-"doc:Example",
+"apiContract:NamedExamples",
+"doc:DomainElement"
+],
+"apiContract:examples": [
+{
+"@id": "#104",
+"@type": [
+"apiContract:Example",
 "doc:DomainElement"
 ],
 "doc:strict": [
@@ -15762,9 +16254,11 @@
 ],
 "doc:structuredValue": [
 {
-"@id": "#96",
+"@id": "#104",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -15774,7 +16268,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#96/source-map",
+"@id": "#104/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -15782,7 +16276,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#96"
+"@value": "amf://id#104"
 }
 ],
 "sourcemaps:value": [
@@ -15803,7 +16297,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#96/source-map",
+"@id": "#104/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -15837,7 +16331,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#96"
+"@value": "amf://id#104"
 }
 ],
 "sourcemaps:value": [
@@ -15850,10 +16344,12 @@
 }
 ]
 }
+]
+}
 ],
 "sourcemaps:sources": [
 {
-"@id": "#95/source-map",
+"@id": "#102/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -15861,7 +16357,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#95"
+"@value": "amf://id#102"
 }
 ],
 "sourcemaps:value": [
@@ -15875,7 +16371,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -15899,7 +16395,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#95"
+"@value": "amf://id#102"
 }
 ],
 "sourcemaps:value": [
@@ -15937,7 +16433,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#94/source-map",
+"@id": "#101/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -15957,7 +16453,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#94"
+"@value": "amf://id#101"
 }
 ],
 "sourcemaps:value": [
@@ -15971,7 +16467,7 @@
 ]
 },
 {
-"@id": "#42",
+"@id": "#35",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -15984,7 +16480,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#43",
+"@id": "#36",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -16001,14 +16497,14 @@
 "@value": "etag"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "ETag of this resource for caching purposes.\n__This property will be ignored when creating an object.__\n"
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#43/source-map",
+"@id": "#36/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -16016,7 +16512,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#43"
+"@value": "amf://id#36"
 }
 ],
 "sourcemaps:value": [
@@ -16030,7 +16526,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -16042,7 +16538,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#43"
+"@value": "amf://id#36"
 }
 ],
 "sourcemaps:value": [
@@ -16080,7 +16576,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#42/source-map",
+"@id": "#35/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -16088,7 +16584,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#42"
+"@value": "amf://id#35"
 }
 ],
 "sourcemaps:value": [
@@ -16102,7 +16598,7 @@
 ]
 },
 {
-"@id": "#97",
+"@id": "#105",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -16115,7 +16611,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#98",
+"@id": "#106",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -16132,16 +16628,23 @@
 "@value": "name"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "Product name"
 }
 ],
-"doc:examples": [
+"apiContract:examples": [
 {
-"@id": "#99",
+"@id": "#107",
 "@type": [
-"doc:Example",
+"apiContract:NamedExamples",
+"doc:DomainElement"
+],
+"apiContract:examples": [
+{
+"@id": "#108",
+"@type": [
+"apiContract:Example",
 "doc:DomainElement"
 ],
 "doc:strict": [
@@ -16151,9 +16654,11 @@
 ],
 "doc:structuredValue": [
 {
-"@id": "#99",
+"@id": "#108",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -16163,7 +16668,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#99/source-map",
+"@id": "#108/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -16171,7 +16676,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#99"
+"@value": "amf://id#108"
 }
 ],
 "sourcemaps:value": [
@@ -16192,7 +16697,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#99/source-map",
+"@id": "#108/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -16226,7 +16731,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#99"
+"@value": "amf://id#108"
 }
 ],
 "sourcemaps:value": [
@@ -16239,10 +16744,12 @@
 }
 ]
 }
+]
+}
 ],
 "sourcemaps:sources": [
 {
-"@id": "#98/source-map",
+"@id": "#106/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -16250,7 +16757,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#98"
+"@value": "amf://id#106"
 }
 ],
 "sourcemaps:value": [
@@ -16264,7 +16771,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -16276,7 +16783,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#98"
+"@value": "amf://id#106"
 }
 ],
 "sourcemaps:value": [
@@ -16314,7 +16821,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#97/source-map",
+"@id": "#105/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -16334,7 +16841,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#97"
+"@value": "amf://id#105"
 }
 ],
 "sourcemaps:value": [
@@ -16348,7 +16855,7 @@
 ]
 },
 {
-"@id": "#100",
+"@id": "#109",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -16361,7 +16868,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#101",
+"@id": "#110",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -16383,14 +16890,14 @@
 "@value": "id"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "Product id. It is a UUID of the database record.\n__This property will be ignored when creating an object.__\nIt will be available when the product is stored in the datastore.\n"
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#101/source-map",
+"@id": "#110/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -16398,7 +16905,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -16410,7 +16917,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#101"
+"@value": "amf://id#110"
 }
 ],
 "sourcemaps:value": [
@@ -16448,7 +16955,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#100/source-map",
+"@id": "#109/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -16456,7 +16963,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#100"
+"@value": "amf://id#109"
 }
 ],
 "sourcemaps:value": [
@@ -16470,7 +16977,7 @@
 ]
 },
 {
-"@id": "#102",
+"@id": "#111",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -16483,7 +16990,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#103",
+"@id": "#112",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -16500,16 +17007,23 @@
 "@value": "unit"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "The unit of measuremet for the quantity property."
 }
 ],
-"doc:examples": [
+"apiContract:examples": [
 {
-"@id": "#104",
+"@id": "#113",
 "@type": [
-"doc:Example",
+"apiContract:NamedExamples",
+"doc:DomainElement"
+],
+"apiContract:examples": [
+{
+"@id": "#114",
+"@type": [
+"apiContract:Example",
 "doc:DomainElement"
 ],
 "doc:strict": [
@@ -16519,9 +17033,11 @@
 ],
 "doc:structuredValue": [
 {
-"@id": "#104",
+"@id": "#114",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -16531,7 +17047,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#104/source-map",
+"@id": "#114/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -16539,7 +17055,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#104"
+"@value": "amf://id#114"
 }
 ],
 "sourcemaps:value": [
@@ -16560,7 +17076,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#104/source-map",
+"@id": "#114/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -16594,7 +17110,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#104"
+"@value": "amf://id#114"
 }
 ],
 "sourcemaps:value": [
@@ -16607,10 +17123,12 @@
 }
 ]
 }
+]
+}
 ],
 "sourcemaps:sources": [
 {
-"@id": "#103/source-map",
+"@id": "#112/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -16618,7 +17136,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#103"
+"@value": "amf://id#112"
 }
 ],
 "sourcemaps:value": [
@@ -16632,7 +17150,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -16644,7 +17162,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#103"
+"@value": "amf://id#112"
 }
 ],
 "sourcemaps:value": [
@@ -16682,7 +17200,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#102/source-map",
+"@id": "#111/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -16702,7 +17220,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#102"
+"@value": "amf://id#111"
 }
 ],
 "sourcemaps:value": [
@@ -16716,7 +17234,7 @@
 ]
 },
 {
-"@id": "#105",
+"@id": "#115",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -16729,7 +17247,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#106",
+"@id": "#116",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -16746,16 +17264,23 @@
 "@value": "available"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "Product current availability in the store.\nProduct may be not available but the users still can order it with later delivery date.\n"
 }
 ],
-"doc:examples": [
+"apiContract:examples": [
 {
-"@id": "#107",
+"@id": "#117",
 "@type": [
-"doc:Example",
+"apiContract:NamedExamples",
+"doc:DomainElement"
+],
+"apiContract:examples": [
+{
+"@id": "#118",
+"@type": [
+"apiContract:Example",
 "doc:DomainElement"
 ],
 "doc:strict": [
@@ -16765,9 +17290,11 @@
 ],
 "doc:structuredValue": [
 {
-"@id": "#107",
+"@id": "#118",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -16777,7 +17304,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#107/source-map",
+"@id": "#118/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -16785,7 +17312,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#107"
+"@value": "amf://id#118"
 }
 ],
 "sourcemaps:value": [
@@ -16806,7 +17333,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#107/source-map",
+"@id": "#118/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -16840,7 +17367,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#107"
+"@value": "amf://id#118"
 }
 ],
 "sourcemaps:value": [
@@ -16853,10 +17380,12 @@
 }
 ]
 }
+]
+}
 ],
 "sourcemaps:sources": [
 {
-"@id": "#106/source-map",
+"@id": "#116/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -16864,7 +17393,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#106"
+"@value": "amf://id#116"
 }
 ],
 "sourcemaps:value": [
@@ -16878,7 +17407,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -16890,7 +17419,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#106"
+"@value": "amf://id#116"
 }
 ],
 "sourcemaps:value": [
@@ -16928,7 +17457,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#105/source-map",
+"@id": "#115/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -16948,7 +17477,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#105"
+"@value": "amf://id#115"
 }
 ],
 "sourcemaps:value": [
@@ -16962,7 +17491,7 @@
 ]
 },
 {
-"@id": "#108",
+"@id": "#119",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -16975,7 +17504,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#109",
+"@id": "#120",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -16992,16 +17521,23 @@
 "@value": "quantity"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "The quantity of the product in the one unit of measurement.\nSee `unit` property for more information.\n"
 }
 ],
-"doc:examples": [
+"apiContract:examples": [
 {
-"@id": "#110",
+"@id": "#121",
 "@type": [
-"doc:Example",
+"apiContract:NamedExamples",
+"doc:DomainElement"
+],
+"apiContract:examples": [
+{
+"@id": "#122",
+"@type": [
+"apiContract:Example",
 "doc:DomainElement"
 ],
 "doc:strict": [
@@ -17011,9 +17547,11 @@
 ],
 "doc:structuredValue": [
 {
-"@id": "#110",
+"@id": "#122",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -17023,7 +17561,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#110/source-map",
+"@id": "#122/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -17031,7 +17569,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#110"
+"@value": "amf://id#122"
 }
 ],
 "sourcemaps:value": [
@@ -17052,7 +17590,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#110/source-map",
+"@id": "#122/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -17086,7 +17624,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#110"
+"@value": "amf://id#122"
 }
 ],
 "sourcemaps:value": [
@@ -17099,10 +17637,12 @@
 }
 ]
 }
+]
+}
 ],
 "sourcemaps:sources": [
 {
-"@id": "#109/source-map",
+"@id": "#120/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -17110,7 +17650,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#109"
+"@value": "amf://id#120"
 }
 ],
 "sourcemaps:value": [
@@ -17124,7 +17664,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -17136,7 +17676,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#109"
+"@value": "amf://id#120"
 }
 ],
 "sourcemaps:value": [
@@ -17174,7 +17714,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#108/source-map",
+"@id": "#119/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -17194,7 +17734,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#108"
+"@value": "amf://id#119"
 }
 ],
 "sourcemaps:value": [
@@ -17213,21 +17753,28 @@
 "@value": "Product"
 }
 ],
-"schema-org:name": [
+"core:name": [
 {
 "@value": "A product resource"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "A single product representing an item in the store."
 }
 ],
-"doc:examples": [
+"apiContract:examples": [
 {
-"@id": "#111",
+"@id": "#123",
 "@type": [
-"doc:Example",
+"apiContract:NamedExamples",
+"doc:DomainElement"
+],
+"apiContract:examples": [
+{
+"@id": "#124",
+"@type": [
+"apiContract:Example",
 "doc:DomainElement"
 ],
 "doc:strict": [
@@ -17237,15 +17784,19 @@
 ],
 "doc:structuredValue": [
 {
-"@id": "#111",
+"@id": "#124",
 "@type": [
-"data:Object"
+"data:Object",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:available": [
 {
-"@id": "#112",
+"@id": "#125",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -17255,7 +17806,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#112/source-map",
+"@id": "#125/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -17263,7 +17814,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#112"
+"@value": "amf://id#125"
 }
 ],
 "sourcemaps:value": [
@@ -17279,9 +17830,11 @@
 ],
 "data:etag": [
 {
-"@id": "#113",
+"@id": "#126",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -17291,7 +17844,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#113/source-map",
+"@id": "#126/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -17299,7 +17852,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#113"
+"@value": "amf://id#126"
 }
 ],
 "sourcemaps:value": [
@@ -17315,9 +17868,11 @@
 ],
 "data:id": [
 {
-"@id": "#114",
+"@id": "#127",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -17327,7 +17882,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#114/source-map",
+"@id": "#127/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -17335,7 +17890,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#114"
+"@value": "amf://id#127"
 }
 ],
 "sourcemaps:value": [
@@ -17351,9 +17906,11 @@
 ],
 "data:name": [
 {
-"@id": "#115",
+"@id": "#128",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -17363,7 +17920,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#115/source-map",
+"@id": "#128/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -17371,7 +17928,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#115"
+"@value": "amf://id#128"
 }
 ],
 "sourcemaps:value": [
@@ -17387,9 +17944,11 @@
 ],
 "data:quantity": [
 {
-"@id": "#116",
+"@id": "#129",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -17399,7 +17958,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#116/source-map",
+"@id": "#129/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -17407,7 +17966,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#116"
+"@value": "amf://id#129"
 }
 ],
 "sourcemaps:value": [
@@ -17423,9 +17982,11 @@
 ],
 "data:unit": [
 {
-"@id": "#117",
+"@id": "#130",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -17435,7 +17996,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#117/source-map",
+"@id": "#130/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -17443,7 +18004,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#117"
+"@value": "amf://id#130"
 }
 ],
 "sourcemaps:value": [
@@ -17459,9 +18020,11 @@
 ],
 "data:upc": [
 {
-"@id": "#118",
+"@id": "#131",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -17471,7 +18034,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#118/source-map",
+"@id": "#131/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -17479,7 +18042,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#118"
+"@value": "amf://id#131"
 }
 ],
 "sourcemaps:value": [
@@ -17495,7 +18058,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#111/source-map",
+"@id": "#124/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -17503,12 +18066,96 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#111"
+"@value": "data:upc"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(50,7)-(50,21)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "data:quantity"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(48,12)-(48,15)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "data:id"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(46,6)-(46,34)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "data:available"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(51,13)-(51,17)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#124"
 }
 ],
 "sourcemaps:value": [
 {
 "@value": "[(46,0)-(53,0)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "data:etag"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(52,8)-(52,28)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "data:name"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(47,8)-(47,20)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "data:unit"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(49,8)-(49,10)]"
 }
 ]
 }
@@ -17517,7 +18164,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#111"
+"@value": "amf://id#124"
 }
 ],
 "sourcemaps:value": [
@@ -17538,7 +18185,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#111/source-map",
+"@id": "#124/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -17572,7 +18219,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#111"
+"@value": "amf://id#124"
 }
 ],
 "sourcemaps:value": [
@@ -17585,10 +18232,12 @@
 }
 ]
 }
+]
+}
 ],
 "sourcemaps:sources": [
 {
-"@id": "#93/source-map",
+"@id": "#100/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -17596,7 +18245,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#93"
+"@value": "amf://id#100"
 }
 ],
 "sourcemaps:value": [
@@ -17610,7 +18259,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#93"
+"@value": "amf://id#100"
 }
 ],
 "sourcemaps:value": [
@@ -17624,7 +18273,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -17636,7 +18285,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#93"
+"@value": "amf://id#100"
 }
 ],
 "sourcemaps:value": [
@@ -17648,7 +18297,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:name"
+"@value": "core:name"
 }
 ],
 "sourcemaps:value": [
@@ -17662,7 +18311,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#93"
+"@value": "amf://id#100"
 }
 ],
 "sourcemaps:value": [
@@ -17678,7 +18327,7 @@
 ],
 "doc:references": [
 {
-"@id": "#90",
+"@id": "#33",
 "@type": [
 "doc:DataType",
 "doc:Fragment",
@@ -17686,7 +18335,7 @@
 ],
 "doc:encodes": [
 {
-"@id": "#91",
+"@id": "#34",
 "@type": [
 "shacl:NodeShape",
 "shacl:Shape",
@@ -17700,7 +18349,7 @@
 ],
 "shacl:property": [
 {
-"@id": "#42",
+"@id": "#35",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -17713,7 +18362,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#43",
+"@id": "#36",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -17730,14 +18379,14 @@
 "@value": "etag"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "ETag of this resource for caching purposes.\n__This property will be ignored when creating an object.__\n"
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#43/source-map",
+"@id": "#36/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -17745,7 +18394,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#43"
+"@value": "amf://id#36"
 }
 ],
 "sourcemaps:value": [
@@ -17759,7 +18408,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -17771,7 +18420,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#43"
+"@value": "amf://id#36"
 }
 ],
 "sourcemaps:value": [
@@ -17809,7 +18458,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#42/source-map",
+"@id": "#35/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -17817,7 +18466,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#42"
+"@value": "amf://id#35"
 }
 ],
 "sourcemaps:value": [
@@ -17836,14 +18485,14 @@
 "@value": "type"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "Common properties for all resources returned by the API.\n"
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#91/source-map",
+"@id": "#34/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -17851,7 +18500,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#91"
+"@value": "amf://id#34"
 }
 ],
 "sourcemaps:value": [
@@ -17865,7 +18514,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -17877,7 +18526,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#91"
+"@value": "amf://id#34"
 }
 ],
 "sourcemaps:value": [
@@ -17891,7 +18540,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#91"
+"@value": "amf://id#34"
 }
 ],
 "sourcemaps:value": [
@@ -17907,7 +18556,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#90/source-map",
+"@id": "#33/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -17915,7 +18564,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#90"
+"@value": "amf://id#33"
 }
 ],
 "sourcemaps:value": [
@@ -17931,7 +18580,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#92/source-map",
+"@id": "#99/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -17939,7 +18588,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#92"
+"@value": "amf://id#99"
 }
 ],
 "sourcemaps:value": [
@@ -17953,7 +18602,7 @@
 ]
 },
 {
-"@id": "#90",
+"@id": "#33",
 "@type": [
 "doc:DataType",
 "doc:Fragment",
@@ -17961,7 +18610,7 @@
 ],
 "doc:encodes": [
 {
-"@id": "#91",
+"@id": "#34",
 "@type": [
 "shacl:NodeShape",
 "shacl:Shape",
@@ -17975,7 +18624,7 @@
 ],
 "shacl:property": [
 {
-"@id": "#42",
+"@id": "#35",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -17988,7 +18637,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#43",
+"@id": "#36",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -18005,14 +18654,14 @@
 "@value": "etag"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "ETag of this resource for caching purposes.\n__This property will be ignored when creating an object.__\n"
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#43/source-map",
+"@id": "#36/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -18020,7 +18669,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#43"
+"@value": "amf://id#36"
 }
 ],
 "sourcemaps:value": [
@@ -18034,7 +18683,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -18046,7 +18695,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#43"
+"@value": "amf://id#36"
 }
 ],
 "sourcemaps:value": [
@@ -18084,7 +18733,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#42/source-map",
+"@id": "#35/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -18092,7 +18741,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#42"
+"@value": "amf://id#35"
 }
 ],
 "sourcemaps:value": [
@@ -18111,14 +18760,14 @@
 "@value": "type"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "Common properties for all resources returned by the API.\n"
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#91/source-map",
+"@id": "#34/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -18126,7 +18775,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#91"
+"@value": "amf://id#34"
 }
 ],
 "sourcemaps:value": [
@@ -18140,7 +18789,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -18152,7 +18801,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#91"
+"@value": "amf://id#34"
 }
 ],
 "sourcemaps:value": [
@@ -18166,7 +18815,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#91"
+"@value": "amf://id#34"
 }
 ],
 "sourcemaps:value": [
@@ -18182,7 +18831,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#90/source-map",
+"@id": "#33/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -18190,7 +18839,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#90"
+"@value": "amf://id#33"
 }
 ],
 "sourcemaps:value": [
@@ -18219,7 +18868,7 @@
 ],
 "sourcemaps:value": [
 {
-"@value": "myLib->amf://id#26::library.raml"
+"@value": "myLib->amf://id#28::library.raml"
 }
 ]
 }
@@ -18228,7 +18877,7 @@
 ],
 "doc:declares": [
 {
-"@id": "#119",
+"@id": "#132",
 "@type": [
 "raml-shapes:ArrayShape",
 "shacl:Shape",
@@ -18237,7 +18886,7 @@
 ],
 "raml-shapes:items": [
 {
-"@id": "#120/linked_2",
+"@id": "#133/linked_2",
 "@type": [
 "shacl:NodeShape",
 "shacl:Shape",
@@ -18246,7 +18895,7 @@
 ],
 "doc:link-target": [
 {
-"@id": "#120"
+"@id": "#133"
 }
 ],
 "doc:link-label": [
@@ -18263,7 +18912,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#119/source-map",
+"@id": "#132/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -18271,7 +18920,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#119"
+"@value": "amf://id#132"
 }
 ],
 "sourcemaps:value": [
@@ -18297,7 +18946,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#119"
+"@value": "amf://id#132"
 }
 ],
 "sourcemaps:value": [
@@ -18311,7 +18960,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#119"
+"@value": "amf://id#132"
 }
 ],
 "sourcemaps:value": [
@@ -18325,7 +18974,7 @@
 ]
 },
 {
-"@id": "#125",
+"@id": "#138",
 "@type": [
 "shacl:NodeShape",
 "shacl:Shape",
@@ -18339,7 +18988,7 @@
 ],
 "shacl:property": [
 {
-"@id": "#32",
+"@id": "#38",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -18352,7 +19001,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#33",
+"@id": "#39",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -18369,14 +19018,14 @@
 "@value": "favouriteTime"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "The person's favourite time of day"
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#33/source-map",
+"@id": "#39/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -18384,7 +19033,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#33"
+"@value": "amf://id#39"
 }
 ],
 "sourcemaps:value": [
@@ -18398,7 +19047,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -18410,7 +19059,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#33"
+"@value": "amf://id#39"
 }
 ],
 "sourcemaps:value": [
@@ -18448,7 +19097,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#32/source-map",
+"@id": "#38/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -18456,7 +19105,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#32"
+"@value": "amf://id#38"
 }
 ],
 "sourcemaps:value": [
@@ -18470,7 +19119,7 @@
 ]
 },
 {
-"@id": "#34",
+"@id": "#40",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -18483,7 +19132,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#35",
+"@id": "#41",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -18515,16 +19164,23 @@
 "@value": "favouriteNumber"
 }
 ],
-"schema-org:name": [
+"core:name": [
 {
 "@value": "Favourite number"
 }
 ],
-"doc:examples": [
+"apiContract:examples": [
 {
-"@id": "#36",
+"@id": "#42",
 "@type": [
-"doc:Example",
+"apiContract:NamedExamples",
+"doc:DomainElement"
+],
+"apiContract:examples": [
+{
+"@id": "#43",
+"@type": [
+"apiContract:Example",
 "doc:DomainElement"
 ],
 "doc:strict": [
@@ -18534,9 +19190,11 @@
 ],
 "doc:structuredValue": [
 {
-"@id": "#36",
+"@id": "#43",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -18546,7 +19204,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#36/source-map",
+"@id": "#43/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -18554,7 +19212,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#36"
+"@value": "amf://id#43"
 }
 ],
 "sourcemaps:value": [
@@ -18575,7 +19233,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#36/source-map",
+"@id": "#43/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -18609,7 +19267,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#36"
+"@value": "amf://id#43"
 }
 ],
 "sourcemaps:value": [
@@ -18622,10 +19280,12 @@
 }
 ]
 }
+]
+}
 ],
 "sourcemaps:sources": [
 {
-"@id": "#35/source-map",
+"@id": "#41/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -18633,7 +19293,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#35"
+"@value": "amf://id#41"
 }
 ],
 "sourcemaps:value": [
@@ -18647,7 +19307,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:name"
+"@value": "core:name"
 }
 ],
 "sourcemaps:value": [
@@ -18683,7 +19343,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#35"
+"@value": "amf://id#41"
 }
 ],
 "sourcemaps:value": [
@@ -18733,7 +19393,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#34/source-map",
+"@id": "#40/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -18753,7 +19413,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#34"
+"@value": "amf://id#40"
 }
 ],
 "sourcemaps:value": [
@@ -18767,7 +19427,7 @@
 ]
 },
 {
-"@id": "#37",
+"@id": "#44",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -18780,7 +19440,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#38",
+"@id": "#45",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -18799,9 +19459,11 @@
 ],
 "shacl:defaultValue": [
 {
-"@id": "#39",
+"@id": "#46",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -18811,7 +19473,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#39/source-map",
+"@id": "#46/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -18819,7 +19481,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#39"
+"@value": "amf://id#46"
 }
 ],
 "sourcemaps:value": [
@@ -18840,7 +19502,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#38/source-map",
+"@id": "#45/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -18848,7 +19510,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#38"
+"@value": "amf://id#45"
 }
 ],
 "sourcemaps:value": [
@@ -18874,7 +19536,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#38"
+"@value": "amf://id#45"
 }
 ],
 "sourcemaps:value": [
@@ -18912,7 +19574,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#37/source-map",
+"@id": "#44/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -18932,7 +19594,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#37"
+"@value": "amf://id#44"
 }
 ],
 "sourcemaps:value": [
@@ -18946,7 +19608,7 @@
 ]
 },
 {
-"@id": "#40",
+"@id": "#47",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -18959,7 +19621,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#41",
+"@id": "#48",
 "@type": [
 "raml-shapes:FileShape",
 "shacl:Shape",
@@ -18991,7 +19653,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#41/source-map",
+"@id": "#48/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -18999,7 +19661,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#41"
+"@value": "amf://id#48"
 }
 ],
 "sourcemaps:value": [
@@ -19037,7 +19699,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#41"
+"@value": "amf://id#48"
 }
 ],
 "sourcemaps:value": [
@@ -19075,7 +19737,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#40/source-map",
+"@id": "#47/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -19095,7 +19757,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#40"
+"@value": "amf://id#47"
 }
 ],
 "sourcemaps:value": [
@@ -19109,7 +19771,7 @@
 ]
 },
 {
-"@id": "#42",
+"@id": "#35",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -19122,7 +19784,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#43",
+"@id": "#36",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -19139,14 +19801,14 @@
 "@value": "etag"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "ETag of this resource for caching purposes.\n__This property will be ignored when creating an object.__\n"
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#43/source-map",
+"@id": "#36/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -19154,7 +19816,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#43"
+"@value": "amf://id#36"
 }
 ],
 "sourcemaps:value": [
@@ -19168,7 +19830,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -19180,7 +19842,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#43"
+"@value": "amf://id#36"
 }
 ],
 "sourcemaps:value": [
@@ -19218,7 +19880,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#42/source-map",
+"@id": "#35/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -19226,7 +19888,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#42"
+"@value": "amf://id#35"
 }
 ],
 "sourcemaps:value": [
@@ -19240,7 +19902,7 @@
 ]
 },
 {
-"@id": "#44",
+"@id": "#49",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -19253,7 +19915,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#45",
+"@id": "#50",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -19270,14 +19932,14 @@
 "@value": "tagline"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "The brief description (tagline) of this person."
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#45/source-map",
+"@id": "#50/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -19285,7 +19947,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#45"
+"@value": "amf://id#50"
 }
 ],
 "sourcemaps:value": [
@@ -19299,7 +19961,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -19311,7 +19973,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#45"
+"@value": "amf://id#50"
 }
 ],
 "sourcemaps:value": [
@@ -19349,7 +20011,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#44/source-map",
+"@id": "#49/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -19357,7 +20019,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#44"
+"@value": "amf://id#49"
 }
 ],
 "sourcemaps:value": [
@@ -19371,7 +20033,7 @@
 ]
 },
 {
-"@id": "#46",
+"@id": "#51",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -19384,7 +20046,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#47",
+"@id": "#52",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -19406,16 +20068,23 @@
 "@value": "name"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "Person full name. The input will be rejected if this property is not set while creating new object."
 }
 ],
-"doc:examples": [
+"apiContract:examples": [
 {
-"@id": "#48",
+"@id": "#53",
 "@type": [
-"doc:Example",
+"apiContract:NamedExamples",
+"doc:DomainElement"
+],
+"apiContract:examples": [
+{
+"@id": "#54",
+"@type": [
+"apiContract:Example",
 "doc:DomainElement"
 ],
 "doc:strict": [
@@ -19425,9 +20094,11 @@
 ],
 "doc:structuredValue": [
 {
-"@id": "#48",
+"@id": "#54",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -19437,7 +20108,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#48/source-map",
+"@id": "#54/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -19445,7 +20116,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#48"
+"@value": "amf://id#54"
 }
 ],
 "sourcemaps:value": [
@@ -19466,7 +20137,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#48/source-map",
+"@id": "#54/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -19500,7 +20171,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#48"
+"@value": "amf://id#54"
 }
 ],
 "sourcemaps:value": [
@@ -19513,10 +20184,12 @@
 }
 ]
 }
+]
+}
 ],
 "sourcemaps:sources": [
 {
-"@id": "#47/source-map",
+"@id": "#52/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -19524,7 +20197,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#47"
+"@value": "amf://id#52"
 }
 ],
 "sourcemaps:value": [
@@ -19538,7 +20211,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -19562,7 +20235,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#47"
+"@value": "amf://id#52"
 }
 ],
 "sourcemaps:value": [
@@ -19600,7 +20273,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#46/source-map",
+"@id": "#51/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -19620,7 +20293,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#46"
+"@value": "amf://id#51"
 }
 ],
 "sourcemaps:value": [
@@ -19634,7 +20307,7 @@
 ]
 },
 {
-"@id": "#49",
+"@id": "#55",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -19647,7 +20320,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#50",
+"@id": "#56",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -19664,11 +20337,18 @@
 "@value": "created"
 }
 ],
-"doc:examples": [
+"apiContract:examples": [
 {
-"@id": "#51",
+"@id": "#57",
 "@type": [
-"doc:Example",
+"apiContract:NamedExamples",
+"doc:DomainElement"
+],
+"apiContract:examples": [
+{
+"@id": "#58",
+"@type": [
+"apiContract:Example",
 "doc:DomainElement"
 ],
 "doc:strict": [
@@ -19678,9 +20358,11 @@
 ],
 "doc:structuredValue": [
 {
-"@id": "#51",
+"@id": "#58",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -19690,7 +20372,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#51/source-map",
+"@id": "#58/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -19698,7 +20380,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#51"
+"@value": "amf://id#58"
 }
 ],
 "sourcemaps:value": [
@@ -19719,7 +20401,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#51/source-map",
+"@id": "#58/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -19753,7 +20435,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#51"
+"@value": "amf://id#58"
 }
 ],
 "sourcemaps:value": [
@@ -19766,10 +20448,12 @@
 }
 ]
 }
+]
+}
 ],
 "sourcemaps:sources": [
 {
-"@id": "#50/source-map",
+"@id": "#56/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -19777,7 +20461,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#50"
+"@value": "amf://id#56"
 }
 ],
 "sourcemaps:value": [
@@ -19803,7 +20487,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#50"
+"@value": "amf://id#56"
 }
 ],
 "sourcemaps:value": [
@@ -19829,7 +20513,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#49/source-map",
+"@id": "#55/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -19849,7 +20533,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#49"
+"@value": "amf://id#55"
 }
 ],
 "sourcemaps:value": [
@@ -19863,7 +20547,7 @@
 ]
 },
 {
-"@id": "#52",
+"@id": "#59",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -19876,7 +20560,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#53",
+"@id": "#60",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -19893,14 +20577,14 @@
 "@value": "url"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "The URL of this person's profile."
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#53/source-map",
+"@id": "#60/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -19908,7 +20592,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#53"
+"@value": "amf://id#60"
 }
 ],
 "sourcemaps:value": [
@@ -19922,7 +20606,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -19934,7 +20618,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#53"
+"@value": "amf://id#60"
 }
 ],
 "sourcemaps:value": [
@@ -19972,7 +20656,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#52/source-map",
+"@id": "#59/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -19980,7 +20664,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#52"
+"@value": "amf://id#59"
 }
 ],
 "sourcemaps:value": [
@@ -19994,7 +20678,7 @@
 ]
 },
 {
-"@id": "#54",
+"@id": "#61",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -20007,7 +20691,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#55",
+"@id": "#62",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -20039,14 +20723,14 @@
 "@value": "id"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "A unique identifier of a person.\n\nIt is a 32 bit string containing alphanumeric characters.\n"
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#55/source-map",
+"@id": "#62/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -20054,7 +20738,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -20078,7 +20762,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#55"
+"@value": "amf://id#62"
 }
 ],
 "sourcemaps:value": [
@@ -20128,7 +20812,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#54/source-map",
+"@id": "#61/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -20136,7 +20820,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#54"
+"@value": "amf://id#61"
 }
 ],
 "sourcemaps:value": [
@@ -20150,7 +20834,7 @@
 ]
 },
 {
-"@id": "#56",
+"@id": "#63",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -20163,7 +20847,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#57",
+"@id": "#64",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -20180,14 +20864,14 @@
 "@value": "language"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "The user's preferred language for rendering."
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#57/source-map",
+"@id": "#64/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -20195,7 +20879,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#57"
+"@value": "amf://id#64"
 }
 ],
 "sourcemaps:value": [
@@ -20209,7 +20893,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -20221,7 +20905,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#57"
+"@value": "amf://id#64"
 }
 ],
 "sourcemaps:value": [
@@ -20259,7 +20943,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#56/source-map",
+"@id": "#63/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -20267,7 +20951,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#56"
+"@value": "amf://id#63"
 }
 ],
 "sourcemaps:value": [
@@ -20281,7 +20965,7 @@
 ]
 },
 {
-"@id": "#58",
+"@id": "#65",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -20294,7 +20978,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#59",
+"@id": "#66",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -20311,14 +20995,14 @@
 "@value": "age"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "Very unpractical property to have in a data store.\n"
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#59/source-map",
+"@id": "#66/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -20326,7 +21010,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#59"
+"@value": "amf://id#66"
 }
 ],
 "sourcemaps:value": [
@@ -20340,7 +21024,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -20352,7 +21036,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#59"
+"@value": "amf://id#66"
 }
 ],
 "sourcemaps:value": [
@@ -20390,7 +21074,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#58/source-map",
+"@id": "#65/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -20410,7 +21094,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#58"
+"@value": "amf://id#65"
 }
 ],
 "sourcemaps:value": [
@@ -20424,7 +21108,7 @@
 ]
 },
 {
-"@id": "#60",
+"@id": "#67",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -20437,7 +21121,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#61",
+"@id": "#68",
 "@type": [
 "raml-shapes:UnionShape",
 "shacl:Shape",
@@ -20445,7 +21129,7 @@
 ],
 "raml-shapes:anyOf": [
 {
-"@id": "#62",
+"@id": "#69",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -20459,7 +21143,7 @@
 ]
 },
 {
-"@id": "#63",
+"@id": "#70",
 "@type": [
 "raml-shapes:NilShape",
 "shacl:Shape",
@@ -20474,7 +21158,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#61/source-map",
+"@id": "#68/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -20482,7 +21166,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#61"
+"@value": "amf://id#68"
 }
 ],
 "sourcemaps:value": [
@@ -20496,7 +21180,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#61"
+"@value": "amf://id#68"
 }
 ],
 "sourcemaps:value": [
@@ -20522,7 +21206,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#60/source-map",
+"@id": "#67/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -20530,7 +21214,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#60"
+"@value": "amf://id#67"
 }
 ],
 "sourcemaps:value": [
@@ -20544,7 +21228,7 @@
 ]
 },
 {
-"@id": "#64",
+"@id": "#71",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -20557,7 +21241,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#65",
+"@id": "#72",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -20574,14 +21258,14 @@
 "@value": "birthday"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "The person's date of birth, represented as YYYY-MM-DD."
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#65/source-map",
+"@id": "#72/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -20589,7 +21273,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#65"
+"@value": "amf://id#72"
 }
 ],
 "sourcemaps:value": [
@@ -20603,7 +21287,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -20615,7 +21299,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#65"
+"@value": "amf://id#72"
 }
 ],
 "sourcemaps:value": [
@@ -20653,7 +21337,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#64/source-map",
+"@id": "#71/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -20661,7 +21345,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#64"
+"@value": "amf://id#71"
 }
 ],
 "sourcemaps:value": [
@@ -20675,7 +21359,7 @@
 ]
 },
 {
-"@id": "#66",
+"@id": "#73",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -20688,7 +21372,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#18",
+"@id": "#19",
 "@type": [
 "shacl:NodeShape",
 "shacl:Shape",
@@ -20702,7 +21386,7 @@
 ],
 "shacl:property": [
 {
-"@id": "#19",
+"@id": "#20",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -20715,7 +21399,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#20",
+"@id": "#21",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -20732,14 +21416,14 @@
 "@value": "url"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "The URL of the image.\nTo resize the image and crop it to a square, append the query string **?sz=x**, where x is the dimension in pixels of each side.\n"
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#20/source-map",
+"@id": "#21/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -20747,7 +21431,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#20"
+"@value": "amf://id#21"
 }
 ],
 "sourcemaps:value": [
@@ -20761,7 +21445,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -20773,7 +21457,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#20"
+"@value": "amf://id#21"
 }
 ],
 "sourcemaps:value": [
@@ -20811,7 +21495,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#19/source-map",
+"@id": "#20/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -20819,7 +21503,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#19"
+"@value": "amf://id#20"
 }
 ],
 "sourcemaps:value": [
@@ -20833,7 +21517,7 @@
 ]
 },
 {
-"@id": "#21",
+"@id": "#22",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -20846,7 +21530,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#22",
+"@id": "#23",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -20863,19 +21547,19 @@
 "@value": "thumb"
 }
 ],
-"schema-org:name": [
+"core:name": [
 {
 "@value": "Thumbnail"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "An URL to the thumbnail of the image. Thumbnails are 60x60px cropped images of the original image.\n"
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#22/source-map",
+"@id": "#23/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -20883,7 +21567,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#22"
+"@value": "amf://id#23"
 }
 ],
 "sourcemaps:value": [
@@ -20897,7 +21581,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -20921,7 +21605,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#22"
+"@value": "amf://id#23"
 }
 ],
 "sourcemaps:value": [
@@ -20933,7 +21617,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:name"
+"@value": "core:name"
 }
 ],
 "sourcemaps:value": [
@@ -20959,7 +21643,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#21/source-map",
+"@id": "#22/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -20967,7 +21651,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#21"
+"@value": "amf://id#22"
 }
 ],
 "sourcemaps:value": [
@@ -20986,16 +21670,23 @@
 "@value": "amf_inline_type_2"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "An image object representing an image object strored in the file store.\nThe image can be only included in the response. It has no effect if the Image appear in the\nrequest. Endpoint handles image creation on it's own and clients can't process images\nexcept of sending image data.\n"
 }
 ],
-"doc:examples": [
+"apiContract:examples": [
 {
-"@id": "#23",
+"@id": "#24",
 "@type": [
-"doc:Example",
+"apiContract:NamedExamples",
+"doc:DomainElement"
+],
+"apiContract:examples": [
+{
+"@id": "#25",
+"@type": [
+"apiContract:Example",
 "doc:DomainElement"
 ],
 "doc:strict": [
@@ -21005,15 +21696,19 @@
 ],
 "doc:structuredValue": [
 {
-"@id": "#23",
+"@id": "#25",
 "@type": [
-"data:Object"
+"data:Object",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:thumb": [
 {
-"@id": "#24",
+"@id": "#26",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -21023,7 +21718,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#24/source-map",
+"@id": "#26/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -21031,7 +21726,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#24"
+"@value": "amf://id#26"
 }
 ],
 "sourcemaps:value": [
@@ -21047,9 +21742,11 @@
 ],
 "data:url": [
 {
-"@id": "#25",
+"@id": "#27",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -21059,7 +21756,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#25/source-map",
+"@id": "#27/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -21067,7 +21764,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#25"
+"@value": "amf://id#27"
 }
 ],
 "sourcemaps:value": [
@@ -21083,7 +21780,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#23/source-map",
+"@id": "#25/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -21091,12 +21788,36 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#23"
+"@value": "data:url"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(22,7)-(22,52)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#25"
 }
 ],
 "sourcemaps:value": [
 {
 "@value": "[(22,0)-(24,0)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "data:thumb"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(23,9)-(23,60)]"
 }
 ]
 }
@@ -21105,7 +21826,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#23"
+"@value": "amf://id#25"
 }
 ],
 "sourcemaps:value": [
@@ -21126,7 +21847,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#23/source-map",
+"@id": "#25/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -21160,7 +21881,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#23"
+"@value": "amf://id#25"
 }
 ],
 "sourcemaps:value": [
@@ -21173,10 +21894,12 @@
 }
 ]
 }
+]
+}
 ],
 "sourcemaps:sources": [
 {
-"@id": "#18/source-map",
+"@id": "#19/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -21184,7 +21907,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#18"
+"@value": "amf://id#19"
 }
 ],
 "sourcemaps:value": [
@@ -21198,7 +21921,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#18"
+"@value": "amf://id#19"
 }
 ],
 "sourcemaps:value": [
@@ -21212,7 +21935,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -21224,7 +21947,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#18"
+"@value": "amf://id#19"
 }
 ],
 "sourcemaps:value": [
@@ -21238,7 +21961,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#18"
+"@value": "amf://id#19"
 }
 ],
 "sourcemaps:value": [
@@ -21264,7 +21987,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#66/source-map",
+"@id": "#73/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -21272,7 +21995,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#66"
+"@value": "amf://id#73"
 }
 ],
 "sourcemaps:value": [
@@ -21286,7 +22009,7 @@
 ]
 },
 {
-"@id": "#67",
+"@id": "#74",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -21299,7 +22022,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#68",
+"@id": "#75",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -21316,20 +22039,22 @@
 "@value": "gender?"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "The person's gender. Possible values includes, but are not limited to, the following values:\n* \"male\" - Male gender.\n* \"female\" - Female gender.\n* \"other\" - Other.\n"
 }
 ],
 "shacl:in": [
 {
-"@id": "#68/list",
+"@id": "#75/list",
 "@type": "rdfs:Seq",
 "rdfs:_1": [
 {
-"@id": "#69",
+"@id": "#76",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -21339,7 +22064,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#69/source-map",
+"@id": "#76/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -21347,7 +22072,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#69"
+"@value": "amf://id#76"
 }
 ],
 "sourcemaps:value": [
@@ -21363,9 +22088,11 @@
 ],
 "rdfs:_2": [
 {
-"@id": "#70",
+"@id": "#77",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -21375,7 +22102,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#70/source-map",
+"@id": "#77/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -21383,7 +22110,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#70"
+"@value": "amf://id#77"
 }
 ],
 "sourcemaps:value": [
@@ -21399,9 +22126,11 @@
 ],
 "rdfs:_3": [
 {
-"@id": "#71",
+"@id": "#78",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -21411,7 +22140,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#71/source-map",
+"@id": "#78/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -21419,7 +22148,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#71"
+"@value": "amf://id#78"
 }
 ],
 "sourcemaps:value": [
@@ -21435,14 +22164,21 @@
 ]
 }
 ],
-"doc:examples": [
+"apiContract:examples": [
 {
-"@id": "#72",
+"@id": "#79",
 "@type": [
-"doc:Example",
+"apiContract:NamedExamples",
 "doc:DomainElement"
 ],
-"schema-org:name": [
+"apiContract:examples": [
+{
+"@id": "#80",
+"@type": [
+"apiContract:Example",
+"doc:DomainElement"
+],
+"core:name": [
 {
 "@value": "Women"
 }
@@ -21454,9 +22190,11 @@
 ],
 "doc:structuredValue": [
 {
-"@id": "#72",
+"@id": "#80",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -21466,7 +22204,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#72/source-map",
+"@id": "#80/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -21474,7 +22212,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#72"
+"@value": "amf://id#80"
 }
 ],
 "sourcemaps:value": [
@@ -21495,7 +22233,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#72/source-map",
+"@id": "#80/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -21529,7 +22267,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#72"
+"@value": "amf://id#80"
 }
 ],
 "sourcemaps:value": [
@@ -21541,7 +22279,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:name"
+"@value": "core:name"
 }
 ],
 "sourcemaps:value": [
@@ -21555,12 +22293,12 @@
 ]
 },
 {
-"@id": "#73",
+"@id": "#81",
 "@type": [
-"doc:Example",
+"apiContract:Example",
 "doc:DomainElement"
 ],
-"schema-org:name": [
+"core:name": [
 {
 "@value": "Man"
 }
@@ -21572,9 +22310,11 @@
 ],
 "doc:structuredValue": [
 {
-"@id": "#73",
+"@id": "#81",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -21584,7 +22324,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#73/source-map",
+"@id": "#81/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -21592,7 +22332,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#73"
+"@value": "amf://id#81"
 }
 ],
 "sourcemaps:value": [
@@ -21613,7 +22353,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#73/source-map",
+"@id": "#81/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -21647,7 +22387,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#73"
+"@value": "amf://id#81"
 }
 ],
 "sourcemaps:value": [
@@ -21659,7 +22399,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:name"
+"@value": "core:name"
 }
 ],
 "sourcemaps:value": [
@@ -21673,12 +22413,12 @@
 ]
 },
 {
-"@id": "#74",
+"@id": "#82",
 "@type": [
-"doc:Example",
+"apiContract:Example",
 "doc:DomainElement"
 ],
-"schema-org:name": [
+"core:name": [
 {
 "@value": "Elmo"
 }
@@ -21690,9 +22430,11 @@
 ],
 "doc:structuredValue": [
 {
-"@id": "#74",
+"@id": "#82",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -21702,7 +22444,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#74/source-map",
+"@id": "#82/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -21710,7 +22452,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#74"
+"@value": "amf://id#82"
 }
 ],
 "sourcemaps:value": [
@@ -21731,7 +22473,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#74/source-map",
+"@id": "#82/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -21765,7 +22507,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#74"
+"@value": "amf://id#82"
 }
 ],
 "sourcemaps:value": [
@@ -21777,7 +22519,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:name"
+"@value": "core:name"
 }
 ],
 "sourcemaps:value": [
@@ -21790,10 +22532,12 @@
 }
 ]
 }
+]
+}
 ],
 "sourcemaps:sources": [
 {
-"@id": "#68/source-map",
+"@id": "#75/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -21801,7 +22545,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#68"
+"@value": "amf://id#75"
 }
 ],
 "sourcemaps:value": [
@@ -21839,7 +22583,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#68"
+"@value": "amf://id#75"
 }
 ],
 "sourcemaps:value": [
@@ -21851,7 +22595,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -21877,7 +22621,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#67/source-map",
+"@id": "#74/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -21885,7 +22629,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#67"
+"@value": "amf://id#74"
 }
 ],
 "sourcemaps:value": [
@@ -21904,21 +22648,28 @@
 "@value": "AppPerson"
 }
 ],
-"schema-org:name": [
+"core:name": [
 {
 "@value": "A person resource"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "An object representing a person in the API.\nThis object will be used in all methods returning a Person or list of people.\n"
 }
 ],
-"doc:examples": [
+"apiContract:examples": [
 {
-"@id": "#75",
+"@id": "#83",
 "@type": [
-"doc:Example",
+"apiContract:NamedExamples",
+"doc:DomainElement"
+],
+"apiContract:examples": [
+{
+"@id": "#84",
+"@type": [
+"apiContract:Example",
 "doc:DomainElement"
 ],
 "doc:strict": [
@@ -21928,351 +22679,23 @@
 ],
 "doc:structuredValue": [
 {
-"@id": "#75",
+"@id": "#84",
 "@type": [
-"data:Object"
+"data:Object",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:birthday": [
 {
-"@id": "#76",
+"@id": "#85",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
 "@value": "1983-10-20",
-"@type": "xsd:string"
-}
-],
-"sourcemaps:sources": [
-{
-"@id": "#76/source-map",
-"@type": [
-"sourcemaps:SourceMap"
-],
-"sourcemaps:lexical": [
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#76"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(12,12)-(12,24)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"data:etag": [
-{
-"@id": "#77",
-"@type": [
-"data:Scalar"
-],
-"data:value": [
-{
-"@value": "W\\244m4n5kj3gbn2nj4k4n4",
-"@type": "xsd:string"
-}
-],
-"sourcemaps:sources": [
-{
-"@id": "#77/source-map",
-"@type": [
-"sourcemaps:SourceMap"
-],
-"sourcemaps:lexical": [
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#77"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(20,8)-(20,34)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"data:favouriteNumber": [
-{
-"@id": "#78",
-"@type": [
-"data:Scalar"
-],
-"data:value": [
-{
-"@value": "10",
-"@type": "xsd:integer"
-}
-],
-"sourcemaps:sources": [
-{
-"@id": "#78/source-map",
-"@type": [
-"sourcemaps:SourceMap"
-],
-"sourcemaps:lexical": [
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#78"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(21,19)-(21,21)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"data:favouriteTime": [
-{
-"@id": "#79",
-"@type": [
-"data:Scalar"
-],
-"data:value": [
-{
-"@value": "10:29:52",
-"@type": "xsd:string"
-}
-],
-"sourcemaps:sources": [
-{
-"@id": "#79/source-map",
-"@type": [
-"sourcemaps:SourceMap"
-],
-"sourcemaps:lexical": [
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#79"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(22,17)-(22,25)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"data:gender": [
-{
-"@id": "#80",
-"@type": [
-"data:Scalar"
-],
-"data:value": [
-{
-"@value": "male",
-"@type": "xsd:string"
-}
-],
-"sourcemaps:sources": [
-{
-"@id": "#80/source-map",
-"@type": [
-"sourcemaps:SourceMap"
-],
-"sourcemaps:lexical": [
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#80"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(13,10)-(13,14)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"data:id": [
-{
-"@id": "#81",
-"@type": [
-"data:Scalar"
-],
-"data:value": [
-{
-"@value": "R34fg663H9KW9MMSKISIhTs1dR7Hss7e",
-"@type": "xsd:string"
-}
-],
-"sourcemaps:sources": [
-{
-"@id": "#81/source-map",
-"@type": [
-"sourcemaps:SourceMap"
-],
-"sourcemaps:lexical": [
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#81"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(10,6)-(10,40)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"data:image": [
-{
-"@id": "#82",
-"@type": [
-"data:Object"
-],
-"data:thumb": [
-{
-"@id": "#83",
-"@type": [
-"data:Scalar"
-],
-"data:value": [
-{
-"@value": "https://domain.com/profile/pawel.psztyc/image/thumb",
-"@type": "xsd:string"
-}
-],
-"sourcemaps:sources": [
-{
-"@id": "#83/source-map",
-"@type": [
-"sourcemaps:SourceMap"
-],
-"sourcemaps:lexical": [
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#83"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(17,11)-(17,62)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"data:url": [
-{
-"@id": "#84",
-"@type": [
-"data:Scalar"
-],
-"data:value": [
-{
-"@value": "https://domain.com/profile/pawel.psztyc/image",
-"@type": "xsd:string"
-}
-],
-"sourcemaps:sources": [
-{
-"@id": "#84/source-map",
-"@type": [
-"sourcemaps:SourceMap"
-],
-"sourcemaps:lexical": [
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#84"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(16,9)-(16,54)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"sourcemaps:sources": [
-{
-"@id": "#82/source-map",
-"@type": [
-"sourcemaps:SourceMap"
-],
-"sourcemaps:data-node-properties": [
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#82"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "url->[(16,4)-(17,0)]#thumb->[(17,4)-(18,0)]"
-}
-]
-}
-],
-"sourcemaps:lexical": [
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#82"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(16,0)-(18,0)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"data:language": [
-{
-"@id": "#85",
-"@type": [
-"data:Scalar"
-],
-"data:value": [
-{
-"@value": "en_GB",
 "@type": "xsd:string"
 }
 ],
@@ -22291,7 +22714,7 @@
 ],
 "sourcemaps:value": [
 {
-"@value": "[(19,12)-(19,17)]"
+"@value": "[(12,12)-(12,24)]"
 }
 ]
 }
@@ -22300,15 +22723,17 @@
 ]
 }
 ],
-"data:name": [
+"data:etag": [
 {
 "@id": "#86",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
-"@value": "Pawel Psztyc",
+"@value": "W\\244m4n5kj3gbn2nj4k4n4",
 "@type": "xsd:string"
 }
 ],
@@ -22327,7 +22752,7 @@
 ],
 "sourcemaps:value": [
 {
-"@value": "[(11,8)-(11,22)]"
+"@value": "[(20,8)-(20,34)]"
 }
 ]
 }
@@ -22336,16 +22761,18 @@
 ]
 }
 ],
-"data:nillable": [
+"data:favouriteNumber": [
 {
 "@id": "#87",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
-"@value": "null",
-"@type": "xsd:nil"
+"@value": "10",
+"@type": "xsd:integer"
 }
 ],
 "sourcemaps:sources": [
@@ -22363,7 +22790,7 @@
 ],
 "sourcemaps:value": [
 {
-"@value": "[(23,12)-(23,16)]"
+"@value": "[(21,19)-(21,21)]"
 }
 ]
 }
@@ -22372,15 +22799,17 @@
 ]
 }
 ],
-"data:tagline": [
+"data:favouriteTime": [
 {
 "@id": "#88",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
-"@value": "Some text about me.",
+"@value": "10:29:52",
 "@type": "xsd:string"
 }
 ],
@@ -22399,7 +22828,7 @@
 ],
 "sourcemaps:value": [
 {
-"@value": "[(18,11)-(18,30)]"
+"@value": "[(22,17)-(22,25)]"
 }
 ]
 }
@@ -22408,15 +22837,17 @@
 ]
 }
 ],
-"data:url": [
+"data:gender": [
 {
 "@id": "#89",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
-"@value": "https://domain.com/profile/pawel.psztyc",
+"@value": "male",
 "@type": "xsd:string"
 }
 ],
@@ -22435,6 +22866,380 @@
 ],
 "sourcemaps:value": [
 {
+"@value": "[(13,10)-(13,14)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"data:id": [
+{
+"@id": "#90",
+"@type": [
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
+],
+"data:value": [
+{
+"@value": "R34fg663H9KW9MMSKISIhTs1dR7Hss7e",
+"@type": "xsd:string"
+}
+],
+"sourcemaps:sources": [
+{
+"@id": "#90/source-map",
+"@type": [
+"sourcemaps:SourceMap"
+],
+"sourcemaps:lexical": [
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#90"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(10,6)-(10,40)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"data:image": [
+{
+"@id": "#91",
+"@type": [
+"data:Object",
+"data:Node",
+"doc:DomainElement"
+],
+"data:thumb": [
+{
+"@id": "#92",
+"@type": [
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
+],
+"data:value": [
+{
+"@value": "https://domain.com/profile/pawel.psztyc/image/thumb",
+"@type": "xsd:string"
+}
+],
+"sourcemaps:sources": [
+{
+"@id": "#92/source-map",
+"@type": [
+"sourcemaps:SourceMap"
+],
+"sourcemaps:lexical": [
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#92"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(17,11)-(17,62)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"data:url": [
+{
+"@id": "#93",
+"@type": [
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
+],
+"data:value": [
+{
+"@value": "https://domain.com/profile/pawel.psztyc/image",
+"@type": "xsd:string"
+}
+],
+"sourcemaps:sources": [
+{
+"@id": "#93/source-map",
+"@type": [
+"sourcemaps:SourceMap"
+],
+"sourcemaps:lexical": [
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#93"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(16,9)-(16,54)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"sourcemaps:sources": [
+{
+"@id": "#91/source-map",
+"@type": [
+"sourcemaps:SourceMap"
+],
+"sourcemaps:data-node-properties": [
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#91"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "url->[(16,4)-(17,0)]#thumb->[(17,4)-(18,0)]"
+}
+]
+}
+],
+"sourcemaps:lexical": [
+{
+"sourcemaps:element": [
+{
+"@value": "data:url"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(16,9)-(16,54)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#91"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(16,0)-(18,0)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "data:thumb"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(17,11)-(17,62)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"data:language": [
+{
+"@id": "#94",
+"@type": [
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
+],
+"data:value": [
+{
+"@value": "en_GB",
+"@type": "xsd:string"
+}
+],
+"sourcemaps:sources": [
+{
+"@id": "#94/source-map",
+"@type": [
+"sourcemaps:SourceMap"
+],
+"sourcemaps:lexical": [
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#94"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(19,12)-(19,17)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"data:name": [
+{
+"@id": "#95",
+"@type": [
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
+],
+"data:value": [
+{
+"@value": "Pawel Psztyc",
+"@type": "xsd:string"
+}
+],
+"sourcemaps:sources": [
+{
+"@id": "#95/source-map",
+"@type": [
+"sourcemaps:SourceMap"
+],
+"sourcemaps:lexical": [
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#95"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(11,8)-(11,22)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"data:nillable": [
+{
+"@id": "#96",
+"@type": [
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
+],
+"data:value": [
+{
+"@value": "null",
+"@type": "xsd:nil"
+}
+],
+"sourcemaps:sources": [
+{
+"@id": "#96/source-map",
+"@type": [
+"sourcemaps:SourceMap"
+],
+"sourcemaps:lexical": [
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#96"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(23,12)-(23,16)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"data:tagline": [
+{
+"@id": "#97",
+"@type": [
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
+],
+"data:value": [
+{
+"@value": "Some text about me.",
+"@type": "xsd:string"
+}
+],
+"sourcemaps:sources": [
+{
+"@id": "#97/source-map",
+"@type": [
+"sourcemaps:SourceMap"
+],
+"sourcemaps:lexical": [
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#97"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(18,11)-(18,30)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"data:url": [
+{
+"@id": "#98",
+"@type": [
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
+],
+"data:value": [
+{
+"@value": "https://domain.com/profile/pawel.psztyc",
+"@type": "xsd:string"
+}
+],
+"sourcemaps:sources": [
+{
+"@id": "#98/source-map",
+"@type": [
+"sourcemaps:SourceMap"
+],
+"sourcemaps:lexical": [
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#98"
+}
+],
+"sourcemaps:value": [
+{
 "@value": "[(14,7)-(14,48)]"
 }
 ]
@@ -22446,7 +23251,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#75/source-map",
+"@id": "#84/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -22454,12 +23259,156 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#75"
+"@value": "data:url"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(14,7)-(14,48)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "data:nillable"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(23,12)-(23,16)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "data:language"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(19,12)-(19,17)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "data:id"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(10,6)-(10,40)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "data:favouriteTime"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(22,17)-(22,25)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "data:etag"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(20,8)-(20,34)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#84"
 }
 ],
 "sourcemaps:value": [
 {
 "@value": "[(10,0)-(25,0)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "data:birthday"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(12,12)-(12,24)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "data:favouriteNumber"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(21,19)-(21,21)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "data:gender"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(13,10)-(13,14)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "data:image"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(16,0)-(18,0)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "data:name"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(11,8)-(11,22)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "data:tagline"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(18,11)-(18,30)]"
 }
 ]
 }
@@ -22468,7 +23417,19 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#75"
+"@value": "data:image"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "url->[(16,4)-(17,0)]#thumb->[(17,4)-(18,0)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#84"
 }
 ],
 "sourcemaps:value": [
@@ -22489,7 +23450,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#75/source-map",
+"@id": "#84/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -22523,7 +23484,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#75"
+"@value": "amf://id#84"
 }
 ],
 "sourcemaps:value": [
@@ -22536,10 +23497,12 @@
 }
 ]
 }
+]
+}
 ],
 "sourcemaps:sources": [
 {
-"@id": "#125/source-map",
+"@id": "#138/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -22547,7 +23510,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#125"
+"@value": "amf://id#138"
 }
 ],
 "sourcemaps:value": [
@@ -22561,7 +23524,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#125"
+"@value": "amf://id#138"
 }
 ],
 "sourcemaps:value": [
@@ -22575,7 +23538,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -22587,7 +23550,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#125"
+"@value": "amf://id#138"
 }
 ],
 "sourcemaps:value": [
@@ -22599,7 +23562,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:name"
+"@value": "core:name"
 }
 ],
 "sourcemaps:value": [
@@ -22613,7 +23576,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#125"
+"@value": "amf://id#138"
 }
 ],
 "sourcemaps:value": [
@@ -22627,7 +23590,7 @@
 ]
 },
 {
-"@id": "#126",
+"@id": "#139",
 "@type": [
 "shacl:NodeShape",
 "shacl:Shape",
@@ -22641,7 +23604,7 @@
 ],
 "shacl:property": [
 {
-"@id": "#42",
+"@id": "#35",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -22654,7 +23617,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#43",
+"@id": "#36",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -22671,14 +23634,14 @@
 "@value": "etag"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "ETag of this resource for caching purposes.\n__This property will be ignored when creating an object.__\n"
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#43/source-map",
+"@id": "#36/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -22686,7 +23649,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#43"
+"@value": "amf://id#36"
 }
 ],
 "sourcemaps:value": [
@@ -22700,7 +23663,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -22712,7 +23675,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#43"
+"@value": "amf://id#36"
 }
 ],
 "sourcemaps:value": [
@@ -22750,7 +23713,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#42/source-map",
+"@id": "#35/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -22758,7 +23721,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#42"
+"@value": "amf://id#35"
 }
 ],
 "sourcemaps:value": [
@@ -22772,7 +23735,7 @@
 ]
 },
 {
-"@id": "#94",
+"@id": "#101",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -22785,7 +23748,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#95",
+"@id": "#102",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -22807,16 +23770,23 @@
 "@value": "upc"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "The Universal Produc Code. It consists of 12 numerical digits. However, because of the\ninteger precision limitation in JavaScript it is represented as a string.\n"
 }
 ],
-"doc:examples": [
+"apiContract:examples": [
 {
-"@id": "#96",
+"@id": "#103",
 "@type": [
-"doc:Example",
+"apiContract:NamedExamples",
+"doc:DomainElement"
+],
+"apiContract:examples": [
+{
+"@id": "#104",
+"@type": [
+"apiContract:Example",
 "doc:DomainElement"
 ],
 "doc:strict": [
@@ -22826,9 +23796,11 @@
 ],
 "doc:structuredValue": [
 {
-"@id": "#96",
+"@id": "#104",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -22838,7 +23810,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#96/source-map",
+"@id": "#104/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -22846,7 +23818,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#96"
+"@value": "amf://id#104"
 }
 ],
 "sourcemaps:value": [
@@ -22867,7 +23839,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#96/source-map",
+"@id": "#104/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -22901,7 +23873,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#96"
+"@value": "amf://id#104"
 }
 ],
 "sourcemaps:value": [
@@ -22914,10 +23886,12 @@
 }
 ]
 }
+]
+}
 ],
 "sourcemaps:sources": [
 {
-"@id": "#95/source-map",
+"@id": "#102/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -22925,7 +23899,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#95"
+"@value": "amf://id#102"
 }
 ],
 "sourcemaps:value": [
@@ -22939,7 +23913,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -22963,7 +23937,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#95"
+"@value": "amf://id#102"
 }
 ],
 "sourcemaps:value": [
@@ -23001,7 +23975,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#94/source-map",
+"@id": "#101/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -23021,7 +23995,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#94"
+"@value": "amf://id#101"
 }
 ],
 "sourcemaps:value": [
@@ -23035,7 +24009,7 @@
 ]
 },
 {
-"@id": "#97",
+"@id": "#105",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -23048,7 +24022,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#98",
+"@id": "#106",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -23065,16 +24039,23 @@
 "@value": "name"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "Product name"
 }
 ],
-"doc:examples": [
+"apiContract:examples": [
 {
-"@id": "#99",
+"@id": "#107",
 "@type": [
-"doc:Example",
+"apiContract:NamedExamples",
+"doc:DomainElement"
+],
+"apiContract:examples": [
+{
+"@id": "#108",
+"@type": [
+"apiContract:Example",
 "doc:DomainElement"
 ],
 "doc:strict": [
@@ -23084,9 +24065,11 @@
 ],
 "doc:structuredValue": [
 {
-"@id": "#99",
+"@id": "#108",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -23096,7 +24079,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#99/source-map",
+"@id": "#108/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -23104,7 +24087,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#99"
+"@value": "amf://id#108"
 }
 ],
 "sourcemaps:value": [
@@ -23125,7 +24108,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#99/source-map",
+"@id": "#108/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -23159,7 +24142,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#99"
+"@value": "amf://id#108"
 }
 ],
 "sourcemaps:value": [
@@ -23172,10 +24155,12 @@
 }
 ]
 }
+]
+}
 ],
 "sourcemaps:sources": [
 {
-"@id": "#98/source-map",
+"@id": "#106/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -23183,7 +24168,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#98"
+"@value": "amf://id#106"
 }
 ],
 "sourcemaps:value": [
@@ -23197,7 +24182,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -23209,7 +24194,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#98"
+"@value": "amf://id#106"
 }
 ],
 "sourcemaps:value": [
@@ -23247,7 +24232,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#97/source-map",
+"@id": "#105/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -23267,7 +24252,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#97"
+"@value": "amf://id#105"
 }
 ],
 "sourcemaps:value": [
@@ -23281,7 +24266,7 @@
 ]
 },
 {
-"@id": "#127",
+"@id": "#140",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -23338,7 +24323,7 @@
 "@value": "width"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "Width of the shape.\n"
 }
@@ -23367,7 +24352,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -23469,7 +24454,7 @@
 "@value": "height"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "Height of the shape.\n"
 }
@@ -23498,7 +24483,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -23600,7 +24585,7 @@
 "@value": "unit?"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "A unit that describes the dimension. It can be, for example, `px` for\npixels, `pt` for points, `%` for percentage.\n"
 }
@@ -23609,7 +24594,9 @@
 {
 "@id": "#9",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -23706,7 +24693,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -23759,16 +24746,23 @@
 "@value": "dimension"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "A dimmensions of an object like image.\n"
 }
 ],
-"doc:examples": [
+"apiContract:examples": [
 {
 "@id": "#10",
 "@type": [
-"doc:Example",
+"apiContract:NamedExamples",
+"doc:DomainElement"
+],
+"apiContract:examples": [
+{
+"@id": "#11",
+"@type": [
+"apiContract:Example",
 "doc:DomainElement"
 ],
 "doc:strict": [
@@ -23778,55 +24772,23 @@
 ],
 "doc:structuredValue": [
 {
-"@id": "#10",
+"@id": "#11",
 "@type": [
-"data:Object"
+"data:Object",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:height": [
 {
-"@id": "#11",
+"@id": "#12",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
 "@value": "160",
-"@type": "xsd:integer"
-}
-],
-"sourcemaps:sources": [
-{
-"@id": "#11/source-map",
-"@type": [
-"sourcemaps:SourceMap"
-],
-"sourcemaps:lexical": [
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#11"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(24,10)-(24,13)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"data:width": [
-{
-"@id": "#12",
-"@type": [
-"data:Scalar"
-],
-"data:value": [
-{
-"@value": "200",
 "@type": "xsd:integer"
 }
 ],
@@ -23845,6 +24807,44 @@
 ],
 "sourcemaps:value": [
 {
+"@value": "[(24,10)-(24,13)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"data:width": [
+{
+"@id": "#13",
+"@type": [
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
+],
+"data:value": [
+{
+"@value": "200",
+"@type": "xsd:integer"
+}
+],
+"sourcemaps:sources": [
+{
+"@id": "#13/source-map",
+"@type": [
+"sourcemaps:SourceMap"
+],
+"sourcemaps:lexical": [
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#13"
+}
+],
+"sourcemaps:value": [
+{
 "@value": "[(23,9)-(23,12)]"
 }
 ]
@@ -23856,7 +24856,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#10/source-map",
+"@id": "#11/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -23864,12 +24864,36 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#10"
+"@value": "data:width"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(23,9)-(23,12)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#11"
 }
 ],
 "sourcemaps:value": [
 {
 "@value": "[(23,0)-(25,0)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "data:height"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(24,10)-(24,13)]"
 }
 ]
 }
@@ -23878,7 +24902,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#10"
+"@value": "amf://id#11"
 }
 ],
 "sourcemaps:value": [
@@ -23899,7 +24923,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#10/source-map",
+"@id": "#11/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -23933,12 +24957,14 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#10"
+"@value": "amf://id#11"
 }
 ],
 "sourcemaps:value": [
 {
 "@value": "[(22,0)-(25,0)]"
+}
+]
 }
 ]
 }
@@ -23971,7 +24997,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -24023,7 +25049,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#127/source-map",
+"@id": "#140/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -24031,7 +25057,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#127"
+"@value": "amf://id#140"
 }
 ],
 "sourcemaps:value": [
@@ -24045,7 +25071,7 @@
 ]
 },
 {
-"@id": "#100",
+"@id": "#109",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -24058,7 +25084,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#101",
+"@id": "#110",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -24080,14 +25106,14 @@
 "@value": "id"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "Product id. It is a UUID of the database record.\n__This property will be ignored when creating an object.__\nIt will be available when the product is stored in the datastore.\n"
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#101/source-map",
+"@id": "#110/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -24095,7 +25121,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -24107,7 +25133,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#101"
+"@value": "amf://id#110"
 }
 ],
 "sourcemaps:value": [
@@ -24145,7 +25171,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#100/source-map",
+"@id": "#109/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -24153,7 +25179,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#100"
+"@value": "amf://id#109"
 }
 ],
 "sourcemaps:value": [
@@ -24167,7 +25193,7 @@
 ]
 },
 {
-"@id": "#102",
+"@id": "#111",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -24180,7 +25206,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#103",
+"@id": "#112",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -24197,16 +25223,23 @@
 "@value": "unit"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "The unit of measuremet for the quantity property."
 }
 ],
-"doc:examples": [
+"apiContract:examples": [
 {
-"@id": "#104",
+"@id": "#113",
 "@type": [
-"doc:Example",
+"apiContract:NamedExamples",
+"doc:DomainElement"
+],
+"apiContract:examples": [
+{
+"@id": "#114",
+"@type": [
+"apiContract:Example",
 "doc:DomainElement"
 ],
 "doc:strict": [
@@ -24216,9 +25249,11 @@
 ],
 "doc:structuredValue": [
 {
-"@id": "#104",
+"@id": "#114",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -24228,7 +25263,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#104/source-map",
+"@id": "#114/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -24236,7 +25271,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#104"
+"@value": "amf://id#114"
 }
 ],
 "sourcemaps:value": [
@@ -24257,7 +25292,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#104/source-map",
+"@id": "#114/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -24291,7 +25326,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#104"
+"@value": "amf://id#114"
 }
 ],
 "sourcemaps:value": [
@@ -24304,10 +25339,12 @@
 }
 ]
 }
+]
+}
 ],
 "sourcemaps:sources": [
 {
-"@id": "#103/source-map",
+"@id": "#112/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -24315,7 +25352,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#103"
+"@value": "amf://id#112"
 }
 ],
 "sourcemaps:value": [
@@ -24329,7 +25366,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -24341,7 +25378,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#103"
+"@value": "amf://id#112"
 }
 ],
 "sourcemaps:value": [
@@ -24379,7 +25416,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#102/source-map",
+"@id": "#111/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -24399,7 +25436,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#102"
+"@value": "amf://id#111"
 }
 ],
 "sourcemaps:value": [
@@ -24413,7 +25450,7 @@
 ]
 },
 {
-"@id": "#105",
+"@id": "#115",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -24426,7 +25463,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#106",
+"@id": "#116",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -24443,16 +25480,23 @@
 "@value": "available"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "Product current availability in the store.\nProduct may be not available but the users still can order it with later delivery date.\n"
 }
 ],
-"doc:examples": [
+"apiContract:examples": [
 {
-"@id": "#107",
+"@id": "#117",
 "@type": [
-"doc:Example",
+"apiContract:NamedExamples",
+"doc:DomainElement"
+],
+"apiContract:examples": [
+{
+"@id": "#118",
+"@type": [
+"apiContract:Example",
 "doc:DomainElement"
 ],
 "doc:strict": [
@@ -24462,9 +25506,11 @@
 ],
 "doc:structuredValue": [
 {
-"@id": "#107",
+"@id": "#118",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -24474,7 +25520,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#107/source-map",
+"@id": "#118/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -24482,7 +25528,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#107"
+"@value": "amf://id#118"
 }
 ],
 "sourcemaps:value": [
@@ -24503,7 +25549,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#107/source-map",
+"@id": "#118/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -24537,7 +25583,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#107"
+"@value": "amf://id#118"
 }
 ],
 "sourcemaps:value": [
@@ -24550,10 +25596,12 @@
 }
 ]
 }
+]
+}
 ],
 "sourcemaps:sources": [
 {
-"@id": "#106/source-map",
+"@id": "#116/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -24561,7 +25609,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#106"
+"@value": "amf://id#116"
 }
 ],
 "sourcemaps:value": [
@@ -24575,7 +25623,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -24587,7 +25635,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#106"
+"@value": "amf://id#116"
 }
 ],
 "sourcemaps:value": [
@@ -24625,7 +25673,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#105/source-map",
+"@id": "#115/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -24645,7 +25693,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#105"
+"@value": "amf://id#115"
 }
 ],
 "sourcemaps:value": [
@@ -24659,7 +25707,7 @@
 ]
 },
 {
-"@id": "#108",
+"@id": "#119",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -24672,7 +25720,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#109",
+"@id": "#120",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -24689,16 +25737,23 @@
 "@value": "quantity"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "The quantity of the product in the one unit of measurement.\nSee `unit` property for more information.\n"
 }
 ],
-"doc:examples": [
+"apiContract:examples": [
 {
-"@id": "#110",
+"@id": "#121",
 "@type": [
-"doc:Example",
+"apiContract:NamedExamples",
+"doc:DomainElement"
+],
+"apiContract:examples": [
+{
+"@id": "#122",
+"@type": [
+"apiContract:Example",
 "doc:DomainElement"
 ],
 "doc:strict": [
@@ -24708,9 +25763,11 @@
 ],
 "doc:structuredValue": [
 {
-"@id": "#110",
+"@id": "#122",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -24720,7 +25777,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#110/source-map",
+"@id": "#122/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -24728,7 +25785,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#110"
+"@value": "amf://id#122"
 }
 ],
 "sourcemaps:value": [
@@ -24749,7 +25806,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#110/source-map",
+"@id": "#122/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -24783,7 +25840,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#110"
+"@value": "amf://id#122"
 }
 ],
 "sourcemaps:value": [
@@ -24796,10 +25853,12 @@
 }
 ]
 }
+]
+}
 ],
 "sourcemaps:sources": [
 {
-"@id": "#109/source-map",
+"@id": "#120/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -24807,7 +25866,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#109"
+"@value": "amf://id#120"
 }
 ],
 "sourcemaps:value": [
@@ -24821,7 +25880,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -24833,7 +25892,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#109"
+"@value": "amf://id#120"
 }
 ],
 "sourcemaps:value": [
@@ -24871,7 +25930,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#108/source-map",
+"@id": "#119/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -24891,7 +25950,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#108"
+"@value": "amf://id#119"
 }
 ],
 "sourcemaps:value": [
@@ -24910,19 +25969,19 @@
 "@value": "ComplexInclusion"
 }
 ],
-"schema-org:name": [
+"core:name": [
 {
 "@value": "A product resource"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "A single product representing an item in the store."
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#126/source-map",
+"@id": "#139/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -24930,7 +25989,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#126"
+"@value": "amf://id#139"
 }
 ],
 "sourcemaps:value": [
@@ -24944,7 +26003,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -24968,7 +26027,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#126"
+"@value": "amf://id#139"
 }
 ],
 "sourcemaps:value": [
@@ -24980,7 +26039,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:name"
+"@value": "core:name"
 }
 ],
 "sourcemaps:value": [
@@ -24994,7 +26053,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#126"
+"@value": "amf://id#139"
 }
 ],
 "sourcemaps:value": [
@@ -25008,7 +26067,7 @@
 ]
 },
 {
-"@id": "#128",
+"@id": "#141",
 "@type": [
 "shacl:NodeShape",
 "shacl:Shape",
@@ -25022,7 +26081,7 @@
 ],
 "shacl:property": [
 {
-"@id": "#129",
+"@id": "#142",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -25035,7 +26094,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#130",
+"@id": "#143",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -25052,16 +26111,18 @@
 "@value": "id"
 }
 ],
-"schema-org:name": [
+"core:name": [
 {
 "@value": "The Id Schema "
 }
 ],
 "shacl:defaultValue": [
 {
-"@id": "#131",
+"@id": "#144",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -25071,7 +26132,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#131/source-map",
+"@id": "#144/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -25079,7 +26140,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#131"
+"@value": "amf://id#144"
 }
 ],
 "sourcemaps:value": [
@@ -25100,7 +26161,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#130/source-map",
+"@id": "#143/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -25108,7 +26169,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#130"
+"@value": "amf://id#143"
 }
 ],
 "sourcemaps:value": [
@@ -25146,7 +26207,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#130"
+"@value": "amf://id#143"
 }
 ],
 "sourcemaps:value": [
@@ -25158,7 +26219,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:name"
+"@value": "core:name"
 }
 ],
 "sourcemaps:value": [
@@ -25184,7 +26245,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#129/source-map",
+"@id": "#142/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -25192,7 +26253,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#129"
+"@value": "amf://id#142"
 }
 ],
 "sourcemaps:value": [
@@ -25206,7 +26267,7 @@
 ]
 },
 {
-"@id": "#132",
+"@id": "#145",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -25219,7 +26280,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#133",
+"@id": "#146",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -25236,16 +26297,18 @@
 "@value": "name"
 }
 ],
-"schema-org:name": [
+"core:name": [
 {
 "@value": "The Name Schema "
 }
 ],
 "shacl:defaultValue": [
 {
-"@id": "#134",
+"@id": "#147",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -25255,7 +26318,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#134/source-map",
+"@id": "#147/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -25263,7 +26326,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#134"
+"@value": "amf://id#147"
 }
 ],
 "sourcemaps:value": [
@@ -25284,7 +26347,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#133/source-map",
+"@id": "#146/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -25292,7 +26355,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#133"
+"@value": "amf://id#146"
 }
 ],
 "sourcemaps:value": [
@@ -25330,7 +26393,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#133"
+"@value": "amf://id#146"
 }
 ],
 "sourcemaps:value": [
@@ -25342,7 +26405,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:name"
+"@value": "core:name"
 }
 ],
 "sourcemaps:value": [
@@ -25368,7 +26431,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#132/source-map",
+"@id": "#145/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -25376,7 +26439,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#132"
+"@value": "amf://id#145"
 }
 ],
 "sourcemaps:value": [
@@ -25390,7 +26453,7 @@
 ]
 },
 {
-"@id": "#135",
+"@id": "#148",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -25403,7 +26466,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#136",
+"@id": "#149",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -25420,16 +26483,18 @@
 "@value": "birthday"
 }
 ],
-"schema-org:name": [
+"core:name": [
 {
 "@value": "The Birthday Schema "
 }
 ],
 "shacl:defaultValue": [
 {
-"@id": "#137",
+"@id": "#150",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -25439,7 +26504,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#137/source-map",
+"@id": "#150/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -25447,7 +26512,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#137"
+"@value": "amf://id#150"
 }
 ],
 "sourcemaps:value": [
@@ -25468,7 +26533,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#136/source-map",
+"@id": "#149/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -25476,7 +26541,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#136"
+"@value": "amf://id#149"
 }
 ],
 "sourcemaps:value": [
@@ -25514,7 +26579,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#136"
+"@value": "amf://id#149"
 }
 ],
 "sourcemaps:value": [
@@ -25526,7 +26591,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:name"
+"@value": "core:name"
 }
 ],
 "sourcemaps:value": [
@@ -25552,7 +26617,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#135/source-map",
+"@id": "#148/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -25560,7 +26625,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#135"
+"@value": "amf://id#148"
 }
 ],
 "sourcemaps:value": [
@@ -25574,7 +26639,7 @@
 ]
 },
 {
-"@id": "#138",
+"@id": "#151",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -25587,7 +26652,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#139",
+"@id": "#152",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -25604,16 +26669,18 @@
 "@value": "gender"
 }
 ],
-"schema-org:name": [
+"core:name": [
 {
 "@value": "The Gender Schema "
 }
 ],
 "shacl:defaultValue": [
 {
-"@id": "#140",
+"@id": "#153",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -25623,7 +26690,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#140/source-map",
+"@id": "#153/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -25631,7 +26698,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#140"
+"@value": "amf://id#153"
 }
 ],
 "sourcemaps:value": [
@@ -25652,7 +26719,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#139/source-map",
+"@id": "#152/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -25660,7 +26727,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#139"
+"@value": "amf://id#152"
 }
 ],
 "sourcemaps:value": [
@@ -25698,7 +26765,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#139"
+"@value": "amf://id#152"
 }
 ],
 "sourcemaps:value": [
@@ -25710,7 +26777,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:name"
+"@value": "core:name"
 }
 ],
 "sourcemaps:value": [
@@ -25736,7 +26803,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#138/source-map",
+"@id": "#151/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -25744,7 +26811,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#138"
+"@value": "amf://id#151"
 }
 ],
 "sourcemaps:value": [
@@ -25758,7 +26825,7 @@
 ]
 },
 {
-"@id": "#141",
+"@id": "#154",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -25771,7 +26838,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#142",
+"@id": "#155",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -25788,16 +26855,18 @@
 "@value": "url"
 }
 ],
-"schema-org:name": [
+"core:name": [
 {
 "@value": "The Url Schema "
 }
 ],
 "shacl:defaultValue": [
 {
-"@id": "#143",
+"@id": "#156",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -25807,7 +26876,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#143/source-map",
+"@id": "#156/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -25815,7 +26884,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#143"
+"@value": "amf://id#156"
 }
 ],
 "sourcemaps:value": [
@@ -25836,7 +26905,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#142/source-map",
+"@id": "#155/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -25844,7 +26913,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#142"
+"@value": "amf://id#155"
 }
 ],
 "sourcemaps:value": [
@@ -25882,7 +26951,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#142"
+"@value": "amf://id#155"
 }
 ],
 "sourcemaps:value": [
@@ -25894,7 +26963,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:name"
+"@value": "core:name"
 }
 ],
 "sourcemaps:value": [
@@ -25920,7 +26989,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#141/source-map",
+"@id": "#154/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -25928,7 +26997,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#141"
+"@value": "amf://id#154"
 }
 ],
 "sourcemaps:value": [
@@ -25942,7 +27011,7 @@
 ]
 },
 {
-"@id": "#144",
+"@id": "#157",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -25955,7 +27024,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#145",
+"@id": "#158",
 "@type": [
 "shacl:NodeShape",
 "shacl:Shape",
@@ -25969,7 +27038,7 @@
 ],
 "shacl:property": [
 {
-"@id": "#146",
+"@id": "#159",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -25982,7 +27051,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#147",
+"@id": "#160",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -25999,16 +27068,18 @@
 "@value": "url"
 }
 ],
-"schema-org:name": [
+"core:name": [
 {
 "@value": "The Url Schema "
 }
 ],
 "shacl:defaultValue": [
 {
-"@id": "#148",
+"@id": "#161",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -26018,7 +27089,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#148/source-map",
+"@id": "#161/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -26026,7 +27097,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#148"
+"@value": "amf://id#161"
 }
 ],
 "sourcemaps:value": [
@@ -26047,7 +27118,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#147/source-map",
+"@id": "#160/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -26055,7 +27126,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#147"
+"@value": "amf://id#160"
 }
 ],
 "sourcemaps:value": [
@@ -26093,7 +27164,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#147"
+"@value": "amf://id#160"
 }
 ],
 "sourcemaps:value": [
@@ -26105,7 +27176,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:name"
+"@value": "core:name"
 }
 ],
 "sourcemaps:value": [
@@ -26131,7 +27202,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#146/source-map",
+"@id": "#159/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -26139,7 +27210,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#146"
+"@value": "amf://id#159"
 }
 ],
 "sourcemaps:value": [
@@ -26153,7 +27224,7 @@
 ]
 },
 {
-"@id": "#149",
+"@id": "#162",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -26166,7 +27237,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#150",
+"@id": "#163",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -26183,16 +27254,18 @@
 "@value": "thumb"
 }
 ],
-"schema-org:name": [
+"core:name": [
 {
 "@value": "The Thumb Schema "
 }
 ],
 "shacl:defaultValue": [
 {
-"@id": "#151",
+"@id": "#164",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -26202,7 +27275,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#151/source-map",
+"@id": "#164/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -26210,7 +27283,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#151"
+"@value": "amf://id#164"
 }
 ],
 "sourcemaps:value": [
@@ -26231,7 +27304,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#150/source-map",
+"@id": "#163/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -26239,7 +27312,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#150"
+"@value": "amf://id#163"
 }
 ],
 "sourcemaps:value": [
@@ -26277,7 +27350,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#150"
+"@value": "amf://id#163"
 }
 ],
 "sourcemaps:value": [
@@ -26289,7 +27362,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:name"
+"@value": "core:name"
 }
 ],
 "sourcemaps:value": [
@@ -26315,7 +27388,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#149/source-map",
+"@id": "#162/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -26323,7 +27396,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#149"
+"@value": "amf://id#162"
 }
 ],
 "sourcemaps:value": [
@@ -26344,7 +27417,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#145/source-map",
+"@id": "#158/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -26352,7 +27425,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#145"
+"@value": "amf://id#158"
 }
 ],
 "sourcemaps:value": [
@@ -26366,7 +27439,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#145"
+"@value": "amf://id#158"
 }
 ],
 "sourcemaps:value": [
@@ -26392,7 +27465,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#144/source-map",
+"@id": "#157/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -26400,7 +27473,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#144"
+"@value": "amf://id#157"
 }
 ],
 "sourcemaps:value": [
@@ -26414,7 +27487,7 @@
 ]
 },
 {
-"@id": "#152",
+"@id": "#165",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -26427,7 +27500,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#153",
+"@id": "#166",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -26444,16 +27517,18 @@
 "@value": "tagline"
 }
 ],
-"schema-org:name": [
+"core:name": [
 {
 "@value": "The Tagline Schema "
 }
 ],
 "shacl:defaultValue": [
 {
-"@id": "#154",
+"@id": "#167",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -26463,7 +27538,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#154/source-map",
+"@id": "#167/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -26471,7 +27546,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#154"
+"@value": "amf://id#167"
 }
 ],
 "sourcemaps:value": [
@@ -26492,7 +27567,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#153/source-map",
+"@id": "#166/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -26500,7 +27575,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#153"
+"@value": "amf://id#166"
 }
 ],
 "sourcemaps:value": [
@@ -26538,7 +27613,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#153"
+"@value": "amf://id#166"
 }
 ],
 "sourcemaps:value": [
@@ -26550,7 +27625,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:name"
+"@value": "core:name"
 }
 ],
 "sourcemaps:value": [
@@ -26576,7 +27651,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#152/source-map",
+"@id": "#165/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -26584,7 +27659,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#152"
+"@value": "amf://id#165"
 }
 ],
 "sourcemaps:value": [
@@ -26598,7 +27673,7 @@
 ]
 },
 {
-"@id": "#155",
+"@id": "#168",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -26611,7 +27686,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#156",
+"@id": "#169",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -26628,16 +27703,18 @@
 "@value": "language"
 }
 ],
-"schema-org:name": [
+"core:name": [
 {
 "@value": "The Language Schema "
 }
 ],
 "shacl:defaultValue": [
 {
-"@id": "#157",
+"@id": "#170",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -26647,7 +27724,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#157/source-map",
+"@id": "#170/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -26655,7 +27732,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#157"
+"@value": "amf://id#170"
 }
 ],
 "sourcemaps:value": [
@@ -26676,7 +27753,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#156/source-map",
+"@id": "#169/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -26684,7 +27761,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#156"
+"@value": "amf://id#169"
 }
 ],
 "sourcemaps:value": [
@@ -26722,7 +27799,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#156"
+"@value": "amf://id#169"
 }
 ],
 "sourcemaps:value": [
@@ -26734,7 +27811,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:name"
+"@value": "core:name"
 }
 ],
 "sourcemaps:value": [
@@ -26760,7 +27837,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#155/source-map",
+"@id": "#168/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -26768,7 +27845,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#155"
+"@value": "amf://id#168"
 }
 ],
 "sourcemaps:value": [
@@ -26782,7 +27859,7 @@
 ]
 },
 {
-"@id": "#158",
+"@id": "#171",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -26795,7 +27872,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#159",
+"@id": "#172",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -26812,16 +27889,18 @@
 "@value": "etag"
 }
 ],
-"schema-org:name": [
+"core:name": [
 {
 "@value": "The Etag Schema "
 }
 ],
 "shacl:defaultValue": [
 {
-"@id": "#160",
+"@id": "#173",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -26831,7 +27910,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#160/source-map",
+"@id": "#173/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -26839,7 +27918,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#160"
+"@value": "amf://id#173"
 }
 ],
 "sourcemaps:value": [
@@ -26860,7 +27939,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#159/source-map",
+"@id": "#172/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -26868,7 +27947,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#159"
+"@value": "amf://id#172"
 }
 ],
 "sourcemaps:value": [
@@ -26906,7 +27985,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#159"
+"@value": "amf://id#172"
 }
 ],
 "sourcemaps:value": [
@@ -26918,7 +27997,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:name"
+"@value": "core:name"
 }
 ],
 "sourcemaps:value": [
@@ -26944,7 +28023,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#158/source-map",
+"@id": "#171/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -26952,7 +28031,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#158"
+"@value": "amf://id#171"
 }
 ],
 "sourcemaps:value": [
@@ -26971,11 +28050,18 @@
 "@value": "SchemaPerson"
 }
 ],
-"doc:examples": [
+"apiContract:examples": [
 {
-"@id": "#161",
+"@id": "#174",
 "@type": [
-"doc:Example",
+"apiContract:NamedExamples",
+"doc:DomainElement"
+],
+"apiContract:examples": [
+{
+"@id": "#175",
+"@type": [
+"apiContract:Example",
 "doc:DomainElement"
 ],
 "doc:strict": [
@@ -26985,15 +28071,19 @@
 ],
 "doc:structuredValue": [
 {
-"@id": "#161",
+"@id": "#175",
 "@type": [
-"data:Object"
+"data:Object",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:birthday": [
 {
-"@id": "#162",
+"@id": "#176",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -27003,7 +28093,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#162/source-map",
+"@id": "#176/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -27011,7 +28101,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#162"
+"@value": "amf://id#176"
 }
 ],
 "sourcemaps:value": [
@@ -27027,9 +28117,11 @@
 ],
 "data:etag": [
 {
-"@id": "#163",
+"@id": "#177",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -27039,7 +28131,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#163/source-map",
+"@id": "#177/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -27047,7 +28139,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#163"
+"@value": "amf://id#177"
 }
 ],
 "sourcemaps:value": [
@@ -27063,9 +28155,11 @@
 ],
 "data:gender": [
 {
-"@id": "#164",
+"@id": "#178",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -27075,7 +28169,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#164/source-map",
+"@id": "#178/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -27083,7 +28177,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#164"
+"@value": "amf://id#178"
 }
 ],
 "sourcemaps:value": [
@@ -27099,9 +28193,11 @@
 ],
 "data:id": [
 {
-"@id": "#165",
+"@id": "#179",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -27111,7 +28207,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#165/source-map",
+"@id": "#179/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -27119,7 +28215,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#165"
+"@value": "amf://id#179"
 }
 ],
 "sourcemaps:value": [
@@ -27135,15 +28231,19 @@
 ],
 "data:image": [
 {
-"@id": "#166",
+"@id": "#180",
 "@type": [
-"data:Object"
+"data:Object",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:thumb": [
 {
-"@id": "#167",
+"@id": "#181",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -27153,7 +28253,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#167/source-map",
+"@id": "#181/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -27161,7 +28261,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#167"
+"@value": "amf://id#181"
 }
 ],
 "sourcemaps:value": [
@@ -27177,9 +28277,11 @@
 ],
 "data:url": [
 {
-"@id": "#168",
+"@id": "#182",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -27189,7 +28291,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#168/source-map",
+"@id": "#182/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -27197,7 +28299,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#168"
+"@value": "amf://id#182"
 }
 ],
 "sourcemaps:value": [
@@ -27213,7 +28315,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#166/source-map",
+"@id": "#180/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -27221,7 +28323,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#166"
+"@value": "amf://id#180"
 }
 ],
 "sourcemaps:value": [
@@ -27235,12 +28337,36 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#166"
+"@value": "data:url"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(8,11)-(8,58)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#180"
 }
 ],
 "sourcemaps:value": [
 {
 "@value": "[(7,11)-(10,3)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "data:thumb"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(9,13)-(9,66)]"
 }
 ]
 }
@@ -27251,9 +28377,11 @@
 ],
 "data:language": [
 {
-"@id": "#169",
+"@id": "#183",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -27263,7 +28391,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#169/source-map",
+"@id": "#183/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -27271,7 +28399,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#169"
+"@value": "amf://id#183"
 }
 ],
 "sourcemaps:value": [
@@ -27287,9 +28415,11 @@
 ],
 "data:name": [
 {
-"@id": "#170",
+"@id": "#184",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -27299,7 +28429,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#170/source-map",
+"@id": "#184/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -27307,7 +28437,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#170"
+"@value": "amf://id#184"
 }
 ],
 "sourcemaps:value": [
@@ -27323,9 +28453,11 @@
 ],
 "data:tagline": [
 {
-"@id": "#171",
+"@id": "#185",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -27335,7 +28467,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#171/source-map",
+"@id": "#185/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -27343,7 +28475,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#171"
+"@value": "amf://id#185"
 }
 ],
 "sourcemaps:value": [
@@ -27359,9 +28491,11 @@
 ],
 "data:url": [
 {
-"@id": "#172",
+"@id": "#186",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -27371,7 +28505,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#172/source-map",
+"@id": "#186/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -27379,7 +28513,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#172"
+"@value": "amf://id#186"
 }
 ],
 "sourcemaps:value": [
@@ -27395,7 +28529,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#161/source-map",
+"@id": "#175/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -27403,7 +28537,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#161"
+"@value": "amf://id#175"
 }
 ],
 "sourcemaps:value": [
@@ -27417,7 +28551,19 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#161"
+"@value": "data:image"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "url->[(8,4)-(8,11)]#thumb->[(9,4)-(9,13)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#175"
 }
 ],
 "sourcemaps:value": [
@@ -27431,12 +28577,120 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#161"
+"@value": "data:url"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(6,9)-(6,50)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "data:name"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(3,10)-(3,24)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "data:image"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(7,11)-(10,3)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "data:gender"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(5,12)-(5,18)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "data:birthday"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(4,14)-(4,26)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#175"
 }
 ],
 "sourcemaps:value": [
 {
 "@value": "[(1,0)-(14,1)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "data:etag"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(13,10)-(13,36)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "data:id"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(2,8)-(2,30)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "data:language"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(12,14)-(12,21)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "data:tagline"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(11,13)-(11,34)]"
 }
 ]
 }
@@ -27447,12 +28701,12 @@
 ],
 "doc:reference-id": [
 {
-"@id": "#16"
+"@id": "#17"
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#161/source-map",
+"@id": "#175/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -27474,7 +28728,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#161"
+"@value": "amf://id#175"
 }
 ],
 "sourcemaps:value": [
@@ -27487,10 +28741,12 @@
 }
 ]
 }
+]
+}
 ],
 "sourcemaps:sources": [
 {
-"@id": "#128/source-map",
+"@id": "#141/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -27498,7 +28754,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#128"
+"@value": "amf://id#141"
 }
 ],
 "sourcemaps:value": [
@@ -27512,7 +28768,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#128"
+"@value": "amf://id#141"
 }
 ],
 "sourcemaps:value": [
@@ -27538,7 +28794,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#128"
+"@value": "amf://id#141"
 }
 ],
 "sourcemaps:value": [
@@ -27552,7 +28808,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#128"
+"@value": "amf://id#141"
 }
 ],
 "sourcemaps:value": [
@@ -27566,7 +28822,7 @@
 ]
 },
 {
-"@id": "#173",
+"@id": "#187",
 "@type": [
 "raml-shapes:UnionShape",
 "shacl:Shape",
@@ -27574,7 +28830,7 @@
 ],
 "raml-shapes:anyOf": [
 {
-"@id": "#174",
+"@id": "#188",
 "@type": [
 "shacl:NodeShape",
 "shacl:Shape",
@@ -27588,7 +28844,7 @@
 ],
 "shacl:property": [
 {
-"@id": "#175",
+"@id": "#189",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -27601,7 +28857,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#176",
+"@id": "#190",
 "@type": [
 "raml-shapes:ArrayShape",
 "shacl:Shape",
@@ -27610,7 +28866,7 @@
 ],
 "raml-shapes:items": [
 {
-"@id": "#177",
+"@id": "#191",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -27629,14 +28885,14 @@
 "@value": "targets"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "The possible content types to convert to."
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#176/source-map",
+"@id": "#190/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -27644,7 +28900,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#176"
+"@value": "amf://id#190"
 }
 ],
 "sourcemaps:value": [
@@ -27658,7 +28914,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -27670,7 +28926,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#176"
+"@value": "amf://id#190"
 }
 ],
 "sourcemaps:value": [
@@ -27696,7 +28952,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#175/source-map",
+"@id": "#189/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -27716,7 +28972,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#175"
+"@value": "amf://id#189"
 }
 ],
 "sourcemaps:value": [
@@ -27730,7 +28986,7 @@
 ]
 },
 {
-"@id": "#178",
+"@id": "#192",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -27743,7 +28999,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#179",
+"@id": "#193",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -27760,14 +29016,14 @@
 "@value": "source"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "The imported file's content type to convert from."
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#179/source-map",
+"@id": "#193/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -27775,7 +29031,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#179"
+"@value": "amf://id#193"
 }
 ],
 "sourcemaps:value": [
@@ -27789,7 +29045,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -27801,7 +29057,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#179"
+"@value": "amf://id#193"
 }
 ],
 "sourcemaps:value": [
@@ -27839,7 +29095,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#178/source-map",
+"@id": "#192/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -27859,7 +29115,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#178"
+"@value": "amf://id#192"
 }
 ],
 "sourcemaps:value": [
@@ -27880,7 +29136,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#174/source-map",
+"@id": "#188/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -27888,7 +29144,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#174"
+"@value": "amf://id#188"
 }
 ],
 "sourcemaps:value": [
@@ -27902,7 +29158,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#174"
+"@value": "amf://id#188"
 }
 ],
 "sourcemaps:value": [
@@ -27916,7 +29172,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#174"
+"@value": "amf://id#188"
 }
 ],
 "sourcemaps:value": [
@@ -27930,7 +29186,7 @@
 ]
 },
 {
-"@id": "#180",
+"@id": "#194",
 "@type": [
 "shacl:NodeShape",
 "shacl:Shape",
@@ -27944,7 +29200,7 @@
 ],
 "shacl:property": [
 {
-"@id": "#42",
+"@id": "#35",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -27957,7 +29213,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#43",
+"@id": "#36",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -27974,14 +29230,14 @@
 "@value": "etag"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "ETag of this resource for caching purposes.\n__This property will be ignored when creating an object.__\n"
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#43/source-map",
+"@id": "#36/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -27989,7 +29245,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#43"
+"@value": "amf://id#36"
 }
 ],
 "sourcemaps:value": [
@@ -28003,7 +29259,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -28015,7 +29271,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#43"
+"@value": "amf://id#36"
 }
 ],
 "sourcemaps:value": [
@@ -28053,7 +29309,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#42/source-map",
+"@id": "#35/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -28061,7 +29317,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#42"
+"@value": "amf://id#35"
 }
 ],
 "sourcemaps:value": [
@@ -28075,7 +29331,7 @@
 ]
 },
 {
-"@id": "#121",
+"@id": "#134",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -28088,7 +29344,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#122",
+"@id": "#135",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -28105,14 +29361,14 @@
 "@value": "url"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "A URL that points to a profile picture of this user."
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#122/source-map",
+"@id": "#135/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -28120,7 +29376,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#122"
+"@value": "amf://id#135"
 }
 ],
 "sourcemaps:value": [
@@ -28134,7 +29390,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -28146,7 +29402,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#122"
+"@value": "amf://id#135"
 }
 ],
 "sourcemaps:value": [
@@ -28184,7 +29440,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#121/source-map",
+"@id": "#134/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -28204,7 +29460,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#121"
+"@value": "amf://id#134"
 }
 ],
 "sourcemaps:value": [
@@ -28218,7 +29474,7 @@
 ]
 },
 {
-"@id": "#123",
+"@id": "#136",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -28231,7 +29487,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#124",
+"@id": "#137",
 "@type": [
 "shacl:NodeShape",
 "shacl:Shape",
@@ -28275,7 +29531,7 @@
 "@value": "width"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "Width of the shape.\n"
 }
@@ -28304,7 +29560,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -28406,7 +29662,7 @@
 "@value": "height"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "Height of the shape.\n"
 }
@@ -28435,7 +29691,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -28537,7 +29793,7 @@
 "@value": "unit?"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "A unit that describes the dimension. It can be, for example, `px` for\npixels, `pt` for points, `%` for percentage.\n"
 }
@@ -28546,7 +29802,9 @@
 {
 "@id": "#9",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -28643,7 +29901,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -28696,16 +29954,23 @@
 "@value": "Dimension"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "A dimmensions of an object like image.\n"
 }
 ],
-"doc:examples": [
+"apiContract:examples": [
 {
 "@id": "#10",
 "@type": [
-"doc:Example",
+"apiContract:NamedExamples",
+"doc:DomainElement"
+],
+"apiContract:examples": [
+{
+"@id": "#11",
+"@type": [
+"apiContract:Example",
 "doc:DomainElement"
 ],
 "doc:strict": [
@@ -28715,55 +29980,23 @@
 ],
 "doc:structuredValue": [
 {
-"@id": "#10",
+"@id": "#11",
 "@type": [
-"data:Object"
+"data:Object",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:height": [
 {
-"@id": "#11",
+"@id": "#12",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
 "@value": "160",
-"@type": "xsd:integer"
-}
-],
-"sourcemaps:sources": [
-{
-"@id": "#11/source-map",
-"@type": [
-"sourcemaps:SourceMap"
-],
-"sourcemaps:lexical": [
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#11"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(24,10)-(24,13)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"data:width": [
-{
-"@id": "#12",
-"@type": [
-"data:Scalar"
-],
-"data:value": [
-{
-"@value": "200",
 "@type": "xsd:integer"
 }
 ],
@@ -28782,6 +30015,44 @@
 ],
 "sourcemaps:value": [
 {
+"@value": "[(24,10)-(24,13)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"data:width": [
+{
+"@id": "#13",
+"@type": [
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
+],
+"data:value": [
+{
+"@value": "200",
+"@type": "xsd:integer"
+}
+],
+"sourcemaps:sources": [
+{
+"@id": "#13/source-map",
+"@type": [
+"sourcemaps:SourceMap"
+],
+"sourcemaps:lexical": [
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#13"
+}
+],
+"sourcemaps:value": [
+{
 "@value": "[(23,9)-(23,12)]"
 }
 ]
@@ -28793,7 +30064,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#10/source-map",
+"@id": "#11/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -28801,12 +30072,36 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#10"
+"@value": "data:width"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(23,9)-(23,12)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#11"
 }
 ],
 "sourcemaps:value": [
 {
 "@value": "[(23,0)-(25,0)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "data:height"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(24,10)-(24,13)]"
 }
 ]
 }
@@ -28815,7 +30110,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#10"
+"@value": "amf://id#11"
 }
 ],
 "sourcemaps:value": [
@@ -28836,7 +30131,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#10/source-map",
+"@id": "#11/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -28870,7 +30165,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#10"
+"@value": "amf://id#11"
 }
 ],
 "sourcemaps:value": [
@@ -28883,10 +30178,12 @@
 }
 ]
 }
+]
+}
 ],
 "sourcemaps:sources": [
 {
-"@id": "#124/source-map",
+"@id": "#137/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -28894,7 +30191,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#124"
+"@value": "amf://id#137"
 }
 ],
 "sourcemaps:value": [
@@ -28908,7 +30205,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#124"
+"@value": "amf://id#137"
 }
 ],
 "sourcemaps:value": [
@@ -28922,7 +30219,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -28934,7 +30231,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#124"
+"@value": "amf://id#137"
 }
 ],
 "sourcemaps:value": [
@@ -28948,7 +30245,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#124"
+"@value": "amf://id#137"
 }
 ],
 "sourcemaps:value": [
@@ -28974,7 +30271,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#123/source-map",
+"@id": "#136/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -28982,7 +30279,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#123"
+"@value": "amf://id#136"
 }
 ],
 "sourcemaps:value": [
@@ -29001,19 +30298,19 @@
 "@value": "Picture"
 }
 ],
-"schema-org:name": [
+"core:name": [
 {
 "@value": "Pic"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "The user's profile picture."
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#180/source-map",
+"@id": "#194/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -29021,7 +30318,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#180"
+"@value": "amf://id#194"
 }
 ],
 "sourcemaps:value": [
@@ -29035,7 +30332,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -29047,7 +30344,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#180"
+"@value": "amf://id#194"
 }
 ],
 "sourcemaps:value": [
@@ -29059,7 +30356,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:name"
+"@value": "core:name"
 }
 ],
 "sourcemaps:value": [
@@ -29073,7 +30370,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#180"
+"@value": "amf://id#194"
 }
 ],
 "sourcemaps:value": [
@@ -29094,7 +30391,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#173/source-map",
+"@id": "#187/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -29114,7 +30411,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#173"
+"@value": "amf://id#187"
 }
 ],
 "sourcemaps:value": [
@@ -29128,7 +30425,7 @@
 ]
 },
 {
-"@id": "#181",
+"@id": "#195",
 "@type": [
 "shacl:NodeShape",
 "shacl:Shape",
@@ -29142,7 +30439,7 @@
 ],
 "shacl:property": [
 {
-"@id": "#178",
+"@id": "#192",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -29155,7 +30452,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#179",
+"@id": "#193",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -29172,14 +30469,14 @@
 "@value": "source"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "The imported file's content type to convert from."
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#179/source-map",
+"@id": "#193/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -29187,7 +30484,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#179"
+"@value": "amf://id#193"
 }
 ],
 "sourcemaps:value": [
@@ -29201,7 +30498,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -29213,7 +30510,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#179"
+"@value": "amf://id#193"
 }
 ],
 "sourcemaps:value": [
@@ -29251,7 +30548,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#178/source-map",
+"@id": "#192/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -29271,7 +30568,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#178"
+"@value": "amf://id#192"
 }
 ],
 "sourcemaps:value": [
@@ -29285,7 +30582,7 @@
 ]
 },
 {
-"@id": "#175",
+"@id": "#189",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -29298,7 +30595,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#176",
+"@id": "#190",
 "@type": [
 "raml-shapes:ArrayShape",
 "shacl:Shape",
@@ -29307,7 +30604,7 @@
 ],
 "raml-shapes:items": [
 {
-"@id": "#177",
+"@id": "#191",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -29326,14 +30623,14 @@
 "@value": "targets"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "The possible content types to convert to."
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#176/source-map",
+"@id": "#190/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -29341,7 +30638,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#176"
+"@value": "amf://id#190"
 }
 ],
 "sourcemaps:value": [
@@ -29355,7 +30652,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -29367,7 +30664,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#176"
+"@value": "amf://id#190"
 }
 ],
 "sourcemaps:value": [
@@ -29393,7 +30690,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#175/source-map",
+"@id": "#189/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -29413,7 +30710,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#175"
+"@value": "amf://id#189"
 }
 ],
 "sourcemaps:value": [
@@ -29434,7 +30731,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#181/source-map",
+"@id": "#195/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -29442,7 +30739,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#181"
+"@value": "amf://id#195"
 }
 ],
 "sourcemaps:value": [
@@ -29468,7 +30765,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#181"
+"@value": "amf://id#195"
 }
 ],
 "sourcemaps:value": [
@@ -29482,7 +30779,7 @@
 ]
 },
 {
-"@id": "#182",
+"@id": "#196",
 "@type": [
 "shacl:NodeShape",
 "shacl:Shape",
@@ -29496,7 +30793,7 @@
 ],
 "shacl:property": [
 {
-"@id": "#42",
+"@id": "#35",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -29509,7 +30806,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#43",
+"@id": "#36",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -29526,14 +30823,14 @@
 "@value": "etag"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "ETag of this resource for caching purposes.\n__This property will be ignored when creating an object.__\n"
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#43/source-map",
+"@id": "#36/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -29541,7 +30838,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#43"
+"@value": "amf://id#36"
 }
 ],
 "sourcemaps:value": [
@@ -29555,7 +30852,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -29567,7 +30864,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#43"
+"@value": "amf://id#36"
 }
 ],
 "sourcemaps:value": [
@@ -29605,7 +30902,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#42/source-map",
+"@id": "#35/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -29613,7 +30910,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#42"
+"@value": "amf://id#35"
 }
 ],
 "sourcemaps:value": [
@@ -29632,14 +30929,14 @@
 "@value": "Resource"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "Common properties for all resources returned by the API.\n"
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#182/source-map",
+"@id": "#196/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -29647,7 +30944,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#182"
+"@value": "amf://id#196"
 }
 ],
 "sourcemaps:value": [
@@ -29661,7 +30958,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#182"
+"@value": "amf://id#196"
 }
 ],
 "sourcemaps:value": [
@@ -29675,7 +30972,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -29687,7 +30984,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#182"
+"@value": "amf://id#196"
 }
 ],
 "sourcemaps:value": [
@@ -29701,7 +30998,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#182"
+"@value": "amf://id#196"
 }
 ],
 "sourcemaps:value": [
@@ -29715,7 +31012,7 @@
 ]
 },
 {
-"@id": "#124",
+"@id": "#137",
 "@type": [
 "shacl:NodeShape",
 "shacl:Shape",
@@ -29759,7 +31056,7 @@
 "@value": "width"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "Width of the shape.\n"
 }
@@ -29788,7 +31085,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -29890,7 +31187,7 @@
 "@value": "height"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "Height of the shape.\n"
 }
@@ -29919,7 +31216,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -30021,7 +31318,7 @@
 "@value": "unit?"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "A unit that describes the dimension. It can be, for example, `px` for\npixels, `pt` for points, `%` for percentage.\n"
 }
@@ -30030,7 +31327,9 @@
 {
 "@id": "#9",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -30127,7 +31426,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -30180,16 +31479,23 @@
 "@value": "Dimension"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "A dimmensions of an object like image.\n"
 }
 ],
-"doc:examples": [
+"apiContract:examples": [
 {
 "@id": "#10",
 "@type": [
-"doc:Example",
+"apiContract:NamedExamples",
+"doc:DomainElement"
+],
+"apiContract:examples": [
+{
+"@id": "#11",
+"@type": [
+"apiContract:Example",
 "doc:DomainElement"
 ],
 "doc:strict": [
@@ -30199,55 +31505,23 @@
 ],
 "doc:structuredValue": [
 {
-"@id": "#10",
+"@id": "#11",
 "@type": [
-"data:Object"
+"data:Object",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:height": [
 {
-"@id": "#11",
+"@id": "#12",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
 "@value": "160",
-"@type": "xsd:integer"
-}
-],
-"sourcemaps:sources": [
-{
-"@id": "#11/source-map",
-"@type": [
-"sourcemaps:SourceMap"
-],
-"sourcemaps:lexical": [
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#11"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(24,10)-(24,13)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"data:width": [
-{
-"@id": "#12",
-"@type": [
-"data:Scalar"
-],
-"data:value": [
-{
-"@value": "200",
 "@type": "xsd:integer"
 }
 ],
@@ -30266,6 +31540,44 @@
 ],
 "sourcemaps:value": [
 {
+"@value": "[(24,10)-(24,13)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"data:width": [
+{
+"@id": "#13",
+"@type": [
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
+],
+"data:value": [
+{
+"@value": "200",
+"@type": "xsd:integer"
+}
+],
+"sourcemaps:sources": [
+{
+"@id": "#13/source-map",
+"@type": [
+"sourcemaps:SourceMap"
+],
+"sourcemaps:lexical": [
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#13"
+}
+],
+"sourcemaps:value": [
+{
 "@value": "[(23,9)-(23,12)]"
 }
 ]
@@ -30277,7 +31589,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#10/source-map",
+"@id": "#11/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -30285,12 +31597,36 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#10"
+"@value": "data:width"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(23,9)-(23,12)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#11"
 }
 ],
 "sourcemaps:value": [
 {
 "@value": "[(23,0)-(25,0)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "data:height"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(24,10)-(24,13)]"
 }
 ]
 }
@@ -30299,7 +31635,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#10"
+"@value": "amf://id#11"
 }
 ],
 "sourcemaps:value": [
@@ -30320,7 +31656,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#10/source-map",
+"@id": "#11/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -30354,7 +31690,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#10"
+"@value": "amf://id#11"
 }
 ],
 "sourcemaps:value": [
@@ -30367,10 +31703,12 @@
 }
 ]
 }
+]
+}
 ],
 "sourcemaps:sources": [
 {
-"@id": "#124/source-map",
+"@id": "#137/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -30378,7 +31716,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#124"
+"@value": "amf://id#137"
 }
 ],
 "sourcemaps:value": [
@@ -30392,7 +31730,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#124"
+"@value": "amf://id#137"
 }
 ],
 "sourcemaps:value": [
@@ -30406,7 +31744,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -30418,7 +31756,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#124"
+"@value": "amf://id#137"
 }
 ],
 "sourcemaps:value": [
@@ -30432,7 +31770,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#124"
+"@value": "amf://id#137"
 }
 ],
 "sourcemaps:value": [
@@ -30446,7 +31784,7 @@
 ]
 },
 {
-"@id": "#183",
+"@id": "#197",
 "@type": [
 "shacl:NodeShape",
 "shacl:Shape",
@@ -30460,7 +31798,7 @@
 ],
 "shacl:property": [
 {
-"@id": "#94",
+"@id": "#101",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -30473,7 +31811,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#95",
+"@id": "#102",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -30495,16 +31833,23 @@
 "@value": "upc"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "The Universal Produc Code. It consists of 12 numerical digits. However, because of the\ninteger precision limitation in JavaScript it is represented as a string.\n"
 }
 ],
-"doc:examples": [
+"apiContract:examples": [
 {
-"@id": "#96",
+"@id": "#103",
 "@type": [
-"doc:Example",
+"apiContract:NamedExamples",
+"doc:DomainElement"
+],
+"apiContract:examples": [
+{
+"@id": "#104",
+"@type": [
+"apiContract:Example",
 "doc:DomainElement"
 ],
 "doc:strict": [
@@ -30514,9 +31859,11 @@
 ],
 "doc:structuredValue": [
 {
-"@id": "#96",
+"@id": "#104",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -30526,7 +31873,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#96/source-map",
+"@id": "#104/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -30534,7 +31881,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#96"
+"@value": "amf://id#104"
 }
 ],
 "sourcemaps:value": [
@@ -30555,7 +31902,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#96/source-map",
+"@id": "#104/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -30589,7 +31936,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#96"
+"@value": "amf://id#104"
 }
 ],
 "sourcemaps:value": [
@@ -30602,10 +31949,12 @@
 }
 ]
 }
+]
+}
 ],
 "sourcemaps:sources": [
 {
-"@id": "#95/source-map",
+"@id": "#102/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -30613,7 +31962,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#95"
+"@value": "amf://id#102"
 }
 ],
 "sourcemaps:value": [
@@ -30627,7 +31976,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -30651,7 +32000,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#95"
+"@value": "amf://id#102"
 }
 ],
 "sourcemaps:value": [
@@ -30689,7 +32038,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#94/source-map",
+"@id": "#101/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -30709,7 +32058,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#94"
+"@value": "amf://id#101"
 }
 ],
 "sourcemaps:value": [
@@ -30723,7 +32072,7 @@
 ]
 },
 {
-"@id": "#42",
+"@id": "#35",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -30736,7 +32085,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#43",
+"@id": "#36",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -30753,14 +32102,14 @@
 "@value": "etag"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "ETag of this resource for caching purposes.\n__This property will be ignored when creating an object.__\n"
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#43/source-map",
+"@id": "#36/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -30768,7 +32117,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#43"
+"@value": "amf://id#36"
 }
 ],
 "sourcemaps:value": [
@@ -30782,7 +32131,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -30794,7 +32143,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#43"
+"@value": "amf://id#36"
 }
 ],
 "sourcemaps:value": [
@@ -30832,7 +32181,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#42/source-map",
+"@id": "#35/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -30840,7 +32189,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#42"
+"@value": "amf://id#35"
 }
 ],
 "sourcemaps:value": [
@@ -30854,7 +32203,7 @@
 ]
 },
 {
-"@id": "#97",
+"@id": "#105",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -30867,7 +32216,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#98",
+"@id": "#106",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -30884,16 +32233,23 @@
 "@value": "name"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "Product name"
 }
 ],
-"doc:examples": [
+"apiContract:examples": [
 {
-"@id": "#99",
+"@id": "#107",
 "@type": [
-"doc:Example",
+"apiContract:NamedExamples",
+"doc:DomainElement"
+],
+"apiContract:examples": [
+{
+"@id": "#108",
+"@type": [
+"apiContract:Example",
 "doc:DomainElement"
 ],
 "doc:strict": [
@@ -30903,9 +32259,11 @@
 ],
 "doc:structuredValue": [
 {
-"@id": "#99",
+"@id": "#108",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -30915,7 +32273,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#99/source-map",
+"@id": "#108/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -30923,7 +32281,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#99"
+"@value": "amf://id#108"
 }
 ],
 "sourcemaps:value": [
@@ -30944,7 +32302,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#99/source-map",
+"@id": "#108/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -30978,7 +32336,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#99"
+"@value": "amf://id#108"
 }
 ],
 "sourcemaps:value": [
@@ -30991,10 +32349,12 @@
 }
 ]
 }
+]
+}
 ],
 "sourcemaps:sources": [
 {
-"@id": "#98/source-map",
+"@id": "#106/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -31002,7 +32362,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#98"
+"@value": "amf://id#106"
 }
 ],
 "sourcemaps:value": [
@@ -31016,7 +32376,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -31028,7 +32388,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#98"
+"@value": "amf://id#106"
 }
 ],
 "sourcemaps:value": [
@@ -31066,7 +32426,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#97/source-map",
+"@id": "#105/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -31086,7 +32446,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#97"
+"@value": "amf://id#105"
 }
 ],
 "sourcemaps:value": [
@@ -31100,7 +32460,7 @@
 ]
 },
 {
-"@id": "#100",
+"@id": "#109",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -31113,7 +32473,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#101",
+"@id": "#110",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -31135,14 +32495,14 @@
 "@value": "id"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "Product id. It is a UUID of the database record.\n__This property will be ignored when creating an object.__\nIt will be available when the product is stored in the datastore.\n"
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#101/source-map",
+"@id": "#110/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -31150,7 +32510,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -31162,7 +32522,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#101"
+"@value": "amf://id#110"
 }
 ],
 "sourcemaps:value": [
@@ -31200,7 +32560,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#100/source-map",
+"@id": "#109/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -31208,7 +32568,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#100"
+"@value": "amf://id#109"
 }
 ],
 "sourcemaps:value": [
@@ -31222,7 +32582,7 @@
 ]
 },
 {
-"@id": "#102",
+"@id": "#111",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -31235,7 +32595,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#103",
+"@id": "#112",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -31252,16 +32612,23 @@
 "@value": "unit"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "The unit of measuremet for the quantity property."
 }
 ],
-"doc:examples": [
+"apiContract:examples": [
 {
-"@id": "#104",
+"@id": "#113",
 "@type": [
-"doc:Example",
+"apiContract:NamedExamples",
+"doc:DomainElement"
+],
+"apiContract:examples": [
+{
+"@id": "#114",
+"@type": [
+"apiContract:Example",
 "doc:DomainElement"
 ],
 "doc:strict": [
@@ -31271,9 +32638,11 @@
 ],
 "doc:structuredValue": [
 {
-"@id": "#104",
+"@id": "#114",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -31283,7 +32652,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#104/source-map",
+"@id": "#114/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -31291,7 +32660,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#104"
+"@value": "amf://id#114"
 }
 ],
 "sourcemaps:value": [
@@ -31312,7 +32681,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#104/source-map",
+"@id": "#114/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -31346,7 +32715,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#104"
+"@value": "amf://id#114"
 }
 ],
 "sourcemaps:value": [
@@ -31359,10 +32728,12 @@
 }
 ]
 }
+]
+}
 ],
 "sourcemaps:sources": [
 {
-"@id": "#103/source-map",
+"@id": "#112/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -31370,7 +32741,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#103"
+"@value": "amf://id#112"
 }
 ],
 "sourcemaps:value": [
@@ -31384,7 +32755,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -31396,7 +32767,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#103"
+"@value": "amf://id#112"
 }
 ],
 "sourcemaps:value": [
@@ -31434,7 +32805,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#102/source-map",
+"@id": "#111/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -31454,7 +32825,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#102"
+"@value": "amf://id#111"
 }
 ],
 "sourcemaps:value": [
@@ -31468,7 +32839,7 @@
 ]
 },
 {
-"@id": "#105",
+"@id": "#115",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -31481,7 +32852,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#106",
+"@id": "#116",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -31498,16 +32869,23 @@
 "@value": "available"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "Product current availability in the store.\nProduct may be not available but the users still can order it with later delivery date.\n"
 }
 ],
-"doc:examples": [
+"apiContract:examples": [
 {
-"@id": "#107",
+"@id": "#117",
 "@type": [
-"doc:Example",
+"apiContract:NamedExamples",
+"doc:DomainElement"
+],
+"apiContract:examples": [
+{
+"@id": "#118",
+"@type": [
+"apiContract:Example",
 "doc:DomainElement"
 ],
 "doc:strict": [
@@ -31517,9 +32895,11 @@
 ],
 "doc:structuredValue": [
 {
-"@id": "#107",
+"@id": "#118",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -31529,7 +32909,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#107/source-map",
+"@id": "#118/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -31537,7 +32917,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#107"
+"@value": "amf://id#118"
 }
 ],
 "sourcemaps:value": [
@@ -31558,7 +32938,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#107/source-map",
+"@id": "#118/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -31592,7 +32972,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#107"
+"@value": "amf://id#118"
 }
 ],
 "sourcemaps:value": [
@@ -31605,10 +32985,12 @@
 }
 ]
 }
+]
+}
 ],
 "sourcemaps:sources": [
 {
-"@id": "#106/source-map",
+"@id": "#116/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -31616,7 +32998,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#106"
+"@value": "amf://id#116"
 }
 ],
 "sourcemaps:value": [
@@ -31630,7 +33012,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -31642,7 +33024,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#106"
+"@value": "amf://id#116"
 }
 ],
 "sourcemaps:value": [
@@ -31680,7 +33062,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#105/source-map",
+"@id": "#115/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -31700,7 +33082,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#105"
+"@value": "amf://id#115"
 }
 ],
 "sourcemaps:value": [
@@ -31714,7 +33096,7 @@
 ]
 },
 {
-"@id": "#108",
+"@id": "#119",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -31727,7 +33109,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#109",
+"@id": "#120",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -31744,16 +33126,23 @@
 "@value": "quantity"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "The quantity of the product in the one unit of measurement.\nSee `unit` property for more information.\n"
 }
 ],
-"doc:examples": [
+"apiContract:examples": [
 {
-"@id": "#110",
+"@id": "#121",
 "@type": [
-"doc:Example",
+"apiContract:NamedExamples",
+"doc:DomainElement"
+],
+"apiContract:examples": [
+{
+"@id": "#122",
+"@type": [
+"apiContract:Example",
 "doc:DomainElement"
 ],
 "doc:strict": [
@@ -31763,9 +33152,11 @@
 ],
 "doc:structuredValue": [
 {
-"@id": "#110",
+"@id": "#122",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -31775,7 +33166,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#110/source-map",
+"@id": "#122/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -31783,7 +33174,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#110"
+"@value": "amf://id#122"
 }
 ],
 "sourcemaps:value": [
@@ -31804,7 +33195,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#110/source-map",
+"@id": "#122/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -31838,7 +33229,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#110"
+"@value": "amf://id#122"
 }
 ],
 "sourcemaps:value": [
@@ -31851,10 +33242,12 @@
 }
 ]
 }
+]
+}
 ],
 "sourcemaps:sources": [
 {
-"@id": "#109/source-map",
+"@id": "#120/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -31862,7 +33255,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#109"
+"@value": "amf://id#120"
 }
 ],
 "sourcemaps:value": [
@@ -31876,7 +33269,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -31888,7 +33281,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#109"
+"@value": "amf://id#120"
 }
 ],
 "sourcemaps:value": [
@@ -31926,7 +33319,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#108/source-map",
+"@id": "#119/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -31946,7 +33339,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#108"
+"@value": "amf://id#119"
 }
 ],
 "sourcemaps:value": [
@@ -31965,21 +33358,28 @@
 "@value": "Product"
 }
 ],
-"schema-org:name": [
+"core:name": [
 {
 "@value": "A product resource"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "A single product representing an item in the store."
 }
 ],
-"doc:examples": [
+"apiContract:examples": [
 {
-"@id": "#111",
+"@id": "#123",
 "@type": [
-"doc:Example",
+"apiContract:NamedExamples",
+"doc:DomainElement"
+],
+"apiContract:examples": [
+{
+"@id": "#124",
+"@type": [
+"apiContract:Example",
 "doc:DomainElement"
 ],
 "doc:strict": [
@@ -31989,15 +33389,19 @@
 ],
 "doc:structuredValue": [
 {
-"@id": "#111",
+"@id": "#124",
 "@type": [
-"data:Object"
+"data:Object",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:available": [
 {
-"@id": "#112",
+"@id": "#125",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -32007,7 +33411,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#112/source-map",
+"@id": "#125/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -32015,7 +33419,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#112"
+"@value": "amf://id#125"
 }
 ],
 "sourcemaps:value": [
@@ -32031,9 +33435,11 @@
 ],
 "data:etag": [
 {
-"@id": "#113",
+"@id": "#126",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -32043,7 +33449,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#113/source-map",
+"@id": "#126/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -32051,7 +33457,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#113"
+"@value": "amf://id#126"
 }
 ],
 "sourcemaps:value": [
@@ -32067,9 +33473,11 @@
 ],
 "data:id": [
 {
-"@id": "#114",
+"@id": "#127",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -32079,7 +33487,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#114/source-map",
+"@id": "#127/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -32087,7 +33495,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#114"
+"@value": "amf://id#127"
 }
 ],
 "sourcemaps:value": [
@@ -32103,9 +33511,11 @@
 ],
 "data:name": [
 {
-"@id": "#115",
+"@id": "#128",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -32115,7 +33525,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#115/source-map",
+"@id": "#128/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -32123,7 +33533,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#115"
+"@value": "amf://id#128"
 }
 ],
 "sourcemaps:value": [
@@ -32139,9 +33549,11 @@
 ],
 "data:quantity": [
 {
-"@id": "#116",
+"@id": "#129",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -32151,7 +33563,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#116/source-map",
+"@id": "#129/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -32159,7 +33571,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#116"
+"@value": "amf://id#129"
 }
 ],
 "sourcemaps:value": [
@@ -32175,9 +33587,11 @@
 ],
 "data:unit": [
 {
-"@id": "#117",
+"@id": "#130",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -32187,7 +33601,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#117/source-map",
+"@id": "#130/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -32195,7 +33609,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#117"
+"@value": "amf://id#130"
 }
 ],
 "sourcemaps:value": [
@@ -32211,9 +33625,11 @@
 ],
 "data:upc": [
 {
-"@id": "#118",
+"@id": "#131",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -32223,7 +33639,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#118/source-map",
+"@id": "#131/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -32231,7 +33647,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#118"
+"@value": "amf://id#131"
 }
 ],
 "sourcemaps:value": [
@@ -32247,7 +33663,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#111/source-map",
+"@id": "#124/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -32255,12 +33671,96 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#111"
+"@value": "data:upc"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(50,7)-(50,21)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "data:quantity"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(48,12)-(48,15)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "data:id"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(46,6)-(46,34)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "data:available"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(51,13)-(51,17)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#124"
 }
 ],
 "sourcemaps:value": [
 {
 "@value": "[(46,0)-(53,0)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "data:etag"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(52,8)-(52,28)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "data:name"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(47,8)-(47,20)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "data:unit"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(49,8)-(49,10)]"
 }
 ]
 }
@@ -32269,7 +33769,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#111"
+"@value": "amf://id#124"
 }
 ],
 "sourcemaps:value": [
@@ -32290,7 +33790,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#111/source-map",
+"@id": "#124/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -32324,7 +33824,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#111"
+"@value": "amf://id#124"
 }
 ],
 "sourcemaps:value": [
@@ -32337,10 +33837,12 @@
 }
 ]
 }
+]
+}
 ],
 "sourcemaps:sources": [
 {
-"@id": "#183/source-map",
+"@id": "#197/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -32348,7 +33850,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#183"
+"@value": "amf://id#197"
 }
 ],
 "sourcemaps:value": [
@@ -32362,7 +33864,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#183"
+"@value": "amf://id#197"
 }
 ],
 "sourcemaps:value": [
@@ -32376,7 +33878,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -32388,7 +33890,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#183"
+"@value": "amf://id#197"
 }
 ],
 "sourcemaps:value": [
@@ -32400,7 +33902,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:name"
+"@value": "core:name"
 }
 ],
 "sourcemaps:value": [
@@ -32414,7 +33916,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#183"
+"@value": "amf://id#197"
 }
 ],
 "sourcemaps:value": [
@@ -32428,7 +33930,7 @@
 ]
 },
 {
-"@id": "#184",
+"@id": "#198",
 "@type": [
 "shacl:NodeShape",
 "shacl:Shape",
@@ -32442,7 +33944,7 @@
 ],
 "shacl:property": [
 {
-"@id": "#19",
+"@id": "#20",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -32455,7 +33957,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#20",
+"@id": "#21",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -32472,14 +33974,14 @@
 "@value": "url"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "The URL of the image.\nTo resize the image and crop it to a square, append the query string **?sz=x**, where x is the dimension in pixels of each side.\n"
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#20/source-map",
+"@id": "#21/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -32487,7 +33989,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#20"
+"@value": "amf://id#21"
 }
 ],
 "sourcemaps:value": [
@@ -32501,7 +34003,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -32513,7 +34015,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#20"
+"@value": "amf://id#21"
 }
 ],
 "sourcemaps:value": [
@@ -32551,7 +34053,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#19/source-map",
+"@id": "#20/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -32559,7 +34061,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#19"
+"@value": "amf://id#20"
 }
 ],
 "sourcemaps:value": [
@@ -32573,7 +34075,7 @@
 ]
 },
 {
-"@id": "#21",
+"@id": "#22",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -32586,7 +34088,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#22",
+"@id": "#23",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -32603,19 +34105,19 @@
 "@value": "thumb"
 }
 ],
-"schema-org:name": [
+"core:name": [
 {
 "@value": "Thumbnail"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "An URL to the thumbnail of the image. Thumbnails are 60x60px cropped images of the original image.\n"
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#22/source-map",
+"@id": "#23/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -32623,7 +34125,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#22"
+"@value": "amf://id#23"
 }
 ],
 "sourcemaps:value": [
@@ -32637,7 +34139,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -32661,7 +34163,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#22"
+"@value": "amf://id#23"
 }
 ],
 "sourcemaps:value": [
@@ -32673,7 +34175,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:name"
+"@value": "core:name"
 }
 ],
 "sourcemaps:value": [
@@ -32699,7 +34201,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#21/source-map",
+"@id": "#22/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -32707,7 +34209,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#21"
+"@value": "amf://id#22"
 }
 ],
 "sourcemaps:value": [
@@ -32726,16 +34228,23 @@
 "@value": "Image"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "An image object representing an image object strored in the file store.\nThe image can be only included in the response. It has no effect if the Image appear in the\nrequest. Endpoint handles image creation on it's own and clients can't process images\nexcept of sending image data.\n"
 }
 ],
-"doc:examples": [
+"apiContract:examples": [
 {
-"@id": "#23",
+"@id": "#24",
 "@type": [
-"doc:Example",
+"apiContract:NamedExamples",
+"doc:DomainElement"
+],
+"apiContract:examples": [
+{
+"@id": "#25",
+"@type": [
+"apiContract:Example",
 "doc:DomainElement"
 ],
 "doc:strict": [
@@ -32745,15 +34254,19 @@
 ],
 "doc:structuredValue": [
 {
-"@id": "#23",
+"@id": "#25",
 "@type": [
-"data:Object"
+"data:Object",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:thumb": [
 {
-"@id": "#24",
+"@id": "#26",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -32763,7 +34276,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#24/source-map",
+"@id": "#26/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -32771,7 +34284,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#24"
+"@value": "amf://id#26"
 }
 ],
 "sourcemaps:value": [
@@ -32787,9 +34300,11 @@
 ],
 "data:url": [
 {
-"@id": "#25",
+"@id": "#27",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -32799,7 +34314,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#25/source-map",
+"@id": "#27/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -32807,7 +34322,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#25"
+"@value": "amf://id#27"
 }
 ],
 "sourcemaps:value": [
@@ -32823,7 +34338,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#23/source-map",
+"@id": "#25/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -32831,12 +34346,36 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#23"
+"@value": "data:url"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(22,7)-(22,52)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#25"
 }
 ],
 "sourcemaps:value": [
 {
 "@value": "[(22,0)-(24,0)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "data:thumb"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(23,9)-(23,60)]"
 }
 ]
 }
@@ -32845,7 +34384,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#23"
+"@value": "amf://id#25"
 }
 ],
 "sourcemaps:value": [
@@ -32866,7 +34405,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#23/source-map",
+"@id": "#25/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -32900,7 +34439,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#23"
+"@value": "amf://id#25"
 }
 ],
 "sourcemaps:value": [
@@ -32913,10 +34452,12 @@
 }
 ]
 }
+]
+}
 ],
 "sourcemaps:sources": [
 {
-"@id": "#184/source-map",
+"@id": "#198/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -32924,7 +34465,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#184"
+"@value": "amf://id#198"
 }
 ],
 "sourcemaps:value": [
@@ -32938,7 +34479,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#184"
+"@value": "amf://id#198"
 }
 ],
 "sourcemaps:value": [
@@ -32952,7 +34493,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -32964,7 +34505,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#184"
+"@value": "amf://id#198"
 }
 ],
 "sourcemaps:value": [
@@ -32978,7 +34519,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#184"
+"@value": "amf://id#198"
 }
 ],
 "sourcemaps:value": [
@@ -32992,7 +34533,7 @@
 ]
 },
 {
-"@id": "#120",
+"@id": "#133",
 "@type": [
 "shacl:NodeShape",
 "shacl:Shape",
@@ -33006,7 +34547,7 @@
 ],
 "shacl:property": [
 {
-"@id": "#42",
+"@id": "#35",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -33019,7 +34560,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#43",
+"@id": "#36",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -33036,14 +34577,14 @@
 "@value": "etag"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "ETag of this resource for caching purposes.\n__This property will be ignored when creating an object.__\n"
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#43/source-map",
+"@id": "#36/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -33051,7 +34592,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#43"
+"@value": "amf://id#36"
 }
 ],
 "sourcemaps:value": [
@@ -33065,7 +34606,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -33077,7 +34618,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#43"
+"@value": "amf://id#36"
 }
 ],
 "sourcemaps:value": [
@@ -33115,7 +34656,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#42/source-map",
+"@id": "#35/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -33123,7 +34664,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#42"
+"@value": "amf://id#35"
 }
 ],
 "sourcemaps:value": [
@@ -33137,7 +34678,7 @@
 ]
 },
 {
-"@id": "#121",
+"@id": "#134",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -33150,7 +34691,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#122",
+"@id": "#135",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -33167,14 +34708,14 @@
 "@value": "url"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "A URL that points to a profile picture of this user."
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#122/source-map",
+"@id": "#135/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -33182,7 +34723,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#122"
+"@value": "amf://id#135"
 }
 ],
 "sourcemaps:value": [
@@ -33196,7 +34737,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -33208,7 +34749,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#122"
+"@value": "amf://id#135"
 }
 ],
 "sourcemaps:value": [
@@ -33246,7 +34787,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#121/source-map",
+"@id": "#134/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -33266,7 +34807,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#121"
+"@value": "amf://id#134"
 }
 ],
 "sourcemaps:value": [
@@ -33280,7 +34821,7 @@
 ]
 },
 {
-"@id": "#123",
+"@id": "#136",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -33293,7 +34834,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#124",
+"@id": "#137",
 "@type": [
 "shacl:NodeShape",
 "shacl:Shape",
@@ -33337,7 +34878,7 @@
 "@value": "width"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "Width of the shape.\n"
 }
@@ -33366,7 +34907,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -33468,7 +35009,7 @@
 "@value": "height"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "Height of the shape.\n"
 }
@@ -33497,7 +35038,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -33599,7 +35140,7 @@
 "@value": "unit?"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "A unit that describes the dimension. It can be, for example, `px` for\npixels, `pt` for points, `%` for percentage.\n"
 }
@@ -33608,7 +35149,9 @@
 {
 "@id": "#9",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -33705,7 +35248,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -33758,16 +35301,23 @@
 "@value": "Dimension"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "A dimmensions of an object like image.\n"
 }
 ],
-"doc:examples": [
+"apiContract:examples": [
 {
 "@id": "#10",
 "@type": [
-"doc:Example",
+"apiContract:NamedExamples",
+"doc:DomainElement"
+],
+"apiContract:examples": [
+{
+"@id": "#11",
+"@type": [
+"apiContract:Example",
 "doc:DomainElement"
 ],
 "doc:strict": [
@@ -33777,55 +35327,23 @@
 ],
 "doc:structuredValue": [
 {
-"@id": "#10",
+"@id": "#11",
 "@type": [
-"data:Object"
+"data:Object",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:height": [
 {
-"@id": "#11",
+"@id": "#12",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
 "@value": "160",
-"@type": "xsd:integer"
-}
-],
-"sourcemaps:sources": [
-{
-"@id": "#11/source-map",
-"@type": [
-"sourcemaps:SourceMap"
-],
-"sourcemaps:lexical": [
-{
-"sourcemaps:element": [
-{
-"@value": "amf://id#11"
-}
-],
-"sourcemaps:value": [
-{
-"@value": "[(24,10)-(24,13)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"data:width": [
-{
-"@id": "#12",
-"@type": [
-"data:Scalar"
-],
-"data:value": [
-{
-"@value": "200",
 "@type": "xsd:integer"
 }
 ],
@@ -33844,6 +35362,44 @@
 ],
 "sourcemaps:value": [
 {
+"@value": "[(24,10)-(24,13)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"data:width": [
+{
+"@id": "#13",
+"@type": [
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
+],
+"data:value": [
+{
+"@value": "200",
+"@type": "xsd:integer"
+}
+],
+"sourcemaps:sources": [
+{
+"@id": "#13/source-map",
+"@type": [
+"sourcemaps:SourceMap"
+],
+"sourcemaps:lexical": [
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#13"
+}
+],
+"sourcemaps:value": [
+{
 "@value": "[(23,9)-(23,12)]"
 }
 ]
@@ -33855,7 +35411,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#10/source-map",
+"@id": "#11/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -33863,12 +35419,36 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#10"
+"@value": "data:width"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(23,9)-(23,12)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#11"
 }
 ],
 "sourcemaps:value": [
 {
 "@value": "[(23,0)-(25,0)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "data:height"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(24,10)-(24,13)]"
 }
 ]
 }
@@ -33877,7 +35457,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#10"
+"@value": "amf://id#11"
 }
 ],
 "sourcemaps:value": [
@@ -33898,7 +35478,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#10/source-map",
+"@id": "#11/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -33932,7 +35512,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#10"
+"@value": "amf://id#11"
 }
 ],
 "sourcemaps:value": [
@@ -33945,10 +35525,12 @@
 }
 ]
 }
+]
+}
 ],
 "sourcemaps:sources": [
 {
-"@id": "#124/source-map",
+"@id": "#137/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -33956,7 +35538,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#124"
+"@value": "amf://id#137"
 }
 ],
 "sourcemaps:value": [
@@ -33970,7 +35552,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#124"
+"@value": "amf://id#137"
 }
 ],
 "sourcemaps:value": [
@@ -33984,7 +35566,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -33996,7 +35578,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#124"
+"@value": "amf://id#137"
 }
 ],
 "sourcemaps:value": [
@@ -34010,7 +35592,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#124"
+"@value": "amf://id#137"
 }
 ],
 "sourcemaps:value": [
@@ -34036,7 +35618,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#123/source-map",
+"@id": "#136/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -34044,7 +35626,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#123"
+"@value": "amf://id#136"
 }
 ],
 "sourcemaps:value": [
@@ -34063,19 +35645,19 @@
 "@value": "Picture"
 }
 ],
-"schema-org:name": [
+"core:name": [
 {
 "@value": "Pic"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "The user's profile picture."
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#120/source-map",
+"@id": "#133/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -34083,7 +35665,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#120"
+"@value": "amf://id#133"
 }
 ],
 "sourcemaps:value": [
@@ -34097,7 +35679,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -34121,7 +35703,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#120"
+"@value": "amf://id#133"
 }
 ],
 "sourcemaps:value": [
@@ -34133,7 +35715,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:name"
+"@value": "core:name"
 }
 ],
 "sourcemaps:value": [
@@ -34147,7 +35729,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#120"
+"@value": "amf://id#133"
 }
 ],
 "sourcemaps:value": [
@@ -34161,7 +35743,7 @@
 ]
 },
 {
-"@id": "#185",
+"@id": "#199",
 "@type": [
 "shacl:NodeShape",
 "shacl:Shape",
@@ -34175,7 +35757,7 @@
 ],
 "shacl:property": [
 {
-"@id": "#186",
+"@id": "#200",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -34188,7 +35770,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#187",
+"@id": "#201",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -34205,16 +35787,18 @@
 "@value": "kind"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "This is always drive#property."
 }
 ],
 "shacl:defaultValue": [
 {
-"@id": "#188",
+"@id": "#202",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -34224,7 +35808,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#188/source-map",
+"@id": "#202/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -34232,7 +35816,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#188"
+"@value": "amf://id#202"
 }
 ],
 "sourcemaps:value": [
@@ -34248,13 +35832,15 @@
 ],
 "shacl:in": [
 {
-"@id": "#187/list",
+"@id": "#201/list",
 "@type": "rdfs:Seq",
 "rdfs:_1": [
 {
-"@id": "#189",
+"@id": "#203",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -34264,7 +35850,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#189/source-map",
+"@id": "#203/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -34272,7 +35858,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#189"
+"@value": "amf://id#203"
 }
 ],
 "sourcemaps:value": [
@@ -34295,7 +35881,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#187/source-map",
+"@id": "#201/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -34303,7 +35889,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#187"
+"@value": "amf://id#201"
 }
 ],
 "sourcemaps:value": [
@@ -34329,7 +35915,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -34341,7 +35927,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#187"
+"@value": "amf://id#201"
 }
 ],
 "sourcemaps:value": [
@@ -34391,7 +35977,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#186/source-map",
+"@id": "#200/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -34399,7 +35985,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#186"
+"@value": "amf://id#200"
 }
 ],
 "sourcemaps:value": [
@@ -34413,7 +35999,7 @@
 ]
 },
 {
-"@id": "#190",
+"@id": "#204",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -34426,7 +36012,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#191",
+"@id": "#205",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -34443,14 +36029,14 @@
 "@value": "etag"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "ETag of the property."
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#191/source-map",
+"@id": "#205/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -34458,7 +36044,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#191"
+"@value": "amf://id#205"
 }
 ],
 "sourcemaps:value": [
@@ -34472,7 +36058,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -34484,7 +36070,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#191"
+"@value": "amf://id#205"
 }
 ],
 "sourcemaps:value": [
@@ -34522,7 +36108,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#190/source-map",
+"@id": "#204/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -34530,7 +36116,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#190"
+"@value": "amf://id#204"
 }
 ],
 "sourcemaps:value": [
@@ -34544,7 +36130,7 @@
 ]
 },
 {
-"@id": "#192",
+"@id": "#206",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -34557,7 +36143,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#193",
+"@id": "#207",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -34574,14 +36160,14 @@
 "@value": "selfLink"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "The link back to this property."
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#193/source-map",
+"@id": "#207/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -34589,7 +36175,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#193"
+"@value": "amf://id#207"
 }
 ],
 "sourcemaps:value": [
@@ -34603,7 +36189,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -34615,7 +36201,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#193"
+"@value": "amf://id#207"
 }
 ],
 "sourcemaps:value": [
@@ -34653,7 +36239,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#192/source-map",
+"@id": "#206/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -34661,7 +36247,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#192"
+"@value": "amf://id#206"
 }
 ],
 "sourcemaps:value": [
@@ -34675,7 +36261,7 @@
 ]
 },
 {
-"@id": "#194",
+"@id": "#208",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -34688,7 +36274,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#195",
+"@id": "#209",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -34705,14 +36291,14 @@
 "@value": "key"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "The key of this property."
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#195/source-map",
+"@id": "#209/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -34720,7 +36306,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#195"
+"@value": "amf://id#209"
 }
 ],
 "sourcemaps:value": [
@@ -34734,7 +36320,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -34746,7 +36332,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#195"
+"@value": "amf://id#209"
 }
 ],
 "sourcemaps:value": [
@@ -34784,7 +36370,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#194/source-map",
+"@id": "#208/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -34792,7 +36378,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#194"
+"@value": "amf://id#208"
 }
 ],
 "sourcemaps:value": [
@@ -34806,7 +36392,7 @@
 ]
 },
 {
-"@id": "#196",
+"@id": "#210",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -34819,7 +36405,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#197",
+"@id": "#211",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -34836,14 +36422,14 @@
 "@value": "visibility"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "The visibility of this property."
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#197/source-map",
+"@id": "#211/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -34851,7 +36437,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#197"
+"@value": "amf://id#211"
 }
 ],
 "sourcemaps:value": [
@@ -34865,7 +36451,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -34877,7 +36463,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#197"
+"@value": "amf://id#211"
 }
 ],
 "sourcemaps:value": [
@@ -34915,7 +36501,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#196/source-map",
+"@id": "#210/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -34923,7 +36509,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#196"
+"@value": "amf://id#210"
 }
 ],
 "sourcemaps:value": [
@@ -34937,7 +36523,7 @@
 ]
 },
 {
-"@id": "#198",
+"@id": "#212",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -34950,7 +36536,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#199",
+"@id": "#213",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -34967,14 +36553,14 @@
 "@value": "value"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "The value of this property."
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#199/source-map",
+"@id": "#213/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -34982,7 +36568,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#199"
+"@value": "amf://id#213"
 }
 ],
 "sourcemaps:value": [
@@ -34996,7 +36582,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -35008,7 +36594,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#199"
+"@value": "amf://id#213"
 }
 ],
 "sourcemaps:value": [
@@ -35046,7 +36632,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#198/source-map",
+"@id": "#212/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -35054,7 +36640,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#198"
+"@value": "amf://id#212"
 }
 ],
 "sourcemaps:value": [
@@ -35075,7 +36661,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#185/source-map",
+"@id": "#199/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -35083,7 +36669,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#185"
+"@value": "amf://id#199"
 }
 ],
 "sourcemaps:value": [
@@ -35109,7 +36695,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#185"
+"@value": "amf://id#199"
 }
 ],
 "sourcemaps:value": [
@@ -35123,7 +36709,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#185"
+"@value": "amf://id#199"
 }
 ],
 "sourcemaps:value": [
@@ -35137,12 +36723,12 @@
 ]
 },
 {
-"@id": "#200",
+"@id": "#214",
 "@type": [
 "security:SecurityScheme",
 "doc:DomainElement"
 ],
-"security:name": [
+"core:name": [
 {
 "@value": "basic"
 }
@@ -35152,14 +36738,14 @@
 "@value": "Basic Authentication"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "Test basic auth method\n"
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#200/source-map",
+"@id": "#214/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -35167,7 +36753,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#200"
+"@value": "amf://id#214"
 }
 ],
 "sourcemaps:value": [
@@ -35181,7 +36767,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -35193,7 +36779,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "security:name"
+"@value": "core:name"
 }
 ],
 "sourcemaps:value": [
@@ -35205,7 +36791,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#200"
+"@value": "amf://id#214"
 }
 ],
 "sourcemaps:value": [
@@ -35231,12 +36817,12 @@
 ]
 },
 {
-"@id": "#201",
+"@id": "#215",
 "@type": [
 "security:SecurityScheme",
 "doc:DomainElement"
 ],
-"security:name": [
+"core:name": [
 {
 "@value": "other"
 }
@@ -35246,14 +36832,14 @@
 "@value": "Digest Authentication"
 }
 ],
-"schema-org:displayName": [
+"core:displayName": [
 {
 "@value": "Digest"
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#201/source-map",
+"@id": "#215/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -35261,7 +36847,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#201"
+"@value": "amf://id#215"
 }
 ],
 "sourcemaps:value": [
@@ -35275,7 +36861,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:displayName"
+"@value": "core:displayName"
 }
 ],
 "sourcemaps:value": [
@@ -35287,7 +36873,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "security:name"
+"@value": "core:name"
 }
 ],
 "sourcemaps:value": [
@@ -35299,7 +36885,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#201"
+"@value": "amf://id#215"
 }
 ],
 "sourcemaps:value": [
@@ -35325,7 +36911,7 @@
 ]
 },
 {
-"@id": "#27",
+"@id": "#29",
 "@type": [
 "shacl:NodeShape",
 "shacl:Shape",
@@ -35339,7 +36925,7 @@
 ],
 "shacl:property": [
 {
-"@id": "#28",
+"@id": "#30",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -35352,7 +36938,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#29",
+"@id": "#31",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -35371,7 +36957,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#29/source-map",
+"@id": "#31/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -35379,7 +36965,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#29"
+"@value": "amf://id#31"
 }
 ],
 "sourcemaps:value": [
@@ -35405,7 +36991,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#28/source-map",
+"@id": "#30/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -35413,7 +36999,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#28"
+"@value": "amf://id#30"
 }
 ],
 "sourcemaps:value": [
@@ -35434,7 +37020,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#27/source-map",
+"@id": "#29/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -35442,7 +37028,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#27"
+"@value": "amf://id#29"
 }
 ],
 "sourcemaps:value": [
@@ -35468,7 +37054,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#27"
+"@value": "amf://id#29"
 }
 ],
 "sourcemaps:value": [
@@ -35482,7 +37068,7 @@
 ]
 },
 {
-"@id": "#61",
+"@id": "#68",
 "@type": [
 "raml-shapes:UnionShape",
 "shacl:Shape",
@@ -35490,7 +37076,7 @@
 ],
 "raml-shapes:anyOf": [
 {
-"@id": "#62",
+"@id": "#69",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -35504,7 +37090,7 @@
 ]
 },
 {
-"@id": "#63",
+"@id": "#70",
 "@type": [
 "raml-shapes:NilShape",
 "shacl:Shape",
@@ -35519,7 +37105,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#61/source-map",
+"@id": "#68/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -35527,7 +37113,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#61"
+"@value": "amf://id#68"
 }
 ],
 "sourcemaps:value": [
@@ -35541,7 +37127,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#61"
+"@value": "amf://id#68"
 }
 ],
 "sourcemaps:value": [
@@ -35555,7 +37141,7 @@
 ]
 },
 {
-"@id": "#18",
+"@id": "#19",
 "@type": [
 "shacl:NodeShape",
 "shacl:Shape",
@@ -35569,7 +37155,7 @@
 ],
 "shacl:property": [
 {
-"@id": "#19",
+"@id": "#20",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -35582,7 +37168,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#20",
+"@id": "#21",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -35599,14 +37185,14 @@
 "@value": "url"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "The URL of the image.\nTo resize the image and crop it to a square, append the query string **?sz=x**, where x is the dimension in pixels of each side.\n"
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#20/source-map",
+"@id": "#21/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -35614,7 +37200,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#20"
+"@value": "amf://id#21"
 }
 ],
 "sourcemaps:value": [
@@ -35628,7 +37214,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -35640,7 +37226,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#20"
+"@value": "amf://id#21"
 }
 ],
 "sourcemaps:value": [
@@ -35678,7 +37264,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#19/source-map",
+"@id": "#20/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -35686,7 +37272,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#19"
+"@value": "amf://id#20"
 }
 ],
 "sourcemaps:value": [
@@ -35700,7 +37286,7 @@
 ]
 },
 {
-"@id": "#21",
+"@id": "#22",
 "@type": [
 "shacl:PropertyShape",
 "shacl:Shape",
@@ -35713,7 +37299,7 @@
 ],
 "raml-shapes:range": [
 {
-"@id": "#22",
+"@id": "#23",
 "@type": [
 "raml-shapes:ScalarShape",
 "shacl:Shape",
@@ -35730,19 +37316,19 @@
 "@value": "thumb"
 }
 ],
-"schema-org:name": [
+"core:name": [
 {
 "@value": "Thumbnail"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "An URL to the thumbnail of the image. Thumbnails are 60x60px cropped images of the original image.\n"
 }
 ],
 "sourcemaps:sources": [
 {
-"@id": "#22/source-map",
+"@id": "#23/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -35750,7 +37336,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#22"
+"@value": "amf://id#23"
 }
 ],
 "sourcemaps:value": [
@@ -35764,7 +37350,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -35788,7 +37374,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#22"
+"@value": "amf://id#23"
 }
 ],
 "sourcemaps:value": [
@@ -35800,7 +37386,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:name"
+"@value": "core:name"
 }
 ],
 "sourcemaps:value": [
@@ -35826,7 +37412,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#21/source-map",
+"@id": "#22/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -35834,7 +37420,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#21"
+"@value": "amf://id#22"
 }
 ],
 "sourcemaps:value": [
@@ -35853,16 +37439,23 @@
 "@value": "amf_inline_type_2"
 }
 ],
-"schema-org:description": [
+"core:description": [
 {
 "@value": "An image object representing an image object strored in the file store.\nThe image can be only included in the response. It has no effect if the Image appear in the\nrequest. Endpoint handles image creation on it's own and clients can't process images\nexcept of sending image data.\n"
 }
 ],
-"doc:examples": [
+"apiContract:examples": [
 {
-"@id": "#23",
+"@id": "#24",
 "@type": [
-"doc:Example",
+"apiContract:NamedExamples",
+"doc:DomainElement"
+],
+"apiContract:examples": [
+{
+"@id": "#25",
+"@type": [
+"apiContract:Example",
 "doc:DomainElement"
 ],
 "doc:strict": [
@@ -35872,15 +37465,19 @@
 ],
 "doc:structuredValue": [
 {
-"@id": "#23",
+"@id": "#25",
 "@type": [
-"data:Object"
+"data:Object",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:thumb": [
 {
-"@id": "#24",
+"@id": "#26",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -35890,7 +37487,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#24/source-map",
+"@id": "#26/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -35898,7 +37495,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#24"
+"@value": "amf://id#26"
 }
 ],
 "sourcemaps:value": [
@@ -35914,9 +37511,11 @@
 ],
 "data:url": [
 {
-"@id": "#25",
+"@id": "#27",
 "@type": [
-"data:Scalar"
+"data:Scalar",
+"data:Node",
+"doc:DomainElement"
 ],
 "data:value": [
 {
@@ -35926,7 +37525,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#25/source-map",
+"@id": "#27/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -35934,7 +37533,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#25"
+"@value": "amf://id#27"
 }
 ],
 "sourcemaps:value": [
@@ -35950,7 +37549,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#23/source-map",
+"@id": "#25/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -35958,12 +37557,36 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#23"
+"@value": "data:url"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(22,7)-(22,52)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "amf://id#25"
 }
 ],
 "sourcemaps:value": [
 {
 "@value": "[(22,0)-(24,0)]"
+}
+]
+},
+{
+"sourcemaps:element": [
+{
+"@value": "data:thumb"
+}
+],
+"sourcemaps:value": [
+{
+"@value": "[(23,9)-(23,60)]"
 }
 ]
 }
@@ -35972,7 +37595,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#23"
+"@value": "amf://id#25"
 }
 ],
 "sourcemaps:value": [
@@ -35993,7 +37616,7 @@
 ],
 "sourcemaps:sources": [
 {
-"@id": "#23/source-map",
+"@id": "#25/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -36027,7 +37650,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#23"
+"@value": "amf://id#25"
 }
 ],
 "sourcemaps:value": [
@@ -36040,10 +37663,12 @@
 }
 ]
 }
+]
+}
 ],
 "sourcemaps:sources": [
 {
-"@id": "#18/source-map",
+"@id": "#19/source-map",
 "@type": [
 "sourcemaps:SourceMap"
 ],
@@ -36051,7 +37676,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#18"
+"@value": "amf://id#19"
 }
 ],
 "sourcemaps:value": [
@@ -36065,7 +37690,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#18"
+"@value": "amf://id#19"
 }
 ],
 "sourcemaps:value": [
@@ -36079,7 +37704,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "schema-org:description"
+"@value": "core:description"
 }
 ],
 "sourcemaps:value": [
@@ -36091,7 +37716,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#18"
+"@value": "amf://id#19"
 }
 ],
 "sourcemaps:value": [
@@ -36105,7 +37730,7 @@
 {
 "sourcemaps:element": [
 {
-"@value": "amf://id#18"
+"@value": "amf://id#19"
 }
 ],
 "sourcemaps:value": [
@@ -36121,17 +37746,16 @@
 ],
 "@context": {
 "@base": "amf://id",
-"raml-http": "http://a.ml/vocabularies/http#",
 "shacl": "http://www.w3.org/ns/shacl#",
 "raml-shapes": "http://a.ml/vocabularies/shapes#",
 "security": "http://a.ml/vocabularies/security#",
 "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
 "data": "http://a.ml/vocabularies/data#",
 "doc": "http://a.ml/vocabularies/document#",
+"apiContract": "http://a.ml/vocabularies/apiContract#",
+"core": "http://a.ml/vocabularies/core#",
 "sourcemaps": "http://a.ml/vocabularies/document-source-maps#",
-"schema-org": "http://schema.org/",
-"xsd": "http://www.w3.org/2001/XMLSchema#",
-"hydra": "http://www.w3.org/ns/hydra/core#"
+"xsd": "http://www.w3.org/2001/XMLSchema#"
 }
 }
 ]

--- a/test/demo-api.json
+++ b/test/demo-api.json
@@ -9,54 +9,54 @@
 ],
 "http://a.ml/vocabularies/document#encodes": [
 {
-"@id": "amf://id#202",
+"@id": "amf://id#216",
 "@type": [
-"http://schema.org/WebAPI",
+"http://a.ml/vocabularies/apiContract#WebAPI",
 "http://a.ml/vocabularies/document#RootDomainElement",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://schema.org/name": [
+"http://a.ml/vocabularies/core#name": [
 {
 "@value": "Navigation demo API"
 }
 ],
-"http://a.ml/vocabularies/http#server": [
+"http://a.ml/vocabularies/apiContract#server": [
 {
-"@id": "amf://id#383",
+"@id": "amf://id#398",
 "@type": [
-"http://a.ml/vocabularies/http#Server",
+"http://a.ml/vocabularies/apiContract#Server",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://a.ml/vocabularies/http#url": [
+"http://a.ml/vocabularies/apiContract#url": [
 {
 "@value": "https://api.mulesoft.com/{version}"
 }
 ],
-"http://a.ml/vocabularies/http#variable": [
+"http://a.ml/vocabularies/apiContract#variable": [
 {
-"@id": "amf://id#384",
+"@id": "amf://id#399",
 "@type": [
-"http://a.ml/vocabularies/http#Parameter",
+"http://a.ml/vocabularies/apiContract#Parameter",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://schema.org/name": [
+"http://a.ml/vocabularies/core#name": [
 {
 "@value": "version"
 }
 ],
-"http://www.w3.org/ns/hydra/core#required": [
+"http://a.ml/vocabularies/apiContract#required": [
 {
 "@value": true
 }
 ],
-"http://a.ml/vocabularies/http#binding": [
+"http://a.ml/vocabularies/apiContract#binding": [
 {
 "@value": "path"
 }
 ],
-"http://a.ml/vocabularies/http#schema": [
+"http://a.ml/vocabularies/apiContract#schema": [
 {
-"@id": "amf://id#385",
+"@id": "amf://id#400",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -77,7 +77,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#384/source-map",
+"@id": "amf://id#399/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -85,7 +85,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#384"
+"@value": "amf://id#399"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -101,7 +101,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#383/source-map",
+"@id": "amf://id#398/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -109,7 +109,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://a.ml/vocabularies/http#url"
+"@value": "http://a.ml/vocabularies/apiContract#url"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -123,7 +123,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#383"
+"@value": "amf://id#398"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -137,36 +137,36 @@
 ]
 }
 ],
-"http://a.ml/vocabularies/http#scheme": [
+"http://a.ml/vocabularies/apiContract#scheme": [
 {
 "@value": "HTTPS"
 }
 ],
-"http://schema.org/version": [
+"http://a.ml/vocabularies/core#version": [
 {
 "@value": "v2"
 }
 ],
-"http://schema.org/documentation": [
+"http://a.ml/vocabularies/core#documentation": [
 {
-"@id": "amf://id#386",
+"@id": "amf://id#401",
 "@type": [
-"http://schema.org/CreativeWork",
+"http://a.ml/vocabularies/core#CreativeWork",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://schema.org/title": [
+"http://a.ml/vocabularies/core#title": [
 {
 "@value": "How to begin"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "Example content\n"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#386/source-map",
+"@id": "amf://id#401/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -174,7 +174,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -186,7 +186,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#386"
+"@value": "amf://id#401"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -198,7 +198,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/title"
+"@value": "http://a.ml/vocabularies/core#title"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -212,24 +212,24 @@
 ]
 },
 {
-"@id": "amf://id#387",
+"@id": "amf://id#402",
 "@type": [
-"http://schema.org/CreativeWork",
+"http://a.ml/vocabularies/core#CreativeWork",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://schema.org/title": [
+"http://a.ml/vocabularies/core#title": [
 {
 "@value": "Other documentation entry"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "Example content\n"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#387/source-map",
+"@id": "amf://id#402/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -237,7 +237,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -249,7 +249,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#387"
+"@value": "amf://id#402"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -261,7 +261,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/title"
+"@value": "http://a.ml/vocabularies/core#title"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -275,48 +275,48 @@
 ]
 }
 ],
-"http://a.ml/vocabularies/http#endpoint": [
+"http://a.ml/vocabularies/apiContract#endpoint": [
 {
-"@id": "amf://id#203",
+"@id": "amf://id#217",
 "@type": [
-"http://a.ml/vocabularies/http#EndPoint",
+"http://a.ml/vocabularies/apiContract#EndPoint",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://a.ml/vocabularies/http#path": [
+"http://a.ml/vocabularies/apiContract#path": [
 {
 "@value": "/files"
 }
 ],
-"http://schema.org/name": [
+"http://a.ml/vocabularies/core#name": [
 {
 "@value": "Files"
 }
 ],
-"http://www.w3.org/ns/hydra/core#supportedOperation": [
+"http://a.ml/vocabularies/apiContract#supportedOperation": [
 {
-"@id": "amf://id#204",
+"@id": "amf://id#218",
 "@type": [
-"http://www.w3.org/ns/hydra/core#Operation",
+"http://a.ml/vocabularies/apiContract#Operation",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://www.w3.org/ns/hydra/core#method": [
+"http://a.ml/vocabularies/apiContract#method": [
 {
 "@value": "post"
 }
 ],
-"http://schema.org/name": [
+"http://a.ml/vocabularies/core#name": [
 {
 "@value": "Insert"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "Insert a new file.\nThis method supports an /upload URI and accepts uploaded media with the following characteristics:\n\n- Maximum file size: 5120GB\n- Accepted Media MIME types: */*\n\nNote: Apps creating shortcuts with files.insert must specify the MIME type `application/vnd.google-apps.drive-sdk`.\n\nApps should specify a file extension in the title property when inserting files with the API. For example, an operation to insert a JPEG file should specify something like `\"title\": \"cat.jpg\"` in the metadata.\n\nSubsequent GET requests include the read-only fileExtension property populated with the extension originally specified in the title property. When a Google Drive user requests to download a file, or when the file is downloaded through the sync client, Drive builds a full filename (with extension) based on the title. In cases where the extension is missing, Google Drive attempts to determine the extension based on the file's MIME type.\n\n### HTTP request\n\nThis method provides media upload functionality through two separate URIs. For more details, see the document on media upload.\n\n- Upload URI, for media upload requests: `POST https://www.googleapis.com/upload/drive/v2/files`\n- Metadata URI, for metadata-only requests: `POST https://www.googleapis.com/drive/v2/files`\n"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#204/source-map",
+"@id": "amf://id#218/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -324,7 +324,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -336,7 +336,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#204"
+"@value": "amf://id#218"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -348,7 +348,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/name"
+"@value": "http://a.ml/vocabularies/core#name"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -362,46 +362,46 @@
 ]
 },
 {
-"@id": "amf://id#205",
+"@id": "amf://id#219",
 "@type": [
-"http://www.w3.org/ns/hydra/core#Operation",
+"http://a.ml/vocabularies/apiContract#Operation",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://www.w3.org/ns/hydra/core#method": [
+"http://a.ml/vocabularies/apiContract#method": [
 {
 "@value": "get"
 }
 ],
-"http://schema.org/name": [
+"http://a.ml/vocabularies/core#name": [
 {
 "@value": "list"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "Lists the user's files. Try it now or see an example.\n\nRequests with `files.list` accept the `q` parameter, which is a search query combining one or more search terms. For more information, see Search for files.\n\nNote: Note: This method returns all files by default. This includes files with trashed=true in the results. Use the trashed=false query parameter to filter these from the results.\n"
 }
 ],
 "http://a.ml/vocabularies/security#security": [
 {
-"@id": "amf://id#206",
+"@id": "amf://id#220",
 "@type": [
 "http://a.ml/vocabularies/security#ParametrizedSecurityScheme",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://a.ml/vocabularies/security#name": [
+"http://a.ml/vocabularies/core#name": [
 {
 "@value": "basic"
 }
 ],
 "http://a.ml/vocabularies/security#scheme": [
 {
-"@id": "amf://id#200",
+"@id": "amf://id#214",
 "@type": [
 "http://a.ml/vocabularies/security#SecurityScheme",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://a.ml/vocabularies/security#name": [
+"http://a.ml/vocabularies/core#name": [
 {
 "@value": "basic"
 }
@@ -411,14 +411,14 @@
 "@value": "Basic Authentication"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "Test basic auth method\n"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#200/source-map",
+"@id": "amf://id#214/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -426,7 +426,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#200"
+"@value": "amf://id#214"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -440,7 +440,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -452,7 +452,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://a.ml/vocabularies/security#name"
+"@value": "http://a.ml/vocabularies/core#name"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -464,7 +464,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#200"
+"@value": "amf://id#214"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -492,7 +492,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#206/source-map",
+"@id": "amf://id#220/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -500,7 +500,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#206"
+"@value": "amf://id#220"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -516,7 +516,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#205/source-map",
+"@id": "amf://id#219/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -524,7 +524,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -536,7 +536,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#205"
+"@value": "amf://id#219"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -548,7 +548,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/name"
+"@value": "http://a.ml/vocabularies/core#name"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -564,7 +564,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#203/source-map",
+"@id": "amf://id#217/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -572,7 +572,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/name"
+"@value": "http://a.ml/vocabularies/core#name"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -584,7 +584,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#203"
+"@value": "amf://id#217"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -598,41 +598,41 @@
 ]
 },
 {
-"@id": "amf://id#207",
+"@id": "amf://id#221",
 "@type": [
-"http://a.ml/vocabularies/http#EndPoint",
+"http://a.ml/vocabularies/apiContract#EndPoint",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://a.ml/vocabularies/http#path": [
+"http://a.ml/vocabularies/apiContract#path": [
 {
 "@value": "/files/{fileId}"
 }
 ],
-"http://schema.org/name": [
+"http://a.ml/vocabularies/core#name": [
 {
 "@value": "Get file"
 }
 ],
-"http://www.w3.org/ns/hydra/core#supportedOperation": [
+"http://a.ml/vocabularies/apiContract#supportedOperation": [
 {
-"@id": "amf://id#208",
+"@id": "amf://id#222",
 "@type": [
-"http://www.w3.org/ns/hydra/core#Operation",
+"http://a.ml/vocabularies/apiContract#Operation",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://www.w3.org/ns/hydra/core#method": [
+"http://a.ml/vocabularies/apiContract#method": [
 {
 "@value": "get"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "Gets a file's metadata by ID."
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#208/source-map",
+"@id": "amf://id#222/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -640,7 +640,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -652,7 +652,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#208"
+"@value": "amf://id#222"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -666,24 +666,24 @@
 ]
 },
 {
-"@id": "amf://id#209",
+"@id": "amf://id#223",
 "@type": [
-"http://www.w3.org/ns/hydra/core#Operation",
+"http://a.ml/vocabularies/apiContract#Operation",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://www.w3.org/ns/hydra/core#method": [
+"http://a.ml/vocabularies/apiContract#method": [
 {
 "@value": "patch"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "Updates file metadata. This method supports patch semantics."
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#209/source-map",
+"@id": "amf://id#223/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -691,7 +691,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -703,7 +703,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#209"
+"@value": "amf://id#223"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -717,24 +717,24 @@
 ]
 },
 {
-"@id": "amf://id#210",
+"@id": "amf://id#224",
 "@type": [
-"http://www.w3.org/ns/hydra/core#Operation",
+"http://a.ml/vocabularies/apiContract#Operation",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://www.w3.org/ns/hydra/core#method": [
+"http://a.ml/vocabularies/apiContract#method": [
 {
 "@value": "put"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "Updates file metadata and/or content."
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#210/source-map",
+"@id": "amf://id#224/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -742,7 +742,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -754,7 +754,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#210"
+"@value": "amf://id#224"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -768,24 +768,24 @@
 ]
 },
 {
-"@id": "amf://id#211",
+"@id": "amf://id#225",
 "@type": [
-"http://www.w3.org/ns/hydra/core#Operation",
+"http://a.ml/vocabularies/apiContract#Operation",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://www.w3.org/ns/hydra/core#method": [
+"http://a.ml/vocabularies/apiContract#method": [
 {
 "@value": "delete"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "Permanently deletes a file by ID. Skips the trash. The currently authenticated user must own the file."
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#211/source-map",
+"@id": "amf://id#225/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -793,7 +793,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -805,7 +805,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#211"
+"@value": "amf://id#225"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -819,36 +819,36 @@
 ]
 }
 ],
-"http://a.ml/vocabularies/http#parameter": [
+"http://a.ml/vocabularies/apiContract#parameter": [
 {
-"@id": "amf://id#212",
+"@id": "amf://id#226",
 "@type": [
-"http://a.ml/vocabularies/http#Parameter",
+"http://a.ml/vocabularies/apiContract#Parameter",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://schema.org/name": [
+"http://a.ml/vocabularies/core#name": [
 {
 "@value": "fileId"
 }
 ],
-"http://a.ml/vocabularies/http#paramName": [
+"http://a.ml/vocabularies/apiContract#paramName": [
 {
 "@value": "fileId"
 }
 ],
-"http://www.w3.org/ns/hydra/core#required": [
+"http://a.ml/vocabularies/apiContract#required": [
 {
 "@value": true
 }
 ],
-"http://a.ml/vocabularies/http#binding": [
+"http://a.ml/vocabularies/apiContract#binding": [
 {
 "@value": "path"
 }
 ],
-"http://a.ml/vocabularies/http#schema": [
+"http://a.ml/vocabularies/apiContract#schema": [
 {
-"@id": "amf://id#213",
+"@id": "amf://id#227",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -869,7 +869,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#212/source-map",
+"@id": "amf://id#226/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -877,7 +877,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#212"
+"@value": "amf://id#226"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -893,7 +893,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#207/source-map",
+"@id": "amf://id#221/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -901,7 +901,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#207"
+"@value": "amf://id#221"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -915,7 +915,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/name"
+"@value": "http://a.ml/vocabularies/core#name"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -927,7 +927,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#207"
+"@value": "amf://id#221"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -941,36 +941,36 @@
 ]
 },
 {
-"@id": "amf://id#214",
+"@id": "amf://id#228",
 "@type": [
-"http://a.ml/vocabularies/http#EndPoint",
+"http://a.ml/vocabularies/apiContract#EndPoint",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://a.ml/vocabularies/http#path": [
+"http://a.ml/vocabularies/apiContract#path": [
 {
 "@value": "/files/{fileId}/copy"
 }
 ],
-"http://www.w3.org/ns/hydra/core#supportedOperation": [
+"http://a.ml/vocabularies/apiContract#supportedOperation": [
 {
-"@id": "amf://id#215",
+"@id": "amf://id#229",
 "@type": [
-"http://www.w3.org/ns/hydra/core#Operation",
+"http://a.ml/vocabularies/apiContract#Operation",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://www.w3.org/ns/hydra/core#method": [
+"http://a.ml/vocabularies/apiContract#method": [
 {
 "@value": "post"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "Creates a copy of the specified file."
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#215/source-map",
+"@id": "amf://id#229/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -978,7 +978,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -990,7 +990,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#215"
+"@value": "amf://id#229"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -1004,36 +1004,36 @@
 ]
 }
 ],
-"http://a.ml/vocabularies/http#parameter": [
+"http://a.ml/vocabularies/apiContract#parameter": [
 {
-"@id": "amf://id#216",
+"@id": "amf://id#230",
 "@type": [
-"http://a.ml/vocabularies/http#Parameter",
+"http://a.ml/vocabularies/apiContract#Parameter",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://schema.org/name": [
+"http://a.ml/vocabularies/core#name": [
 {
 "@value": "fileId"
 }
 ],
-"http://a.ml/vocabularies/http#paramName": [
+"http://a.ml/vocabularies/apiContract#paramName": [
 {
 "@value": "fileId"
 }
 ],
-"http://www.w3.org/ns/hydra/core#required": [
+"http://a.ml/vocabularies/apiContract#required": [
 {
 "@value": true
 }
 ],
-"http://a.ml/vocabularies/http#binding": [
+"http://a.ml/vocabularies/apiContract#binding": [
 {
 "@value": "path"
 }
 ],
-"http://a.ml/vocabularies/http#schema": [
+"http://a.ml/vocabularies/apiContract#schema": [
 {
-"@id": "amf://id#217",
+"@id": "amf://id#231",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -1054,7 +1054,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#216/source-map",
+"@id": "amf://id#230/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -1062,7 +1062,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#216"
+"@value": "amf://id#230"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -1078,7 +1078,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#214/source-map",
+"@id": "amf://id#228/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -1086,7 +1086,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#214"
+"@value": "amf://id#228"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -1100,7 +1100,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#214"
+"@value": "amf://id#228"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -1114,36 +1114,36 @@
 ]
 },
 {
-"@id": "amf://id#218",
+"@id": "amf://id#232",
 "@type": [
-"http://a.ml/vocabularies/http#EndPoint",
+"http://a.ml/vocabularies/apiContract#EndPoint",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://a.ml/vocabularies/http#path": [
+"http://a.ml/vocabularies/apiContract#path": [
 {
 "@value": "/files/{fileId}/touch"
 }
 ],
-"http://www.w3.org/ns/hydra/core#supportedOperation": [
+"http://a.ml/vocabularies/apiContract#supportedOperation": [
 {
-"@id": "amf://id#219",
+"@id": "amf://id#233",
 "@type": [
-"http://www.w3.org/ns/hydra/core#Operation",
+"http://a.ml/vocabularies/apiContract#Operation",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://www.w3.org/ns/hydra/core#method": [
+"http://a.ml/vocabularies/apiContract#method": [
 {
 "@value": "post"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "Set the file's updated time to the current server time."
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#219/source-map",
+"@id": "amf://id#233/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -1151,7 +1151,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -1163,7 +1163,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#219"
+"@value": "amf://id#233"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -1177,36 +1177,36 @@
 ]
 }
 ],
-"http://a.ml/vocabularies/http#parameter": [
+"http://a.ml/vocabularies/apiContract#parameter": [
 {
-"@id": "amf://id#220",
+"@id": "amf://id#234",
 "@type": [
-"http://a.ml/vocabularies/http#Parameter",
+"http://a.ml/vocabularies/apiContract#Parameter",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://schema.org/name": [
+"http://a.ml/vocabularies/core#name": [
 {
 "@value": "fileId"
 }
 ],
-"http://a.ml/vocabularies/http#paramName": [
+"http://a.ml/vocabularies/apiContract#paramName": [
 {
 "@value": "fileId"
 }
 ],
-"http://www.w3.org/ns/hydra/core#required": [
+"http://a.ml/vocabularies/apiContract#required": [
 {
 "@value": true
 }
 ],
-"http://a.ml/vocabularies/http#binding": [
+"http://a.ml/vocabularies/apiContract#binding": [
 {
 "@value": "path"
 }
 ],
-"http://a.ml/vocabularies/http#schema": [
+"http://a.ml/vocabularies/apiContract#schema": [
 {
-"@id": "amf://id#221",
+"@id": "amf://id#235",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -1227,7 +1227,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#220/source-map",
+"@id": "amf://id#234/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -1235,7 +1235,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#220"
+"@value": "amf://id#234"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -1251,7 +1251,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#218/source-map",
+"@id": "amf://id#232/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -1259,7 +1259,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#218"
+"@value": "amf://id#232"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -1273,7 +1273,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#218"
+"@value": "amf://id#232"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -1287,36 +1287,36 @@
 ]
 },
 {
-"@id": "amf://id#222",
+"@id": "amf://id#236",
 "@type": [
-"http://a.ml/vocabularies/http#EndPoint",
+"http://a.ml/vocabularies/apiContract#EndPoint",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://a.ml/vocabularies/http#path": [
+"http://a.ml/vocabularies/apiContract#path": [
 {
 "@value": "/files/{fileId}/trash"
 }
 ],
-"http://www.w3.org/ns/hydra/core#supportedOperation": [
+"http://a.ml/vocabularies/apiContract#supportedOperation": [
 {
-"@id": "amf://id#223",
+"@id": "amf://id#237",
 "@type": [
-"http://www.w3.org/ns/hydra/core#Operation",
+"http://a.ml/vocabularies/apiContract#Operation",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://www.w3.org/ns/hydra/core#method": [
+"http://a.ml/vocabularies/apiContract#method": [
 {
 "@value": "post"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "Moves a file to the trash. The currently authenticated user must own the file."
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#223/source-map",
+"@id": "amf://id#237/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -1324,7 +1324,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -1336,7 +1336,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#223"
+"@value": "amf://id#237"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -1350,655 +1350,34 @@
 ]
 }
 ],
-"http://a.ml/vocabularies/http#parameter": [
-{
-"@id": "amf://id#224",
-"@type": [
-"http://a.ml/vocabularies/http#Parameter",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://schema.org/name": [
-{
-"@value": "fileId"
-}
-],
-"http://a.ml/vocabularies/http#paramName": [
-{
-"@value": "fileId"
-}
-],
-"http://www.w3.org/ns/hydra/core#required": [
-{
-"@value": true
-}
-],
-"http://a.ml/vocabularies/http#binding": [
-{
-"@value": "path"
-}
-],
-"http://a.ml/vocabularies/http#schema": [
-{
-"@id": "amf://id#225",
-"@type": [
-"http://a.ml/vocabularies/shapes#ScalarShape",
-"http://www.w3.org/ns/shacl#Shape",
-"http://a.ml/vocabularies/shapes#Shape",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://www.w3.org/ns/shacl#datatype": [
-{
-"@id": "http://www.w3.org/2001/XMLSchema#string"
-}
-],
-"http://www.w3.org/ns/shacl#name": [
-{
-"@value": "fileId"
-}
-]
-}
-],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "amf://id#224/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#synthesized-field": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#224"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "true"
-}
-]
-}
-]
-}
-]
-}
-],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "amf://id#222/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#parent-end-point": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#222"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "file://test/demo-api/demo-api.raml#/web-api/end-points/%2Ffiles%2F%7BfileId%7D"
-}
-]
-}
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#222"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(140,4)-(143,0)]"
-}
-]
-}
-]
-}
-]
-},
-{
-"@id": "amf://id#226",
-"@type": [
-"http://a.ml/vocabularies/http#EndPoint",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://a.ml/vocabularies/http#path": [
-{
-"@value": "/files/{fileId}/untrash"
-}
-],
-"http://www.w3.org/ns/hydra/core#supportedOperation": [
-{
-"@id": "amf://id#227",
-"@type": [
-"http://www.w3.org/ns/hydra/core#Operation",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://www.w3.org/ns/hydra/core#method": [
-{
-"@value": "post"
-}
-],
-"http://schema.org/description": [
-{
-"@value": "Restores a file from the trash."
-}
-],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "amf://id#227/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "http://schema.org/description"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(145,8)-(146,0)]"
-}
-]
-},
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#227"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(144,6)-(146,0)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"http://a.ml/vocabularies/http#parameter": [
-{
-"@id": "amf://id#228",
-"@type": [
-"http://a.ml/vocabularies/http#Parameter",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://schema.org/name": [
-{
-"@value": "fileId"
-}
-],
-"http://a.ml/vocabularies/http#paramName": [
-{
-"@value": "fileId"
-}
-],
-"http://www.w3.org/ns/hydra/core#required": [
-{
-"@value": true
-}
-],
-"http://a.ml/vocabularies/http#binding": [
-{
-"@value": "path"
-}
-],
-"http://a.ml/vocabularies/http#schema": [
-{
-"@id": "amf://id#229",
-"@type": [
-"http://a.ml/vocabularies/shapes#ScalarShape",
-"http://www.w3.org/ns/shacl#Shape",
-"http://a.ml/vocabularies/shapes#Shape",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://www.w3.org/ns/shacl#datatype": [
-{
-"@id": "http://www.w3.org/2001/XMLSchema#string"
-}
-],
-"http://www.w3.org/ns/shacl#name": [
-{
-"@value": "fileId"
-}
-]
-}
-],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "amf://id#228/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#synthesized-field": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#228"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "true"
-}
-]
-}
-]
-}
-]
-}
-],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "amf://id#226/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#parent-end-point": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#226"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "file://test/demo-api/demo-api.raml#/web-api/end-points/%2Ffiles%2F%7BfileId%7D"
-}
-]
-}
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#226"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(143,4)-(146,0)]"
-}
-]
-}
-]
-}
-]
-},
-{
-"@id": "amf://id#230",
-"@type": [
-"http://a.ml/vocabularies/http#EndPoint",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://a.ml/vocabularies/http#path": [
-{
-"@value": "/files/{fileId}/parents"
-}
-],
-"http://www.w3.org/ns/hydra/core#supportedOperation": [
-{
-"@id": "amf://id#231",
-"@type": [
-"http://www.w3.org/ns/hydra/core#Operation",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://www.w3.org/ns/hydra/core#method": [
-{
-"@value": "get"
-}
-],
-"http://schema.org/description": [
-{
-"@value": "Lists a file's parents."
-}
-],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "amf://id#231/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "http://schema.org/description"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(148,8)-(149,0)]"
-}
-]
-},
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#231"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(147,6)-(149,0)]"
-}
-]
-}
-]
-}
-]
-},
-{
-"@id": "amf://id#232",
-"@type": [
-"http://www.w3.org/ns/hydra/core#Operation",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://www.w3.org/ns/hydra/core#method": [
-{
-"@value": "post"
-}
-],
-"http://schema.org/description": [
-{
-"@value": "Adds a parent folder for a file."
-}
-],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "amf://id#232/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "http://schema.org/description"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(150,8)-(151,0)]"
-}
-]
-},
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#232"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(149,6)-(151,0)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"http://a.ml/vocabularies/http#parameter": [
-{
-"@id": "amf://id#233",
-"@type": [
-"http://a.ml/vocabularies/http#Parameter",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://schema.org/name": [
-{
-"@value": "fileId"
-}
-],
-"http://a.ml/vocabularies/http#paramName": [
-{
-"@value": "fileId"
-}
-],
-"http://www.w3.org/ns/hydra/core#required": [
-{
-"@value": true
-}
-],
-"http://a.ml/vocabularies/http#binding": [
-{
-"@value": "path"
-}
-],
-"http://a.ml/vocabularies/http#schema": [
-{
-"@id": "amf://id#234",
-"@type": [
-"http://a.ml/vocabularies/shapes#ScalarShape",
-"http://www.w3.org/ns/shacl#Shape",
-"http://a.ml/vocabularies/shapes#Shape",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://www.w3.org/ns/shacl#datatype": [
-{
-"@id": "http://www.w3.org/2001/XMLSchema#string"
-}
-],
-"http://www.w3.org/ns/shacl#name": [
-{
-"@value": "fileId"
-}
-]
-}
-],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "amf://id#233/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#synthesized-field": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#233"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "true"
-}
-]
-}
-]
-}
-]
-}
-],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "amf://id#230/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#parent-end-point": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#230"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "file://test/demo-api/demo-api.raml#/web-api/end-points/%2Ffiles%2F%7BfileId%7D"
-}
-]
-}
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#230"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(146,4)-(160,0)]"
-}
-]
-}
-]
-}
-]
-},
-{
-"@id": "amf://id#235",
-"@type": [
-"http://a.ml/vocabularies/http#EndPoint",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://a.ml/vocabularies/http#path": [
-{
-"@value": "/files/{fileId}/parents/{parentId}"
-}
-],
-"http://www.w3.org/ns/hydra/core#supportedOperation": [
-{
-"@id": "amf://id#236",
-"@type": [
-"http://www.w3.org/ns/hydra/core#Operation",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://www.w3.org/ns/hydra/core#method": [
-{
-"@value": "get"
-}
-],
-"http://schema.org/description": [
-{
-"@value": "Gets a specific parent reference."
-}
-],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "amf://id#236/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "http://schema.org/description"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(157,10)-(158,0)]"
-}
-]
-},
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#236"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(156,8)-(158,0)]"
-}
-]
-}
-]
-}
-]
-},
-{
-"@id": "amf://id#237",
-"@type": [
-"http://www.w3.org/ns/hydra/core#Operation",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://www.w3.org/ns/hydra/core#method": [
-{
-"@value": "delete"
-}
-],
-"http://schema.org/description": [
-{
-"@value": "Removes a parent from a file."
-}
-],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "amf://id#237/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "http://schema.org/description"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(159,10)-(160,0)]"
-}
-]
-},
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#237"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(158,8)-(160,0)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"http://a.ml/vocabularies/http#parameter": [
+"http://a.ml/vocabularies/apiContract#parameter": [
 {
 "@id": "amf://id#238",
 "@type": [
-"http://a.ml/vocabularies/http#Parameter",
+"http://a.ml/vocabularies/apiContract#Parameter",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://schema.org/name": [
+"http://a.ml/vocabularies/core#name": [
 {
 "@value": "fileId"
 }
 ],
-"http://a.ml/vocabularies/http#paramName": [
+"http://a.ml/vocabularies/apiContract#paramName": [
 {
 "@value": "fileId"
 }
 ],
-"http://www.w3.org/ns/hydra/core#required": [
+"http://a.ml/vocabularies/apiContract#required": [
 {
 "@value": true
 }
 ],
-"http://a.ml/vocabularies/http#binding": [
+"http://a.ml/vocabularies/apiContract#binding": [
 {
 "@value": "path"
 }
 ],
-"http://a.ml/vocabularies/http#schema": [
+"http://a.ml/vocabularies/apiContract#schema": [
 {
 "@id": "amf://id#239",
 "@type": [
@@ -2041,41 +1420,662 @@
 ]
 }
 ]
+}
+],
+"http://a.ml/vocabularies/document-source-maps#sources": [
+{
+"@id": "amf://id#236/source-map",
+"@type": [
+"http://a.ml/vocabularies/document-source-maps#SourceMap"
+],
+"http://a.ml/vocabularies/document-source-maps#parent-end-point": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#236"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "file://test/demo-api/demo-api.raml#/web-api/end-points/%2Ffiles%2F%7BfileId%7D"
+}
+]
+}
+],
+"http://a.ml/vocabularies/document-source-maps#lexical": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#236"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(140,4)-(143,0)]"
+}
+]
+}
+]
+}
+]
 },
 {
 "@id": "amf://id#240",
 "@type": [
-"http://a.ml/vocabularies/http#Parameter",
+"http://a.ml/vocabularies/apiContract#EndPoint",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://schema.org/name": [
+"http://a.ml/vocabularies/apiContract#path": [
 {
-"@value": "parentId"
+"@value": "/files/{fileId}/untrash"
 }
 ],
-"http://a.ml/vocabularies/http#paramName": [
+"http://a.ml/vocabularies/apiContract#supportedOperation": [
 {
-"@value": "parentId"
+"@id": "amf://id#241",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Operation",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/apiContract#method": [
+{
+"@value": "post"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
-"@value": "The ID of the parent."
+"@value": "Restores a file from the trash."
 }
 ],
-"http://www.w3.org/ns/hydra/core#required": [
+"http://a.ml/vocabularies/document-source-maps#sources": [
+{
+"@id": "amf://id#241/source-map",
+"@type": [
+"http://a.ml/vocabularies/document-source-maps#SourceMap"
+],
+"http://a.ml/vocabularies/document-source-maps#lexical": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/core#description"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(145,8)-(146,0)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#241"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(144,6)-(146,0)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"http://a.ml/vocabularies/apiContract#parameter": [
+{
+"@id": "amf://id#242",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Parameter",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/core#name": [
+{
+"@value": "fileId"
+}
+],
+"http://a.ml/vocabularies/apiContract#paramName": [
+{
+"@value": "fileId"
+}
+],
+"http://a.ml/vocabularies/apiContract#required": [
 {
 "@value": true
 }
 ],
-"http://a.ml/vocabularies/http#binding": [
+"http://a.ml/vocabularies/apiContract#binding": [
 {
 "@value": "path"
 }
 ],
-"http://a.ml/vocabularies/http#schema": [
+"http://a.ml/vocabularies/apiContract#schema": [
 {
-"@id": "amf://id#241",
+"@id": "amf://id#243",
+"@type": [
+"http://a.ml/vocabularies/shapes#ScalarShape",
+"http://www.w3.org/ns/shacl#Shape",
+"http://a.ml/vocabularies/shapes#Shape",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://www.w3.org/ns/shacl#datatype": [
+{
+"@id": "http://www.w3.org/2001/XMLSchema#string"
+}
+],
+"http://www.w3.org/ns/shacl#name": [
+{
+"@value": "fileId"
+}
+]
+}
+],
+"http://a.ml/vocabularies/document-source-maps#sources": [
+{
+"@id": "amf://id#242/source-map",
+"@type": [
+"http://a.ml/vocabularies/document-source-maps#SourceMap"
+],
+"http://a.ml/vocabularies/document-source-maps#synthesized-field": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#242"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "true"
+}
+]
+}
+]
+}
+]
+}
+],
+"http://a.ml/vocabularies/document-source-maps#sources": [
+{
+"@id": "amf://id#240/source-map",
+"@type": [
+"http://a.ml/vocabularies/document-source-maps#SourceMap"
+],
+"http://a.ml/vocabularies/document-source-maps#parent-end-point": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#240"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "file://test/demo-api/demo-api.raml#/web-api/end-points/%2Ffiles%2F%7BfileId%7D"
+}
+]
+}
+],
+"http://a.ml/vocabularies/document-source-maps#lexical": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#240"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(143,4)-(146,0)]"
+}
+]
+}
+]
+}
+]
+},
+{
+"@id": "amf://id#244",
+"@type": [
+"http://a.ml/vocabularies/apiContract#EndPoint",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/apiContract#path": [
+{
+"@value": "/files/{fileId}/parents"
+}
+],
+"http://a.ml/vocabularies/apiContract#supportedOperation": [
+{
+"@id": "amf://id#245",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Operation",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/apiContract#method": [
+{
+"@value": "get"
+}
+],
+"http://a.ml/vocabularies/core#description": [
+{
+"@value": "Lists a file's parents."
+}
+],
+"http://a.ml/vocabularies/document-source-maps#sources": [
+{
+"@id": "amf://id#245/source-map",
+"@type": [
+"http://a.ml/vocabularies/document-source-maps#SourceMap"
+],
+"http://a.ml/vocabularies/document-source-maps#lexical": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/core#description"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(148,8)-(149,0)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#245"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(147,6)-(149,0)]"
+}
+]
+}
+]
+}
+]
+},
+{
+"@id": "amf://id#246",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Operation",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/apiContract#method": [
+{
+"@value": "post"
+}
+],
+"http://a.ml/vocabularies/core#description": [
+{
+"@value": "Adds a parent folder for a file."
+}
+],
+"http://a.ml/vocabularies/document-source-maps#sources": [
+{
+"@id": "amf://id#246/source-map",
+"@type": [
+"http://a.ml/vocabularies/document-source-maps#SourceMap"
+],
+"http://a.ml/vocabularies/document-source-maps#lexical": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/core#description"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(150,8)-(151,0)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#246"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(149,6)-(151,0)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"http://a.ml/vocabularies/apiContract#parameter": [
+{
+"@id": "amf://id#247",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Parameter",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/core#name": [
+{
+"@value": "fileId"
+}
+],
+"http://a.ml/vocabularies/apiContract#paramName": [
+{
+"@value": "fileId"
+}
+],
+"http://a.ml/vocabularies/apiContract#required": [
+{
+"@value": true
+}
+],
+"http://a.ml/vocabularies/apiContract#binding": [
+{
+"@value": "path"
+}
+],
+"http://a.ml/vocabularies/apiContract#schema": [
+{
+"@id": "amf://id#248",
+"@type": [
+"http://a.ml/vocabularies/shapes#ScalarShape",
+"http://www.w3.org/ns/shacl#Shape",
+"http://a.ml/vocabularies/shapes#Shape",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://www.w3.org/ns/shacl#datatype": [
+{
+"@id": "http://www.w3.org/2001/XMLSchema#string"
+}
+],
+"http://www.w3.org/ns/shacl#name": [
+{
+"@value": "fileId"
+}
+]
+}
+],
+"http://a.ml/vocabularies/document-source-maps#sources": [
+{
+"@id": "amf://id#247/source-map",
+"@type": [
+"http://a.ml/vocabularies/document-source-maps#SourceMap"
+],
+"http://a.ml/vocabularies/document-source-maps#synthesized-field": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#247"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "true"
+}
+]
+}
+]
+}
+]
+}
+],
+"http://a.ml/vocabularies/document-source-maps#sources": [
+{
+"@id": "amf://id#244/source-map",
+"@type": [
+"http://a.ml/vocabularies/document-source-maps#SourceMap"
+],
+"http://a.ml/vocabularies/document-source-maps#parent-end-point": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#244"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "file://test/demo-api/demo-api.raml#/web-api/end-points/%2Ffiles%2F%7BfileId%7D"
+}
+]
+}
+],
+"http://a.ml/vocabularies/document-source-maps#lexical": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#244"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(146,4)-(160,0)]"
+}
+]
+}
+]
+}
+]
+},
+{
+"@id": "amf://id#249",
+"@type": [
+"http://a.ml/vocabularies/apiContract#EndPoint",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/apiContract#path": [
+{
+"@value": "/files/{fileId}/parents/{parentId}"
+}
+],
+"http://a.ml/vocabularies/apiContract#supportedOperation": [
+{
+"@id": "amf://id#250",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Operation",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/apiContract#method": [
+{
+"@value": "get"
+}
+],
+"http://a.ml/vocabularies/core#description": [
+{
+"@value": "Gets a specific parent reference."
+}
+],
+"http://a.ml/vocabularies/document-source-maps#sources": [
+{
+"@id": "amf://id#250/source-map",
+"@type": [
+"http://a.ml/vocabularies/document-source-maps#SourceMap"
+],
+"http://a.ml/vocabularies/document-source-maps#lexical": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/core#description"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(157,10)-(158,0)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#250"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(156,8)-(158,0)]"
+}
+]
+}
+]
+}
+]
+},
+{
+"@id": "amf://id#251",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Operation",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/apiContract#method": [
+{
+"@value": "delete"
+}
+],
+"http://a.ml/vocabularies/core#description": [
+{
+"@value": "Removes a parent from a file."
+}
+],
+"http://a.ml/vocabularies/document-source-maps#sources": [
+{
+"@id": "amf://id#251/source-map",
+"@type": [
+"http://a.ml/vocabularies/document-source-maps#SourceMap"
+],
+"http://a.ml/vocabularies/document-source-maps#lexical": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/core#description"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(159,10)-(160,0)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#251"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(158,8)-(160,0)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"http://a.ml/vocabularies/apiContract#parameter": [
+{
+"@id": "amf://id#252",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Parameter",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/core#name": [
+{
+"@value": "fileId"
+}
+],
+"http://a.ml/vocabularies/apiContract#paramName": [
+{
+"@value": "fileId"
+}
+],
+"http://a.ml/vocabularies/apiContract#required": [
+{
+"@value": true
+}
+],
+"http://a.ml/vocabularies/apiContract#binding": [
+{
+"@value": "path"
+}
+],
+"http://a.ml/vocabularies/apiContract#schema": [
+{
+"@id": "amf://id#253",
+"@type": [
+"http://a.ml/vocabularies/shapes#ScalarShape",
+"http://www.w3.org/ns/shacl#Shape",
+"http://a.ml/vocabularies/shapes#Shape",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://www.w3.org/ns/shacl#datatype": [
+{
+"@id": "http://www.w3.org/2001/XMLSchema#string"
+}
+],
+"http://www.w3.org/ns/shacl#name": [
+{
+"@value": "fileId"
+}
+]
+}
+],
+"http://a.ml/vocabularies/document-source-maps#sources": [
+{
+"@id": "amf://id#252/source-map",
+"@type": [
+"http://a.ml/vocabularies/document-source-maps#SourceMap"
+],
+"http://a.ml/vocabularies/document-source-maps#synthesized-field": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#252"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "true"
+}
+]
+}
+]
+}
+]
+},
+{
+"@id": "amf://id#254",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Parameter",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/core#name": [
+{
+"@value": "parentId"
+}
+],
+"http://a.ml/vocabularies/apiContract#paramName": [
+{
+"@value": "parentId"
+}
+],
+"http://a.ml/vocabularies/core#description": [
+{
+"@value": "The ID of the parent."
+}
+],
+"http://a.ml/vocabularies/apiContract#required": [
+{
+"@value": true
+}
+],
+"http://a.ml/vocabularies/apiContract#binding": [
+{
+"@value": "path"
+}
+],
+"http://a.ml/vocabularies/apiContract#schema": [
+{
+"@id": "amf://id#255",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -2092,14 +2092,14 @@
 "@value": "schema"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "The ID of the parent."
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#241/source-map",
+"@id": "amf://id#255/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -2107,7 +2107,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#241"
+"@value": "amf://id#255"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -2121,7 +2121,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -2133,7 +2133,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#241"
+"@value": "amf://id#255"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -2161,7 +2161,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#240/source-map",
+"@id": "amf://id#254/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -2169,7 +2169,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -2181,7 +2181,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#240"
+"@value": "amf://id#254"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -2197,7 +2197,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#235/source-map",
+"@id": "amf://id#249/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -2205,7 +2205,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#235"
+"@value": "amf://id#249"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -2219,7 +2219,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://a.ml/vocabularies/http#parameter"
+"@value": "http://a.ml/vocabularies/apiContract#parameter"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -2231,7 +2231,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#235"
+"@value": "amf://id#249"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -2245,36 +2245,36 @@
 ]
 },
 {
-"@id": "amf://id#242",
+"@id": "amf://id#256",
 "@type": [
-"http://a.ml/vocabularies/http#EndPoint",
+"http://a.ml/vocabularies/apiContract#EndPoint",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://a.ml/vocabularies/http#path": [
+"http://a.ml/vocabularies/apiContract#path": [
 {
 "@value": "/files/{fileId}/permissions"
 }
 ],
-"http://www.w3.org/ns/hydra/core#supportedOperation": [
+"http://a.ml/vocabularies/apiContract#supportedOperation": [
 {
-"@id": "amf://id#243",
+"@id": "amf://id#257",
 "@type": [
-"http://www.w3.org/ns/hydra/core#Operation",
+"http://a.ml/vocabularies/apiContract#Operation",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://www.w3.org/ns/hydra/core#method": [
+"http://a.ml/vocabularies/apiContract#method": [
 {
 "@value": "get"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "Lists a file's permissions."
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#243/source-map",
+"@id": "amf://id#257/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -2282,7 +2282,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -2294,7 +2294,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#243"
+"@value": "amf://id#257"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -2308,24 +2308,24 @@
 ]
 },
 {
-"@id": "amf://id#244",
+"@id": "amf://id#258",
 "@type": [
-"http://www.w3.org/ns/hydra/core#Operation",
+"http://a.ml/vocabularies/apiContract#Operation",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://www.w3.org/ns/hydra/core#method": [
+"http://a.ml/vocabularies/apiContract#method": [
 {
 "@value": "post"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "Inserts a permission for a file.\n\nWarning: Concurrent permissions operations on the same file are not supported; only the last update is applied.\n"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#244/source-map",
+"@id": "amf://id#258/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -2333,7 +2333,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -2345,7 +2345,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#244"
+"@value": "amf://id#258"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -2359,734 +2359,34 @@
 ]
 }
 ],
-"http://a.ml/vocabularies/http#parameter": [
-{
-"@id": "amf://id#245",
-"@type": [
-"http://a.ml/vocabularies/http#Parameter",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://schema.org/name": [
-{
-"@value": "fileId"
-}
-],
-"http://a.ml/vocabularies/http#paramName": [
-{
-"@value": "fileId"
-}
-],
-"http://www.w3.org/ns/hydra/core#required": [
-{
-"@value": true
-}
-],
-"http://a.ml/vocabularies/http#binding": [
-{
-"@value": "path"
-}
-],
-"http://a.ml/vocabularies/http#schema": [
-{
-"@id": "amf://id#246",
-"@type": [
-"http://a.ml/vocabularies/shapes#ScalarShape",
-"http://www.w3.org/ns/shacl#Shape",
-"http://a.ml/vocabularies/shapes#Shape",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://www.w3.org/ns/shacl#datatype": [
-{
-"@id": "http://www.w3.org/2001/XMLSchema#string"
-}
-],
-"http://www.w3.org/ns/shacl#name": [
-{
-"@value": "fileId"
-}
-]
-}
-],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "amf://id#245/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#synthesized-field": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#245"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "true"
-}
-]
-}
-]
-}
-]
-}
-],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "amf://id#242/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#parent-end-point": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#242"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "file://test/demo-api/demo-api.raml#/web-api/end-points/%2Ffiles%2F%7BfileId%7D"
-}
-]
-}
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#242"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(160,4)-(192,0)]"
-}
-]
-}
-]
-}
-]
-},
-{
-"@id": "amf://id#247",
-"@type": [
-"http://a.ml/vocabularies/http#EndPoint",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://a.ml/vocabularies/http#path": [
-{
-"@value": "/files/{fileId}/permissions/{permissionId}"
-}
-],
-"http://www.w3.org/ns/hydra/core#supportedOperation": [
-{
-"@id": "amf://id#248",
-"@type": [
-"http://www.w3.org/ns/hydra/core#Operation",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://www.w3.org/ns/hydra/core#method": [
-{
-"@value": "get"
-}
-],
-"http://schema.org/description": [
-{
-"@value": "Gets a permission by ID."
-}
-],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "amf://id#248/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "http://schema.org/description"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(174,10)-(175,0)]"
-}
-]
-},
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#248"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(173,8)-(175,0)]"
-}
-]
-}
-]
-}
-]
-},
-{
-"@id": "amf://id#249",
-"@type": [
-"http://www.w3.org/ns/hydra/core#Operation",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://www.w3.org/ns/hydra/core#method": [
-{
-"@value": "put"
-}
-],
-"http://schema.org/description": [
-{
-"@value": "Updates a permission.\n\n**Warning**: Concurrent permissions operations on the same file are not supported; only the last update is applied.\n"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "amf://id#249/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "http://schema.org/description"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(176,10)-(180,0)]"
-}
-]
-},
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#249"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(175,8)-(180,0)]"
-}
-]
-}
-]
-}
-]
-},
-{
-"@id": "amf://id#250",
-"@type": [
-"http://www.w3.org/ns/hydra/core#Operation",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://www.w3.org/ns/hydra/core#method": [
-{
-"@value": "delete"
-}
-],
-"http://schema.org/description": [
-{
-"@value": "Deletes a permission from a file.\n\nWarning: Concurrent permissions operations on the same file are not supported; only the last update is applied.\n"
-}
-],
-"http://www.w3.org/ns/hydra/core#returns": [
-{
-"@id": "amf://id#251",
-"@type": [
-"http://a.ml/vocabularies/http#Response",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://schema.org/name": [
-{
-"@value": "204"
-}
-],
-"http://www.w3.org/ns/hydra/core#statusCode": [
-{
-"@value": "204"
-}
-],
-"http://a.ml/vocabularies/http#payload": [],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "amf://id#251/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#251"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(186,12)-(187,0)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "amf://id#250/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "http://www.w3.org/ns/hydra/core#returns"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(185,10)-(187,0)]"
-}
-]
-},
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#250"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(180,8)-(187,0)]"
-}
-]
-},
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "http://schema.org/description"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(181,10)-(185,0)]"
-}
-]
-}
-]
-}
-]
-},
-{
-"@id": "amf://id#252",
-"@type": [
-"http://www.w3.org/ns/hydra/core#Operation",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://www.w3.org/ns/hydra/core#method": [
-{
-"@value": "patch"
-}
-],
-"http://schema.org/description": [
-{
-"@value": "Updates a permission. This method supports patch semantics.\n\n**Warning**: Concurrent permissions operations on the same file are not supported; only the last update is applied.\n"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "amf://id#252/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "http://schema.org/description"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(188,10)-(192,0)]"
-}
-]
-},
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#252"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(187,8)-(192,0)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"http://a.ml/vocabularies/http#parameter": [
-{
-"@id": "amf://id#253",
-"@type": [
-"http://a.ml/vocabularies/http#Parameter",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://schema.org/name": [
-{
-"@value": "fileId"
-}
-],
-"http://a.ml/vocabularies/http#paramName": [
-{
-"@value": "fileId"
-}
-],
-"http://www.w3.org/ns/hydra/core#required": [
-{
-"@value": true
-}
-],
-"http://a.ml/vocabularies/http#binding": [
-{
-"@value": "path"
-}
-],
-"http://a.ml/vocabularies/http#schema": [
-{
-"@id": "amf://id#254",
-"@type": [
-"http://a.ml/vocabularies/shapes#ScalarShape",
-"http://www.w3.org/ns/shacl#Shape",
-"http://a.ml/vocabularies/shapes#Shape",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://www.w3.org/ns/shacl#datatype": [
-{
-"@id": "http://www.w3.org/2001/XMLSchema#string"
-}
-],
-"http://www.w3.org/ns/shacl#name": [
-{
-"@value": "fileId"
-}
-]
-}
-],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "amf://id#253/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#synthesized-field": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#253"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "true"
-}
-]
-}
-]
-}
-]
-},
-{
-"@id": "amf://id#255",
-"@type": [
-"http://a.ml/vocabularies/http#Parameter",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://schema.org/name": [
-{
-"@value": "permissionId"
-}
-],
-"http://a.ml/vocabularies/http#paramName": [
-{
-"@value": "permissionId"
-}
-],
-"http://schema.org/description": [
-{
-"@value": "The ID for the permission."
-}
-],
-"http://www.w3.org/ns/hydra/core#required": [
-{
-"@value": true
-}
-],
-"http://a.ml/vocabularies/http#binding": [
-{
-"@value": "path"
-}
-],
-"http://a.ml/vocabularies/http#schema": [
-{
-"@id": "amf://id#256",
-"@type": [
-"http://a.ml/vocabularies/shapes#ScalarShape",
-"http://www.w3.org/ns/shacl#Shape",
-"http://a.ml/vocabularies/shapes#Shape",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://www.w3.org/ns/shacl#datatype": [
-{
-"@id": "http://www.w3.org/2001/XMLSchema#string"
-}
-],
-"http://www.w3.org/ns/shacl#name": [
-{
-"@value": "schema"
-}
-],
-"http://schema.org/description": [
-{
-"@value": "The ID for the permission."
-}
-],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "amf://id#256/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#256"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(171,12)-(171,16)]"
-}
-]
-}
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "http://schema.org/description"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(172,12)-(173,0)]"
-}
-]
-},
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#256"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(170,10)-(173,0)]"
-}
-]
-},
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "http://www.w3.org/ns/shacl#datatype"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(171,12)-(172,0)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "amf://id#255/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "http://schema.org/description"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(172,12)-(173,0)]"
-}
-]
-},
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#255"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(170,10)-(173,0)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "amf://id#247/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#parent-end-point": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#247"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "file://test/demo-api/demo-api.raml#/web-api/end-points/%2Ffiles%2F%7BfileId%7D%2Fpermissions"
-}
-]
-}
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "http://a.ml/vocabularies/http#parameter"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(169,22)-(173,0)]"
-}
-]
-},
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#247"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(168,6)-(192,0)]"
-}
-]
-}
-]
-}
-]
-},
-{
-"@id": "amf://id#257",
-"@type": [
-"http://a.ml/vocabularies/http#EndPoint",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://a.ml/vocabularies/http#path": [
-{
-"@value": "/files/{fileId}/revisions"
-}
-],
-"http://www.w3.org/ns/hydra/core#supportedOperation": [
-{
-"@id": "amf://id#258",
-"@type": [
-"http://www.w3.org/ns/hydra/core#Operation",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://www.w3.org/ns/hydra/core#method": [
-{
-"@value": "get"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "amf://id#258/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#258"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(193,6)-(194,0)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"http://a.ml/vocabularies/http#parameter": [
+"http://a.ml/vocabularies/apiContract#parameter": [
 {
 "@id": "amf://id#259",
 "@type": [
-"http://a.ml/vocabularies/http#Parameter",
+"http://a.ml/vocabularies/apiContract#Parameter",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://schema.org/name": [
+"http://a.ml/vocabularies/core#name": [
 {
 "@value": "fileId"
 }
 ],
-"http://a.ml/vocabularies/http#paramName": [
+"http://a.ml/vocabularies/apiContract#paramName": [
 {
 "@value": "fileId"
 }
 ],
-"http://www.w3.org/ns/hydra/core#required": [
+"http://a.ml/vocabularies/apiContract#required": [
 {
 "@value": true
 }
 ],
-"http://a.ml/vocabularies/http#binding": [
+"http://a.ml/vocabularies/apiContract#binding": [
 {
 "@value": "path"
 }
 ],
-"http://a.ml/vocabularies/http#schema": [
+"http://a.ml/vocabularies/apiContract#schema": [
 {
 "@id": "amf://id#260",
 "@type": [
@@ -3133,7 +2433,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#257/source-map",
+"@id": "amf://id#256/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -3141,7 +2441,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#257"
+"@value": "amf://id#256"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -3155,12 +2455,12 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#257"
+"@value": "amf://id#256"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
 {
-"@value": "[(192,4)-(208,0)]"
+"@value": "[(160,4)-(192,0)]"
 }
 ]
 }
@@ -3171,24 +2471,29 @@
 {
 "@id": "amf://id#261",
 "@type": [
-"http://a.ml/vocabularies/http#EndPoint",
+"http://a.ml/vocabularies/apiContract#EndPoint",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://a.ml/vocabularies/http#path": [
+"http://a.ml/vocabularies/apiContract#path": [
 {
-"@value": "/files/{fileId}/revisions/{revisionId}"
+"@value": "/files/{fileId}/permissions/{permissionId}"
 }
 ],
-"http://www.w3.org/ns/hydra/core#supportedOperation": [
+"http://a.ml/vocabularies/apiContract#supportedOperation": [
 {
 "@id": "amf://id#262",
 "@type": [
-"http://www.w3.org/ns/hydra/core#Operation",
+"http://a.ml/vocabularies/apiContract#Operation",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://www.w3.org/ns/hydra/core#method": [
+"http://a.ml/vocabularies/apiContract#method": [
 {
 "@value": "get"
+}
+],
+"http://a.ml/vocabularies/core#description": [
+{
+"@value": "Gets a permission by ID."
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
@@ -3201,12 +2506,24 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
+"@value": "http://a.ml/vocabularies/core#description"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(174,10)-(175,0)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
 "@value": "amf://id#262"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
 {
-"@value": "[(200,8)-(202,0)]"
+"@value": "[(173,8)-(175,0)]"
 }
 ]
 }
@@ -3217,12 +2534,17 @@
 {
 "@id": "amf://id#263",
 "@type": [
-"http://www.w3.org/ns/hydra/core#Operation",
+"http://a.ml/vocabularies/apiContract#Operation",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://www.w3.org/ns/hydra/core#method": [
+"http://a.ml/vocabularies/apiContract#method": [
 {
 "@value": "put"
+}
+],
+"http://a.ml/vocabularies/core#description": [
+{
+"@value": "Updates a permission.\n\n**Warning**: Concurrent permissions operations on the same file are not supported; only the last update is applied.\n"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
@@ -3235,12 +2557,24 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
+"@value": "http://a.ml/vocabularies/core#description"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(176,10)-(180,0)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
 "@value": "amf://id#263"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
 {
-"@value": "[(202,8)-(204,0)]"
+"@value": "[(175,8)-(180,0)]"
 }
 ]
 }
@@ -3251,48 +2585,37 @@
 {
 "@id": "amf://id#264",
 "@type": [
-"http://www.w3.org/ns/hydra/core#Operation",
+"http://a.ml/vocabularies/apiContract#Operation",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://www.w3.org/ns/hydra/core#method": [
+"http://a.ml/vocabularies/apiContract#method": [
 {
 "@value": "delete"
 }
 ],
-"http://a.ml/vocabularies/document-source-maps#sources": [
+"http://a.ml/vocabularies/core#description": [
 {
-"@id": "amf://id#264/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#264"
+"@value": "Deletes a permission from a file.\n\nWarning: Concurrent permissions operations on the same file are not supported; only the last update is applied.\n"
 }
 ],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(204,8)-(206,0)]"
-}
-]
-}
-]
-}
-]
-},
+"http://a.ml/vocabularies/apiContract#returns": [
 {
 "@id": "amf://id#265",
 "@type": [
-"http://www.w3.org/ns/hydra/core#Operation",
+"http://a.ml/vocabularies/apiContract#Response",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://www.w3.org/ns/hydra/core#method": [
+"http://a.ml/vocabularies/core#name": [
 {
-"@value": "patch"
+"@value": "204"
 }
 ],
+"http://a.ml/vocabularies/apiContract#statusCode": [
+{
+"@value": "204"
+}
+],
+"http://a.ml/vocabularies/apiContract#payload": [],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
 "@id": "amf://id#265/source-map",
@@ -3308,7 +2631,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
 {
-"@value": "[(206,8)-(208,0)]"
+"@value": "[(186,12)-(187,0)]"
 }
 ]
 }
@@ -3317,36 +2640,135 @@
 ]
 }
 ],
-"http://a.ml/vocabularies/http#parameter": [
+"http://a.ml/vocabularies/document-source-maps#sources": [
+{
+"@id": "amf://id#264/source-map",
+"@type": [
+"http://a.ml/vocabularies/document-source-maps#SourceMap"
+],
+"http://a.ml/vocabularies/document-source-maps#lexical": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/apiContract#returns"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(185,10)-(187,0)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#264"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(180,8)-(187,0)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/core#description"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(181,10)-(185,0)]"
+}
+]
+}
+]
+}
+]
+},
 {
 "@id": "amf://id#266",
 "@type": [
-"http://a.ml/vocabularies/http#Parameter",
+"http://a.ml/vocabularies/apiContract#Operation",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://schema.org/name": [
+"http://a.ml/vocabularies/apiContract#method": [
+{
+"@value": "patch"
+}
+],
+"http://a.ml/vocabularies/core#description": [
+{
+"@value": "Updates a permission. This method supports patch semantics.\n\n**Warning**: Concurrent permissions operations on the same file are not supported; only the last update is applied.\n"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#sources": [
+{
+"@id": "amf://id#266/source-map",
+"@type": [
+"http://a.ml/vocabularies/document-source-maps#SourceMap"
+],
+"http://a.ml/vocabularies/document-source-maps#lexical": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/core#description"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(188,10)-(192,0)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#266"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(187,8)-(192,0)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"http://a.ml/vocabularies/apiContract#parameter": [
+{
+"@id": "amf://id#267",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Parameter",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/core#name": [
 {
 "@value": "fileId"
 }
 ],
-"http://a.ml/vocabularies/http#paramName": [
+"http://a.ml/vocabularies/apiContract#paramName": [
 {
 "@value": "fileId"
 }
 ],
-"http://www.w3.org/ns/hydra/core#required": [
+"http://a.ml/vocabularies/apiContract#required": [
 {
 "@value": true
 }
 ],
-"http://a.ml/vocabularies/http#binding": [
+"http://a.ml/vocabularies/apiContract#binding": [
 {
 "@value": "path"
 }
 ],
-"http://a.ml/vocabularies/http#schema": [
+"http://a.ml/vocabularies/apiContract#schema": [
 {
-"@id": "amf://id#267",
+"@id": "amf://id#268",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -3367,7 +2789,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#266/source-map",
+"@id": "amf://id#267/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -3375,7 +2797,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#266"
+"@value": "amf://id#267"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -3389,39 +2811,39 @@
 ]
 },
 {
-"@id": "amf://id#268",
+"@id": "amf://id#269",
 "@type": [
-"http://a.ml/vocabularies/http#Parameter",
+"http://a.ml/vocabularies/apiContract#Parameter",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://schema.org/name": [
+"http://a.ml/vocabularies/core#name": [
 {
-"@value": "revisionId"
+"@value": "permissionId"
 }
 ],
-"http://a.ml/vocabularies/http#paramName": [
+"http://a.ml/vocabularies/apiContract#paramName": [
 {
-"@value": "revisionId"
+"@value": "permissionId"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
-"@value": "The ID of the revision."
+"@value": "The ID for the permission."
 }
 ],
-"http://www.w3.org/ns/hydra/core#required": [
+"http://a.ml/vocabularies/apiContract#required": [
 {
 "@value": true
 }
 ],
-"http://a.ml/vocabularies/http#binding": [
+"http://a.ml/vocabularies/apiContract#binding": [
 {
 "@value": "path"
 }
 ],
-"http://a.ml/vocabularies/http#schema": [
+"http://a.ml/vocabularies/apiContract#schema": [
 {
-"@id": "amf://id#269",
+"@id": "amf://id#270",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -3438,21 +2860,9 @@
 "@value": "schema"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
-"@value": "The ID of the revision."
-}
-],
-"http://www.w3.org/ns/shacl#defaultValue": [
-{
-"@id": "amf://id#270",
-"@type": [
-"http://a.ml/vocabularies/data#Scalar"
-],
-"http://a.ml/vocabularies/data#value": [
-{
-"@value": "defaultRevision",
-"@type": "http://www.w3.org/2001/XMLSchema#string"
+"@value": "The ID for the permission."
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
@@ -3461,7 +2871,7 @@
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
+"http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
@@ -3470,36 +2880,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
 {
-"@value": "[(199,21)-(199,36)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"http://www.w3.org/ns/shacl#defaultValueStr": [
-{
-"@value": "defaultRevision"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "amf://id#269/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#269"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(197,12)-(197,16)]"
+"@value": "[(171,12)-(171,16)]"
 }
 ]
 }
@@ -3508,12 +2889,24 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://www.w3.org/ns/shacl#defaultValueStr"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
 {
-"@value": "[(199,12)-(200,0)]"
+"@value": "[(172,12)-(173,0)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#270"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(170,10)-(173,0)]"
 }
 ]
 },
@@ -3525,7 +2918,31 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
 {
-"@value": "[(197,12)-(198,0)]"
+"@value": "[(171,12)-(172,0)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"http://a.ml/vocabularies/document-source-maps#sources": [
+{
+"@id": "amf://id#269/source-map",
+"@type": [
+"http://a.ml/vocabularies/document-source-maps#SourceMap"
+],
+"http://a.ml/vocabularies/document-source-maps#lexical": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/core#description"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(172,12)-(173,0)]"
 }
 ]
 },
@@ -3537,55 +2954,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
 {
-"@value": "[(196,10)-(200,0)]"
-}
-]
-},
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "http://schema.org/description"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(198,12)-(199,0)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "amf://id#268/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "http://schema.org/description"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(198,12)-(199,0)]"
-}
-]
-},
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#268"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(196,10)-(200,0)]"
+"@value": "[(170,10)-(173,0)]"
 }
 ]
 }
@@ -3609,7 +2978,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
 {
-"@value": "file://test/demo-api/demo-api.raml#/web-api/end-points/%2Ffiles%2F%7BfileId%7D%2Frevisions"
+"@value": "file://test/demo-api/demo-api.raml#/web-api/end-points/%2Ffiles%2F%7BfileId%7D%2Fpermissions"
 }
 ]
 }
@@ -3618,12 +2987,12 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://a.ml/vocabularies/http#parameter"
+"@value": "http://a.ml/vocabularies/apiContract#parameter"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
 {
-"@value": "[(195,22)-(200,0)]"
+"@value": "[(169,22)-(173,0)]"
 }
 ]
 },
@@ -3635,7 +3004,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
 {
-"@value": "[(194,6)-(208,0)]"
+"@value": "[(168,6)-(192,0)]"
 }
 ]
 }
@@ -3646,22 +3015,22 @@
 {
 "@id": "amf://id#271",
 "@type": [
-"http://a.ml/vocabularies/http#EndPoint",
+"http://a.ml/vocabularies/apiContract#EndPoint",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://a.ml/vocabularies/http#path": [
+"http://a.ml/vocabularies/apiContract#path": [
 {
-"@value": "/files/{fileId}/comments"
+"@value": "/files/{fileId}/revisions"
 }
 ],
-"http://www.w3.org/ns/hydra/core#supportedOperation": [
+"http://a.ml/vocabularies/apiContract#supportedOperation": [
 {
 "@id": "amf://id#272",
 "@type": [
-"http://www.w3.org/ns/hydra/core#Operation",
+"http://a.ml/vocabularies/apiContract#Operation",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://www.w3.org/ns/hydra/core#method": [
+"http://a.ml/vocabularies/apiContract#method": [
 {
 "@value": "get"
 }
@@ -3681,96 +3050,45 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
 {
-"@value": "[(209,6)-(211,0)]"
+"@value": "[(193,6)-(194,0)]"
 }
 ]
 }
 ]
 }
 ]
-},
+}
+],
+"http://a.ml/vocabularies/apiContract#parameter": [
 {
 "@id": "amf://id#273",
 "@type": [
-"http://www.w3.org/ns/hydra/core#Operation",
+"http://a.ml/vocabularies/apiContract#Parameter",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://www.w3.org/ns/hydra/core#method": [
-{
-"@value": "post"
-}
-],
-"http://schema.org/description": [
-{
-"@value": "Creates a new comment on the given file."
-}
-],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "amf://id#273/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "http://schema.org/description"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(212,8)-(213,0)]"
-}
-]
-},
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#273"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(211,6)-(213,0)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"http://a.ml/vocabularies/http#parameter": [
-{
-"@id": "amf://id#274",
-"@type": [
-"http://a.ml/vocabularies/http#Parameter",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://schema.org/name": [
+"http://a.ml/vocabularies/core#name": [
 {
 "@value": "fileId"
 }
 ],
-"http://a.ml/vocabularies/http#paramName": [
+"http://a.ml/vocabularies/apiContract#paramName": [
 {
 "@value": "fileId"
 }
 ],
-"http://www.w3.org/ns/hydra/core#required": [
+"http://a.ml/vocabularies/apiContract#required": [
 {
 "@value": true
 }
 ],
-"http://a.ml/vocabularies/http#binding": [
+"http://a.ml/vocabularies/apiContract#binding": [
 {
 "@value": "path"
 }
 ],
-"http://a.ml/vocabularies/http#schema": [
+"http://a.ml/vocabularies/apiContract#schema": [
 {
-"@id": "amf://id#275",
+"@id": "amf://id#274",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -3791,7 +3109,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#274/source-map",
+"@id": "amf://id#273/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -3799,7 +3117,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#274"
+"@value": "amf://id#273"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -3842,7 +3160,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
 {
-"@value": "[(208,4)-(250,0)]"
+"@value": "[(192,4)-(208,0)]"
 }
 ]
 }
@@ -3851,31 +3169,60 @@
 ]
 },
 {
-"@id": "amf://id#276",
+"@id": "amf://id#275",
 "@type": [
-"http://a.ml/vocabularies/http#EndPoint",
+"http://a.ml/vocabularies/apiContract#EndPoint",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://a.ml/vocabularies/http#path": [
+"http://a.ml/vocabularies/apiContract#path": [
 {
-"@value": "/files/{fileId}/comments/{commentId}"
+"@value": "/files/{fileId}/revisions/{revisionId}"
 }
 ],
-"http://www.w3.org/ns/hydra/core#supportedOperation": [
+"http://a.ml/vocabularies/apiContract#supportedOperation": [
 {
-"@id": "amf://id#277",
+"@id": "amf://id#276",
 "@type": [
-"http://www.w3.org/ns/hydra/core#Operation",
+"http://a.ml/vocabularies/apiContract#Operation",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://www.w3.org/ns/hydra/core#method": [
+"http://a.ml/vocabularies/apiContract#method": [
 {
 "@value": "get"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@value": "Gets a comment by ID."
+"@id": "amf://id#276/source-map",
+"@type": [
+"http://a.ml/vocabularies/document-source-maps#SourceMap"
+],
+"http://a.ml/vocabularies/document-source-maps#lexical": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#276"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(200,8)-(202,0)]"
+}
+]
+}
+]
+}
+]
+},
+{
+"@id": "amf://id#277",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Operation",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/apiContract#method": [
+{
+"@value": "put"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
@@ -3888,24 +3235,12 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(219,10)-(221,0)]"
-}
-]
-},
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
 "@value": "amf://id#277"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
 {
-"@value": "[(218,8)-(221,0)]"
+"@value": "[(202,8)-(204,0)]"
 }
 ]
 }
@@ -3916,12 +3251,12 @@
 {
 "@id": "amf://id#278",
 "@type": [
-"http://www.w3.org/ns/hydra/core#Operation",
+"http://a.ml/vocabularies/apiContract#Operation",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://www.w3.org/ns/hydra/core#method": [
+"http://a.ml/vocabularies/apiContract#method": [
 {
-"@value": "put"
+"@value": "delete"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
@@ -3939,7 +3274,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
 {
-"@value": "[(221,8)-(223,0)]"
+"@value": "[(204,8)-(206,0)]"
 }
 ]
 }
@@ -3950,17 +3285,12 @@
 {
 "@id": "amf://id#279",
 "@type": [
-"http://www.w3.org/ns/hydra/core#Operation",
+"http://a.ml/vocabularies/apiContract#Operation",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://www.w3.org/ns/hydra/core#method": [
+"http://a.ml/vocabularies/apiContract#method": [
 {
-"@value": "delete"
-}
-],
-"http://schema.org/description": [
-{
-"@value": "Deletes a comment."
+"@value": "patch"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
@@ -3973,7 +3303,679 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "amf://id#279"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(206,8)-(208,0)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"http://a.ml/vocabularies/apiContract#parameter": [
+{
+"@id": "amf://id#280",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Parameter",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/core#name": [
+{
+"@value": "fileId"
+}
+],
+"http://a.ml/vocabularies/apiContract#paramName": [
+{
+"@value": "fileId"
+}
+],
+"http://a.ml/vocabularies/apiContract#required": [
+{
+"@value": true
+}
+],
+"http://a.ml/vocabularies/apiContract#binding": [
+{
+"@value": "path"
+}
+],
+"http://a.ml/vocabularies/apiContract#schema": [
+{
+"@id": "amf://id#281",
+"@type": [
+"http://a.ml/vocabularies/shapes#ScalarShape",
+"http://www.w3.org/ns/shacl#Shape",
+"http://a.ml/vocabularies/shapes#Shape",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://www.w3.org/ns/shacl#datatype": [
+{
+"@id": "http://www.w3.org/2001/XMLSchema#string"
+}
+],
+"http://www.w3.org/ns/shacl#name": [
+{
+"@value": "fileId"
+}
+]
+}
+],
+"http://a.ml/vocabularies/document-source-maps#sources": [
+{
+"@id": "amf://id#280/source-map",
+"@type": [
+"http://a.ml/vocabularies/document-source-maps#SourceMap"
+],
+"http://a.ml/vocabularies/document-source-maps#synthesized-field": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#280"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "true"
+}
+]
+}
+]
+}
+]
+},
+{
+"@id": "amf://id#282",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Parameter",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/core#name": [
+{
+"@value": "revisionId"
+}
+],
+"http://a.ml/vocabularies/apiContract#paramName": [
+{
+"@value": "revisionId"
+}
+],
+"http://a.ml/vocabularies/core#description": [
+{
+"@value": "The ID of the revision."
+}
+],
+"http://a.ml/vocabularies/apiContract#required": [
+{
+"@value": true
+}
+],
+"http://a.ml/vocabularies/apiContract#binding": [
+{
+"@value": "path"
+}
+],
+"http://a.ml/vocabularies/apiContract#schema": [
+{
+"@id": "amf://id#283",
+"@type": [
+"http://a.ml/vocabularies/shapes#ScalarShape",
+"http://www.w3.org/ns/shacl#Shape",
+"http://a.ml/vocabularies/shapes#Shape",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://www.w3.org/ns/shacl#datatype": [
+{
+"@id": "http://www.w3.org/2001/XMLSchema#string"
+}
+],
+"http://www.w3.org/ns/shacl#name": [
+{
+"@value": "schema"
+}
+],
+"http://a.ml/vocabularies/core#description": [
+{
+"@value": "The ID of the revision."
+}
+],
+"http://www.w3.org/ns/shacl#defaultValue": [
+{
+"@id": "amf://id#284",
+"@type": [
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/data#value": [
+{
+"@value": "defaultRevision",
+"@type": "http://www.w3.org/2001/XMLSchema#string"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#sources": [
+{
+"@id": "amf://id#284/source-map",
+"@type": [
+"http://a.ml/vocabularies/document-source-maps#SourceMap"
+],
+"http://a.ml/vocabularies/document-source-maps#lexical": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#284"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(199,21)-(199,36)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"http://www.w3.org/ns/shacl#defaultValueStr": [
+{
+"@value": "defaultRevision"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#sources": [
+{
+"@id": "amf://id#283/source-map",
+"@type": [
+"http://a.ml/vocabularies/document-source-maps#SourceMap"
+],
+"http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#283"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(197,12)-(197,16)]"
+}
+]
+}
+],
+"http://a.ml/vocabularies/document-source-maps#lexical": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://www.w3.org/ns/shacl#defaultValueStr"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(199,12)-(200,0)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://www.w3.org/ns/shacl#datatype"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(197,12)-(198,0)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#283"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(196,10)-(200,0)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/core#description"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(198,12)-(199,0)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"http://a.ml/vocabularies/document-source-maps#sources": [
+{
+"@id": "amf://id#282/source-map",
+"@type": [
+"http://a.ml/vocabularies/document-source-maps#SourceMap"
+],
+"http://a.ml/vocabularies/document-source-maps#lexical": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/core#description"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(198,12)-(199,0)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#282"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(196,10)-(200,0)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"http://a.ml/vocabularies/document-source-maps#sources": [
+{
+"@id": "amf://id#275/source-map",
+"@type": [
+"http://a.ml/vocabularies/document-source-maps#SourceMap"
+],
+"http://a.ml/vocabularies/document-source-maps#parent-end-point": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#275"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "file://test/demo-api/demo-api.raml#/web-api/end-points/%2Ffiles%2F%7BfileId%7D%2Frevisions"
+}
+]
+}
+],
+"http://a.ml/vocabularies/document-source-maps#lexical": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/apiContract#parameter"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(195,22)-(200,0)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#275"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(194,6)-(208,0)]"
+}
+]
+}
+]
+}
+]
+},
+{
+"@id": "amf://id#285",
+"@type": [
+"http://a.ml/vocabularies/apiContract#EndPoint",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/apiContract#path": [
+{
+"@value": "/files/{fileId}/comments"
+}
+],
+"http://a.ml/vocabularies/apiContract#supportedOperation": [
+{
+"@id": "amf://id#286",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Operation",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/apiContract#method": [
+{
+"@value": "get"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#sources": [
+{
+"@id": "amf://id#286/source-map",
+"@type": [
+"http://a.ml/vocabularies/document-source-maps#SourceMap"
+],
+"http://a.ml/vocabularies/document-source-maps#lexical": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#286"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(209,6)-(211,0)]"
+}
+]
+}
+]
+}
+]
+},
+{
+"@id": "amf://id#287",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Operation",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/apiContract#method": [
+{
+"@value": "post"
+}
+],
+"http://a.ml/vocabularies/core#description": [
+{
+"@value": "Creates a new comment on the given file."
+}
+],
+"http://a.ml/vocabularies/document-source-maps#sources": [
+{
+"@id": "amf://id#287/source-map",
+"@type": [
+"http://a.ml/vocabularies/document-source-maps#SourceMap"
+],
+"http://a.ml/vocabularies/document-source-maps#lexical": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/core#description"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(212,8)-(213,0)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#287"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(211,6)-(213,0)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"http://a.ml/vocabularies/apiContract#parameter": [
+{
+"@id": "amf://id#288",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Parameter",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/core#name": [
+{
+"@value": "fileId"
+}
+],
+"http://a.ml/vocabularies/apiContract#paramName": [
+{
+"@value": "fileId"
+}
+],
+"http://a.ml/vocabularies/apiContract#required": [
+{
+"@value": true
+}
+],
+"http://a.ml/vocabularies/apiContract#binding": [
+{
+"@value": "path"
+}
+],
+"http://a.ml/vocabularies/apiContract#schema": [
+{
+"@id": "amf://id#289",
+"@type": [
+"http://a.ml/vocabularies/shapes#ScalarShape",
+"http://www.w3.org/ns/shacl#Shape",
+"http://a.ml/vocabularies/shapes#Shape",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://www.w3.org/ns/shacl#datatype": [
+{
+"@id": "http://www.w3.org/2001/XMLSchema#string"
+}
+],
+"http://www.w3.org/ns/shacl#name": [
+{
+"@value": "fileId"
+}
+]
+}
+],
+"http://a.ml/vocabularies/document-source-maps#sources": [
+{
+"@id": "amf://id#288/source-map",
+"@type": [
+"http://a.ml/vocabularies/document-source-maps#SourceMap"
+],
+"http://a.ml/vocabularies/document-source-maps#synthesized-field": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#288"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "true"
+}
+]
+}
+]
+}
+]
+}
+],
+"http://a.ml/vocabularies/document-source-maps#sources": [
+{
+"@id": "amf://id#285/source-map",
+"@type": [
+"http://a.ml/vocabularies/document-source-maps#SourceMap"
+],
+"http://a.ml/vocabularies/document-source-maps#parent-end-point": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#285"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "file://test/demo-api/demo-api.raml#/web-api/end-points/%2Ffiles%2F%7BfileId%7D"
+}
+]
+}
+],
+"http://a.ml/vocabularies/document-source-maps#lexical": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#285"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(208,4)-(250,0)]"
+}
+]
+}
+]
+}
+]
+},
+{
+"@id": "amf://id#290",
+"@type": [
+"http://a.ml/vocabularies/apiContract#EndPoint",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/apiContract#path": [
+{
+"@value": "/files/{fileId}/comments/{commentId}"
+}
+],
+"http://a.ml/vocabularies/apiContract#supportedOperation": [
+{
+"@id": "amf://id#291",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Operation",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/apiContract#method": [
+{
+"@value": "get"
+}
+],
+"http://a.ml/vocabularies/core#description": [
+{
+"@value": "Gets a comment by ID."
+}
+],
+"http://a.ml/vocabularies/document-source-maps#sources": [
+{
+"@id": "amf://id#291/source-map",
+"@type": [
+"http://a.ml/vocabularies/document-source-maps#SourceMap"
+],
+"http://a.ml/vocabularies/document-source-maps#lexical": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/core#description"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(219,10)-(221,0)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#291"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(218,8)-(221,0)]"
+}
+]
+}
+]
+}
+]
+},
+{
+"@id": "amf://id#292",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Operation",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/apiContract#method": [
+{
+"@value": "put"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#sources": [
+{
+"@id": "amf://id#292/source-map",
+"@type": [
+"http://a.ml/vocabularies/document-source-maps#SourceMap"
+],
+"http://a.ml/vocabularies/document-source-maps#lexical": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#292"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(221,8)-(223,0)]"
+}
+]
+}
+]
+}
+]
+},
+{
+"@id": "amf://id#293",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Operation",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/apiContract#method": [
+{
+"@value": "delete"
+}
+],
+"http://a.ml/vocabularies/core#description": [
+{
+"@value": "Deletes a comment."
+}
+],
+"http://a.ml/vocabularies/document-source-maps#sources": [
+{
+"@id": "amf://id#293/source-map",
+"@type": [
+"http://a.ml/vocabularies/document-source-maps#SourceMap"
+],
+"http://a.ml/vocabularies/document-source-maps#lexical": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -3985,7 +3987,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#279"
+"@value": "amf://id#293"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -3999,19 +4001,19 @@
 ]
 },
 {
-"@id": "amf://id#280",
+"@id": "amf://id#294",
 "@type": [
-"http://www.w3.org/ns/hydra/core#Operation",
+"http://a.ml/vocabularies/apiContract#Operation",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://www.w3.org/ns/hydra/core#method": [
+"http://a.ml/vocabularies/apiContract#method": [
 {
 "@value": "patch"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#280/source-map",
+"@id": "amf://id#294/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -4019,7 +4021,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#280"
+"@value": "amf://id#294"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -4033,36 +4035,36 @@
 ]
 }
 ],
-"http://a.ml/vocabularies/http#parameter": [
+"http://a.ml/vocabularies/apiContract#parameter": [
 {
-"@id": "amf://id#281",
+"@id": "amf://id#295",
 "@type": [
-"http://a.ml/vocabularies/http#Parameter",
+"http://a.ml/vocabularies/apiContract#Parameter",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://schema.org/name": [
+"http://a.ml/vocabularies/core#name": [
 {
 "@value": "fileId"
 }
 ],
-"http://a.ml/vocabularies/http#paramName": [
+"http://a.ml/vocabularies/apiContract#paramName": [
 {
 "@value": "fileId"
 }
 ],
-"http://www.w3.org/ns/hydra/core#required": [
+"http://a.ml/vocabularies/apiContract#required": [
 {
 "@value": true
 }
 ],
-"http://a.ml/vocabularies/http#binding": [
+"http://a.ml/vocabularies/apiContract#binding": [
 {
 "@value": "path"
 }
 ],
-"http://a.ml/vocabularies/http#schema": [
+"http://a.ml/vocabularies/apiContract#schema": [
 {
-"@id": "amf://id#282",
+"@id": "amf://id#296",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -4083,7 +4085,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#281/source-map",
+"@id": "amf://id#295/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -4091,7 +4093,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#281"
+"@value": "amf://id#295"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -4105,34 +4107,34 @@
 ]
 },
 {
-"@id": "amf://id#283",
+"@id": "amf://id#297",
 "@type": [
-"http://a.ml/vocabularies/http#Parameter",
+"http://a.ml/vocabularies/apiContract#Parameter",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://schema.org/name": [
+"http://a.ml/vocabularies/core#name": [
 {
 "@value": "commentId"
 }
 ],
-"http://a.ml/vocabularies/http#paramName": [
+"http://a.ml/vocabularies/apiContract#paramName": [
 {
 "@value": "commentId"
 }
 ],
-"http://www.w3.org/ns/hydra/core#required": [
+"http://a.ml/vocabularies/apiContract#required": [
 {
 "@value": true
 }
 ],
-"http://a.ml/vocabularies/http#binding": [
+"http://a.ml/vocabularies/apiContract#binding": [
 {
 "@value": "path"
 }
 ],
-"http://a.ml/vocabularies/http#schema": [
+"http://a.ml/vocabularies/apiContract#schema": [
 {
-"@id": "amf://id#284",
+"@id": "amf://id#298",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -4149,11 +4151,18 @@
 "@value": "schema"
 }
 ],
-"http://a.ml/vocabularies/document#examples": [
+"http://a.ml/vocabularies/apiContract#examples": [
 {
-"@id": "amf://id#285",
+"@id": "amf://id#299",
 "@type": [
-"http://a.ml/vocabularies/document#Example",
+"http://a.ml/vocabularies/apiContract#NamedExamples",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/apiContract#examples": [
+{
+"@id": "amf://id#300",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Example",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/document#strict": [
@@ -4163,9 +4172,11 @@
 ],
 "http://a.ml/vocabularies/document#structuredValue": [
 {
-"@id": "amf://id#285",
+"@id": "amf://id#300",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -4175,7 +4186,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#285/source-map",
+"@id": "amf://id#300/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -4183,7 +4194,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#285"
+"@value": "amf://id#300"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -4204,7 +4215,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#285/source-map",
+"@id": "amf://id#300/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -4238,7 +4249,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#285"
+"@value": "amf://id#300"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -4252,12 +4263,14 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#285"
+"@value": "amf://id#300"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
 {
-"@value": "amf://id#283"
+"@value": "amf://id#297"
+}
+]
 }
 ]
 }
@@ -4268,7 +4281,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#284/source-map",
+"@id": "amf://id#298/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -4276,7 +4289,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#284"
+"@value": "amf://id#298"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -4302,7 +4315,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#284"
+"@value": "amf://id#298"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -4318,7 +4331,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#283/source-map",
+"@id": "amf://id#297/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -4326,7 +4339,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#283"
+"@value": "amf://id#297"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -4342,7 +4355,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#276/source-map",
+"@id": "amf://id#290/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -4350,7 +4363,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#276"
+"@value": "amf://id#290"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -4364,7 +4377,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://a.ml/vocabularies/http#parameter"
+"@value": "http://a.ml/vocabularies/apiContract#parameter"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -4376,7 +4389,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#276"
+"@value": "amf://id#290"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -4390,31 +4403,31 @@
 ]
 },
 {
-"@id": "amf://id#286",
+"@id": "amf://id#301",
 "@type": [
-"http://a.ml/vocabularies/http#EndPoint",
+"http://a.ml/vocabularies/apiContract#EndPoint",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://a.ml/vocabularies/http#path": [
+"http://a.ml/vocabularies/apiContract#path": [
 {
 "@value": "/files/{fileId}/comments/{commentId}/replies"
 }
 ],
-"http://www.w3.org/ns/hydra/core#supportedOperation": [
+"http://a.ml/vocabularies/apiContract#supportedOperation": [
 {
-"@id": "amf://id#287",
+"@id": "amf://id#302",
 "@type": [
-"http://www.w3.org/ns/hydra/core#Operation",
+"http://a.ml/vocabularies/apiContract#Operation",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://www.w3.org/ns/hydra/core#method": [
+"http://a.ml/vocabularies/apiContract#method": [
 {
 "@value": "get"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#287/source-map",
+"@id": "amf://id#302/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -4422,7 +4435,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#287"
+"@value": "amf://id#302"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -4436,19 +4449,19 @@
 ]
 },
 {
-"@id": "amf://id#288",
+"@id": "amf://id#303",
 "@type": [
-"http://www.w3.org/ns/hydra/core#Operation",
+"http://a.ml/vocabularies/apiContract#Operation",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://www.w3.org/ns/hydra/core#method": [
+"http://a.ml/vocabularies/apiContract#method": [
 {
 "@value": "post"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#288/source-map",
+"@id": "amf://id#303/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -4456,7 +4469,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#288"
+"@value": "amf://id#303"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -4470,36 +4483,36 @@
 ]
 }
 ],
-"http://a.ml/vocabularies/http#parameter": [
+"http://a.ml/vocabularies/apiContract#parameter": [
 {
-"@id": "amf://id#289",
+"@id": "amf://id#304",
 "@type": [
-"http://a.ml/vocabularies/http#Parameter",
+"http://a.ml/vocabularies/apiContract#Parameter",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://schema.org/name": [
+"http://a.ml/vocabularies/core#name": [
 {
 "@value": "fileId"
 }
 ],
-"http://a.ml/vocabularies/http#paramName": [
+"http://a.ml/vocabularies/apiContract#paramName": [
 {
 "@value": "fileId"
 }
 ],
-"http://www.w3.org/ns/hydra/core#required": [
+"http://a.ml/vocabularies/apiContract#required": [
 {
 "@value": true
 }
 ],
-"http://a.ml/vocabularies/http#binding": [
+"http://a.ml/vocabularies/apiContract#binding": [
 {
 "@value": "path"
 }
 ],
-"http://a.ml/vocabularies/http#schema": [
+"http://a.ml/vocabularies/apiContract#schema": [
 {
-"@id": "amf://id#290",
+"@id": "amf://id#305",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -4520,7 +4533,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#289/source-map",
+"@id": "amf://id#304/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -4528,7 +4541,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#289"
+"@value": "amf://id#304"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -4542,34 +4555,34 @@
 ]
 },
 {
-"@id": "amf://id#291",
+"@id": "amf://id#306",
 "@type": [
-"http://a.ml/vocabularies/http#Parameter",
+"http://a.ml/vocabularies/apiContract#Parameter",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://schema.org/name": [
+"http://a.ml/vocabularies/core#name": [
 {
 "@value": "commentId"
 }
 ],
-"http://a.ml/vocabularies/http#paramName": [
+"http://a.ml/vocabularies/apiContract#paramName": [
 {
 "@value": "commentId"
 }
 ],
-"http://www.w3.org/ns/hydra/core#required": [
+"http://a.ml/vocabularies/apiContract#required": [
 {
 "@value": true
 }
 ],
-"http://a.ml/vocabularies/http#binding": [
+"http://a.ml/vocabularies/apiContract#binding": [
 {
 "@value": "path"
 }
 ],
-"http://a.ml/vocabularies/http#schema": [
+"http://a.ml/vocabularies/apiContract#schema": [
 {
-"@id": "amf://id#292",
+"@id": "amf://id#307",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -4586,11 +4599,18 @@
 "@value": "schema"
 }
 ],
-"http://a.ml/vocabularies/document#examples": [
+"http://a.ml/vocabularies/apiContract#examples": [
 {
-"@id": "amf://id#285",
+"@id": "amf://id#299",
 "@type": [
-"http://a.ml/vocabularies/document#Example",
+"http://a.ml/vocabularies/apiContract#NamedExamples",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/apiContract#examples": [
+{
+"@id": "amf://id#300",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Example",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/document#strict": [
@@ -4600,9 +4620,11 @@
 ],
 "http://a.ml/vocabularies/document#structuredValue": [
 {
-"@id": "amf://id#285",
+"@id": "amf://id#300",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -4612,7 +4634,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#285/source-map",
+"@id": "amf://id#300/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -4620,7 +4642,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#285"
+"@value": "amf://id#300"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -4641,7 +4663,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#285/source-map",
+"@id": "amf://id#300/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -4675,7 +4697,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#285"
+"@value": "amf://id#300"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -4689,12 +4711,14 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#285"
+"@value": "amf://id#300"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
 {
-"@value": "amf://id#283"
+"@value": "amf://id#297"
+}
+]
 }
 ]
 }
@@ -4705,7 +4729,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#292/source-map",
+"@id": "amf://id#307/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -4713,7 +4737,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#292"
+"@value": "amf://id#307"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -4739,7 +4763,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#292"
+"@value": "amf://id#307"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -4755,7 +4779,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#291/source-map",
+"@id": "amf://id#306/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -4763,7 +4787,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#291"
+"@value": "amf://id#306"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -4777,499 +4801,12 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#291"
+"@value": "amf://id#306"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
 {
 "@value": "[(215,10)-(218,0)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "amf://id#286/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#parent-end-point": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#286"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "file://test/demo-api/demo-api.raml#/web-api/end-points/%2Ffiles%2F%7BfileId%7D%2Fcomments%2F%7BcommentId%7D"
-}
-]
-}
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#286"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(228,8)-(250,0)]"
-}
-]
-}
-]
-}
-]
-},
-{
-"@id": "amf://id#293",
-"@type": [
-"http://a.ml/vocabularies/http#EndPoint",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://a.ml/vocabularies/http#path": [
-{
-"@value": "/files/{fileId}/comments/{commentId}/replies/{replyId}"
-}
-],
-"http://www.w3.org/ns/hydra/core#supportedOperation": [
-{
-"@id": "amf://id#294",
-"@type": [
-"http://www.w3.org/ns/hydra/core#Operation",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://www.w3.org/ns/hydra/core#method": [
-{
-"@value": "get"
-}
-],
-"http://schema.org/description": [
-{
-"@value": "Gets a reply."
-}
-],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "amf://id#294/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "http://schema.org/description"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(239,14)-(241,0)]"
-}
-]
-},
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#294"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(238,12)-(241,0)]"
-}
-]
-}
-]
-}
-]
-},
-{
-"@id": "amf://id#295",
-"@type": [
-"http://www.w3.org/ns/hydra/core#Operation",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://www.w3.org/ns/hydra/core#method": [
-{
-"@value": "put"
-}
-],
-"http://schema.org/description": [
-{
-"@value": "Updates an existing reply."
-}
-],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "amf://id#295/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "http://schema.org/description"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(242,14)-(244,0)]"
-}
-]
-},
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#295"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(241,12)-(244,0)]"
-}
-]
-}
-]
-}
-]
-},
-{
-"@id": "amf://id#296",
-"@type": [
-"http://www.w3.org/ns/hydra/core#Operation",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://www.w3.org/ns/hydra/core#method": [
-{
-"@value": "delete"
-}
-],
-"http://schema.org/description": [
-{
-"@value": "Deletes a reply."
-}
-],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "amf://id#296/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "http://schema.org/description"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(245,14)-(247,0)]"
-}
-]
-},
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#296"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(244,12)-(247,0)]"
-}
-]
-}
-]
-}
-]
-},
-{
-"@id": "amf://id#297",
-"@type": [
-"http://www.w3.org/ns/hydra/core#Operation",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://www.w3.org/ns/hydra/core#method": [
-{
-"@value": "patch"
-}
-],
-"http://schema.org/description": [
-{
-"@value": "Updates an existing reply. This method supports patch semantics."
-}
-],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "amf://id#297/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "http://schema.org/description"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(248,14)-(250,0)]"
-}
-]
-},
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#297"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(247,12)-(250,0)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"http://a.ml/vocabularies/http#parameter": [
-{
-"@id": "amf://id#298",
-"@type": [
-"http://a.ml/vocabularies/http#Parameter",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://schema.org/name": [
-{
-"@value": "fileId"
-}
-],
-"http://a.ml/vocabularies/http#paramName": [
-{
-"@value": "fileId"
-}
-],
-"http://www.w3.org/ns/hydra/core#required": [
-{
-"@value": true
-}
-],
-"http://a.ml/vocabularies/http#binding": [
-{
-"@value": "path"
-}
-],
-"http://a.ml/vocabularies/http#schema": [
-{
-"@id": "amf://id#299",
-"@type": [
-"http://a.ml/vocabularies/shapes#ScalarShape",
-"http://www.w3.org/ns/shacl#Shape",
-"http://a.ml/vocabularies/shapes#Shape",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://www.w3.org/ns/shacl#datatype": [
-{
-"@id": "http://www.w3.org/2001/XMLSchema#string"
-}
-],
-"http://www.w3.org/ns/shacl#name": [
-{
-"@value": "fileId"
-}
-]
-}
-],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "amf://id#298/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#synthesized-field": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#298"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "true"
-}
-]
-}
-]
-}
-]
-},
-{
-"@id": "amf://id#300",
-"@type": [
-"http://a.ml/vocabularies/http#Parameter",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://schema.org/name": [
-{
-"@value": "commentId"
-}
-],
-"http://a.ml/vocabularies/http#paramName": [
-{
-"@value": "commentId"
-}
-],
-"http://www.w3.org/ns/hydra/core#required": [
-{
-"@value": true
-}
-],
-"http://a.ml/vocabularies/http#binding": [
-{
-"@value": "path"
-}
-],
-"http://a.ml/vocabularies/http#schema": [
-{
-"@id": "amf://id#301",
-"@type": [
-"http://a.ml/vocabularies/shapes#ScalarShape",
-"http://www.w3.org/ns/shacl#Shape",
-"http://a.ml/vocabularies/shapes#Shape",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://www.w3.org/ns/shacl#datatype": [
-{
-"@id": "http://www.w3.org/2001/XMLSchema#string"
-}
-],
-"http://www.w3.org/ns/shacl#name": [
-{
-"@value": "schema"
-}
-],
-"http://a.ml/vocabularies/document#examples": [
-{
-"@id": "amf://id#285",
-"@type": [
-"http://a.ml/vocabularies/document#Example",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://a.ml/vocabularies/document#strict": [
-{
-"@value": true
-}
-],
-"http://a.ml/vocabularies/document#structuredValue": [
-{
-"@id": "amf://id#285",
-"@type": [
-"http://a.ml/vocabularies/data#Scalar"
-],
-"http://a.ml/vocabularies/data#value": [
-{
-"@value": "commant-id",
-"@type": "http://www.w3.org/2001/XMLSchema#string"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "amf://id#285/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#285"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(217,21)-(217,31)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"http://www.w3.org/ns/shacl#raw": [
-{
-"@value": "commant-id"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "amf://id#285/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#synthesized-field": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "http://a.ml/vocabularies/document#strict"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "true"
-}
-]
-}
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "http://www.w3.org/ns/shacl#raw"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(217,21)-(217,31)]"
-}
-]
-},
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#285"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(217,21)-(217,31)]"
-}
-]
-}
-],
-"http://a.ml/vocabularies/document-source-maps#tracked-element": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#285"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "amf://id#283"
 }
 ]
 }
@@ -5284,11 +4821,509 @@
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
-"http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
+"http://a.ml/vocabularies/document-source-maps#parent-end-point": [
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
 "@value": "amf://id#301"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "file://test/demo-api/demo-api.raml#/web-api/end-points/%2Ffiles%2F%7BfileId%7D%2Fcomments%2F%7BcommentId%7D"
+}
+]
+}
+],
+"http://a.ml/vocabularies/document-source-maps#lexical": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#301"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(228,8)-(250,0)]"
+}
+]
+}
+]
+}
+]
+},
+{
+"@id": "amf://id#308",
+"@type": [
+"http://a.ml/vocabularies/apiContract#EndPoint",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/apiContract#path": [
+{
+"@value": "/files/{fileId}/comments/{commentId}/replies/{replyId}"
+}
+],
+"http://a.ml/vocabularies/apiContract#supportedOperation": [
+{
+"@id": "amf://id#309",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Operation",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/apiContract#method": [
+{
+"@value": "get"
+}
+],
+"http://a.ml/vocabularies/core#description": [
+{
+"@value": "Gets a reply."
+}
+],
+"http://a.ml/vocabularies/document-source-maps#sources": [
+{
+"@id": "amf://id#309/source-map",
+"@type": [
+"http://a.ml/vocabularies/document-source-maps#SourceMap"
+],
+"http://a.ml/vocabularies/document-source-maps#lexical": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/core#description"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(239,14)-(241,0)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#309"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(238,12)-(241,0)]"
+}
+]
+}
+]
+}
+]
+},
+{
+"@id": "amf://id#310",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Operation",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/apiContract#method": [
+{
+"@value": "put"
+}
+],
+"http://a.ml/vocabularies/core#description": [
+{
+"@value": "Updates an existing reply."
+}
+],
+"http://a.ml/vocabularies/document-source-maps#sources": [
+{
+"@id": "amf://id#310/source-map",
+"@type": [
+"http://a.ml/vocabularies/document-source-maps#SourceMap"
+],
+"http://a.ml/vocabularies/document-source-maps#lexical": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/core#description"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(242,14)-(244,0)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#310"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(241,12)-(244,0)]"
+}
+]
+}
+]
+}
+]
+},
+{
+"@id": "amf://id#311",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Operation",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/apiContract#method": [
+{
+"@value": "delete"
+}
+],
+"http://a.ml/vocabularies/core#description": [
+{
+"@value": "Deletes a reply."
+}
+],
+"http://a.ml/vocabularies/document-source-maps#sources": [
+{
+"@id": "amf://id#311/source-map",
+"@type": [
+"http://a.ml/vocabularies/document-source-maps#SourceMap"
+],
+"http://a.ml/vocabularies/document-source-maps#lexical": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/core#description"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(245,14)-(247,0)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#311"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(244,12)-(247,0)]"
+}
+]
+}
+]
+}
+]
+},
+{
+"@id": "amf://id#312",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Operation",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/apiContract#method": [
+{
+"@value": "patch"
+}
+],
+"http://a.ml/vocabularies/core#description": [
+{
+"@value": "Updates an existing reply. This method supports patch semantics."
+}
+],
+"http://a.ml/vocabularies/document-source-maps#sources": [
+{
+"@id": "amf://id#312/source-map",
+"@type": [
+"http://a.ml/vocabularies/document-source-maps#SourceMap"
+],
+"http://a.ml/vocabularies/document-source-maps#lexical": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/core#description"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(248,14)-(250,0)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#312"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(247,12)-(250,0)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"http://a.ml/vocabularies/apiContract#parameter": [
+{
+"@id": "amf://id#313",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Parameter",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/core#name": [
+{
+"@value": "fileId"
+}
+],
+"http://a.ml/vocabularies/apiContract#paramName": [
+{
+"@value": "fileId"
+}
+],
+"http://a.ml/vocabularies/apiContract#required": [
+{
+"@value": true
+}
+],
+"http://a.ml/vocabularies/apiContract#binding": [
+{
+"@value": "path"
+}
+],
+"http://a.ml/vocabularies/apiContract#schema": [
+{
+"@id": "amf://id#314",
+"@type": [
+"http://a.ml/vocabularies/shapes#ScalarShape",
+"http://www.w3.org/ns/shacl#Shape",
+"http://a.ml/vocabularies/shapes#Shape",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://www.w3.org/ns/shacl#datatype": [
+{
+"@id": "http://www.w3.org/2001/XMLSchema#string"
+}
+],
+"http://www.w3.org/ns/shacl#name": [
+{
+"@value": "fileId"
+}
+]
+}
+],
+"http://a.ml/vocabularies/document-source-maps#sources": [
+{
+"@id": "amf://id#313/source-map",
+"@type": [
+"http://a.ml/vocabularies/document-source-maps#SourceMap"
+],
+"http://a.ml/vocabularies/document-source-maps#synthesized-field": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#313"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "true"
+}
+]
+}
+]
+}
+]
+},
+{
+"@id": "amf://id#315",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Parameter",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/core#name": [
+{
+"@value": "commentId"
+}
+],
+"http://a.ml/vocabularies/apiContract#paramName": [
+{
+"@value": "commentId"
+}
+],
+"http://a.ml/vocabularies/apiContract#required": [
+{
+"@value": true
+}
+],
+"http://a.ml/vocabularies/apiContract#binding": [
+{
+"@value": "path"
+}
+],
+"http://a.ml/vocabularies/apiContract#schema": [
+{
+"@id": "amf://id#316",
+"@type": [
+"http://a.ml/vocabularies/shapes#ScalarShape",
+"http://www.w3.org/ns/shacl#Shape",
+"http://a.ml/vocabularies/shapes#Shape",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://www.w3.org/ns/shacl#datatype": [
+{
+"@id": "http://www.w3.org/2001/XMLSchema#string"
+}
+],
+"http://www.w3.org/ns/shacl#name": [
+{
+"@value": "schema"
+}
+],
+"http://a.ml/vocabularies/apiContract#examples": [
+{
+"@id": "amf://id#299",
+"@type": [
+"http://a.ml/vocabularies/apiContract#NamedExamples",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/apiContract#examples": [
+{
+"@id": "amf://id#300",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Example",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/document#strict": [
+{
+"@value": true
+}
+],
+"http://a.ml/vocabularies/document#structuredValue": [
+{
+"@id": "amf://id#300",
+"@type": [
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/data#value": [
+{
+"@value": "commant-id",
+"@type": "http://www.w3.org/2001/XMLSchema#string"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#sources": [
+{
+"@id": "amf://id#300/source-map",
+"@type": [
+"http://a.ml/vocabularies/document-source-maps#SourceMap"
+],
+"http://a.ml/vocabularies/document-source-maps#lexical": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#300"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(217,21)-(217,31)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"http://www.w3.org/ns/shacl#raw": [
+{
+"@value": "commant-id"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#sources": [
+{
+"@id": "amf://id#300/source-map",
+"@type": [
+"http://a.ml/vocabularies/document-source-maps#SourceMap"
+],
+"http://a.ml/vocabularies/document-source-maps#synthesized-field": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/document#strict"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "true"
+}
+]
+}
+],
+"http://a.ml/vocabularies/document-source-maps#lexical": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://www.w3.org/ns/shacl#raw"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(217,21)-(217,31)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#300"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(217,21)-(217,31)]"
+}
+]
+}
+],
+"http://a.ml/vocabularies/document-source-maps#tracked-element": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#300"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "amf://id#297"
+}
+]
+}
+]
+}
+]
+}
+]
+}
+],
+"http://a.ml/vocabularies/document-source-maps#sources": [
+{
+"@id": "amf://id#316/source-map",
+"@type": [
+"http://a.ml/vocabularies/document-source-maps#SourceMap"
+],
+"http://a.ml/vocabularies/document-source-maps#type-property-lexical-info": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#316"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -5314,7 +5349,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#301"
+"@value": "amf://id#316"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -5330,7 +5365,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#300/source-map",
+"@id": "amf://id#315/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -5338,7 +5373,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#300"
+"@value": "amf://id#315"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -5352,7 +5387,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#300"
+"@value": "amf://id#315"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -5366,39 +5401,39 @@
 ]
 },
 {
-"@id": "amf://id#302",
+"@id": "amf://id#317",
 "@type": [
-"http://a.ml/vocabularies/http#Parameter",
+"http://a.ml/vocabularies/apiContract#Parameter",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://schema.org/name": [
+"http://a.ml/vocabularies/core#name": [
 {
 "@value": "replyId"
 }
 ],
-"http://a.ml/vocabularies/http#paramName": [
+"http://a.ml/vocabularies/apiContract#paramName": [
 {
 "@value": "replyId"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "The ID of the reply."
 }
 ],
-"http://www.w3.org/ns/hydra/core#required": [
+"http://a.ml/vocabularies/apiContract#required": [
 {
 "@value": true
 }
 ],
-"http://a.ml/vocabularies/http#binding": [
+"http://a.ml/vocabularies/apiContract#binding": [
 {
 "@value": "path"
 }
 ],
-"http://a.ml/vocabularies/http#schema": [
+"http://a.ml/vocabularies/apiContract#schema": [
 {
-"@id": "amf://id#303",
+"@id": "amf://id#318",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -5415,14 +5450,14 @@
 "@value": "schema"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "The ID of the reply."
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#303/source-map",
+"@id": "amf://id#318/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -5430,7 +5465,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#303"
+"@value": "amf://id#318"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -5444,7 +5479,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -5456,7 +5491,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#303"
+"@value": "amf://id#318"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -5484,7 +5519,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#302/source-map",
+"@id": "amf://id#317/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -5492,7 +5527,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -5504,7 +5539,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#302"
+"@value": "amf://id#317"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -5520,7 +5555,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#293/source-map",
+"@id": "amf://id#308/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -5528,7 +5563,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#293"
+"@value": "amf://id#308"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -5542,7 +5577,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://a.ml/vocabularies/http#parameter"
+"@value": "http://a.ml/vocabularies/apiContract#parameter"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -5554,7 +5589,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#293"
+"@value": "amf://id#308"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -5568,36 +5603,36 @@
 ]
 },
 {
-"@id": "amf://id#304",
+"@id": "amf://id#319",
 "@type": [
-"http://a.ml/vocabularies/http#EndPoint",
+"http://a.ml/vocabularies/apiContract#EndPoint",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://a.ml/vocabularies/http#path": [
+"http://a.ml/vocabularies/apiContract#path": [
 {
 "@value": "/files/{fileId}/realtime"
 }
 ],
-"http://www.w3.org/ns/hydra/core#supportedOperation": [
+"http://a.ml/vocabularies/apiContract#supportedOperation": [
 {
-"@id": "amf://id#305",
+"@id": "amf://id#320",
 "@type": [
-"http://www.w3.org/ns/hydra/core#Operation",
+"http://a.ml/vocabularies/apiContract#Operation",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://www.w3.org/ns/hydra/core#method": [
+"http://a.ml/vocabularies/apiContract#method": [
 {
 "@value": "get"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "Exports the contents of the Realtime API data model associated with this file as JSON."
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#305/source-map",
+"@id": "amf://id#320/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -5605,7 +5640,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -5617,7 +5652,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#305"
+"@value": "amf://id#320"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -5631,29 +5666,29 @@
 ]
 },
 {
-"@id": "amf://id#306",
+"@id": "amf://id#321",
 "@type": [
-"http://www.w3.org/ns/hydra/core#Operation",
+"http://a.ml/vocabularies/apiContract#Operation",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://www.w3.org/ns/hydra/core#method": [
+"http://a.ml/vocabularies/apiContract#method": [
 {
 "@value": "put"
 }
 ],
-"http://schema.org/name": [
+"http://a.ml/vocabularies/core#name": [
 {
 "@value": "update"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "Overwrites the Realtime API data model associated with this file with the provided JSON data model.\n\nThis method supports an /upload URI and accepts uploaded media with the following characteristics:\n\n- **Maximum file size**: 10MB\n- **Accepted Media MIME** types: */*\n"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#306/source-map",
+"@id": "amf://id#321/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -5661,7 +5696,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -5673,7 +5708,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#306"
+"@value": "amf://id#321"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -5685,7 +5720,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/name"
+"@value": "http://a.ml/vocabularies/core#name"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -5699,36 +5734,36 @@
 ]
 }
 ],
-"http://a.ml/vocabularies/http#parameter": [
+"http://a.ml/vocabularies/apiContract#parameter": [
 {
-"@id": "amf://id#307",
+"@id": "amf://id#322",
 "@type": [
-"http://a.ml/vocabularies/http#Parameter",
+"http://a.ml/vocabularies/apiContract#Parameter",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://schema.org/name": [
+"http://a.ml/vocabularies/core#name": [
 {
 "@value": "fileId"
 }
 ],
-"http://a.ml/vocabularies/http#paramName": [
+"http://a.ml/vocabularies/apiContract#paramName": [
 {
 "@value": "fileId"
 }
 ],
-"http://www.w3.org/ns/hydra/core#required": [
+"http://a.ml/vocabularies/apiContract#required": [
 {
 "@value": true
 }
 ],
-"http://a.ml/vocabularies/http#binding": [
+"http://a.ml/vocabularies/apiContract#binding": [
 {
 "@value": "path"
 }
 ],
-"http://a.ml/vocabularies/http#schema": [
+"http://a.ml/vocabularies/apiContract#schema": [
 {
-"@id": "amf://id#308",
+"@id": "amf://id#323",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -5749,7 +5784,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#307/source-map",
+"@id": "amf://id#322/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -5757,7 +5792,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#307"
+"@value": "amf://id#322"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -5773,7 +5808,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#304/source-map",
+"@id": "amf://id#319/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -5781,7 +5816,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#304"
+"@value": "amf://id#319"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -5795,7 +5830,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#304"
+"@value": "amf://id#319"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -5809,36 +5844,36 @@
 ]
 },
 {
-"@id": "amf://id#309",
+"@id": "amf://id#324",
 "@type": [
-"http://a.ml/vocabularies/http#EndPoint",
+"http://a.ml/vocabularies/apiContract#EndPoint",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://a.ml/vocabularies/http#path": [
+"http://a.ml/vocabularies/apiContract#path": [
 {
 "@value": "/files/{fileId}/properties"
 }
 ],
-"http://www.w3.org/ns/hydra/core#supportedOperation": [
+"http://a.ml/vocabularies/apiContract#supportedOperation": [
 {
-"@id": "amf://id#310",
+"@id": "amf://id#325",
 "@type": [
-"http://www.w3.org/ns/hydra/core#Operation",
+"http://a.ml/vocabularies/apiContract#Operation",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://www.w3.org/ns/hydra/core#method": [
+"http://a.ml/vocabularies/apiContract#method": [
 {
 "@value": "get"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "Lists a file's properties."
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#310/source-map",
+"@id": "amf://id#325/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -5846,7 +5881,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -5858,7 +5893,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#310"
+"@value": "amf://id#325"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -5872,24 +5907,24 @@
 ]
 },
 {
-"@id": "amf://id#311",
+"@id": "amf://id#326",
 "@type": [
-"http://www.w3.org/ns/hydra/core#Operation",
+"http://a.ml/vocabularies/apiContract#Operation",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://www.w3.org/ns/hydra/core#method": [
+"http://a.ml/vocabularies/apiContract#method": [
 {
 "@value": "post"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "Adds a property to a file."
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#311/source-map",
+"@id": "amf://id#326/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -5897,7 +5932,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -5909,7 +5944,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#311"
+"@value": "amf://id#326"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -5923,36 +5958,36 @@
 ]
 }
 ],
-"http://a.ml/vocabularies/http#parameter": [
+"http://a.ml/vocabularies/apiContract#parameter": [
 {
-"@id": "amf://id#312",
+"@id": "amf://id#327",
 "@type": [
-"http://a.ml/vocabularies/http#Parameter",
+"http://a.ml/vocabularies/apiContract#Parameter",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://schema.org/name": [
+"http://a.ml/vocabularies/core#name": [
 {
 "@value": "fileId"
 }
 ],
-"http://a.ml/vocabularies/http#paramName": [
+"http://a.ml/vocabularies/apiContract#paramName": [
 {
 "@value": "fileId"
 }
 ],
-"http://www.w3.org/ns/hydra/core#required": [
+"http://a.ml/vocabularies/apiContract#required": [
 {
 "@value": true
 }
 ],
-"http://a.ml/vocabularies/http#binding": [
+"http://a.ml/vocabularies/apiContract#binding": [
 {
 "@value": "path"
 }
 ],
-"http://a.ml/vocabularies/http#schema": [
+"http://a.ml/vocabularies/apiContract#schema": [
 {
-"@id": "amf://id#313",
+"@id": "amf://id#328",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -5973,7 +6008,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#312/source-map",
+"@id": "amf://id#327/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -5981,7 +6016,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#312"
+"@value": "amf://id#327"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -5997,7 +6032,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#309/source-map",
+"@id": "amf://id#324/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -6005,7 +6040,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#309"
+"@value": "amf://id#324"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -6019,7 +6054,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#309"
+"@value": "amf://id#324"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -6033,31 +6068,31 @@
 ]
 },
 {
-"@id": "amf://id#314",
+"@id": "amf://id#329",
 "@type": [
-"http://a.ml/vocabularies/http#EndPoint",
+"http://a.ml/vocabularies/apiContract#EndPoint",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://a.ml/vocabularies/http#path": [
+"http://a.ml/vocabularies/apiContract#path": [
 {
 "@value": "/files/{fileId}/properties/{propertyKey}"
 }
 ],
-"http://www.w3.org/ns/hydra/core#supportedOperation": [
+"http://a.ml/vocabularies/apiContract#supportedOperation": [
 {
-"@id": "amf://id#315",
+"@id": "amf://id#330",
 "@type": [
-"http://www.w3.org/ns/hydra/core#Operation",
+"http://a.ml/vocabularies/apiContract#Operation",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://www.w3.org/ns/hydra/core#method": [
+"http://a.ml/vocabularies/apiContract#method": [
 {
 "@value": "get"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#315/source-map",
+"@id": "amf://id#330/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -6065,7 +6100,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#315"
+"@value": "amf://id#330"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -6079,19 +6114,19 @@
 ]
 },
 {
-"@id": "amf://id#316",
+"@id": "amf://id#331",
 "@type": [
-"http://www.w3.org/ns/hydra/core#Operation",
+"http://a.ml/vocabularies/apiContract#Operation",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://www.w3.org/ns/hydra/core#method": [
+"http://a.ml/vocabularies/apiContract#method": [
 {
 "@value": "put"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#316/source-map",
+"@id": "amf://id#331/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -6099,7 +6134,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#316"
+"@value": "amf://id#331"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -6113,19 +6148,19 @@
 ]
 },
 {
-"@id": "amf://id#317",
+"@id": "amf://id#332",
 "@type": [
-"http://www.w3.org/ns/hydra/core#Operation",
+"http://a.ml/vocabularies/apiContract#Operation",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://www.w3.org/ns/hydra/core#method": [
+"http://a.ml/vocabularies/apiContract#method": [
 {
 "@value": "delete"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#317/source-map",
+"@id": "amf://id#332/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -6133,7 +6168,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#317"
+"@value": "amf://id#332"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -6147,19 +6182,19 @@
 ]
 },
 {
-"@id": "amf://id#318",
+"@id": "amf://id#333",
 "@type": [
-"http://www.w3.org/ns/hydra/core#Operation",
+"http://a.ml/vocabularies/apiContract#Operation",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://www.w3.org/ns/hydra/core#method": [
+"http://a.ml/vocabularies/apiContract#method": [
 {
 "@value": "patch"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#318/source-map",
+"@id": "amf://id#333/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -6167,7 +6202,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#318"
+"@value": "amf://id#333"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -6181,36 +6216,36 @@
 ]
 }
 ],
-"http://a.ml/vocabularies/http#parameter": [
+"http://a.ml/vocabularies/apiContract#parameter": [
 {
-"@id": "amf://id#319",
+"@id": "amf://id#334",
 "@type": [
-"http://a.ml/vocabularies/http#Parameter",
+"http://a.ml/vocabularies/apiContract#Parameter",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://schema.org/name": [
+"http://a.ml/vocabularies/core#name": [
 {
 "@value": "fileId"
 }
 ],
-"http://a.ml/vocabularies/http#paramName": [
+"http://a.ml/vocabularies/apiContract#paramName": [
 {
 "@value": "fileId"
 }
 ],
-"http://www.w3.org/ns/hydra/core#required": [
+"http://a.ml/vocabularies/apiContract#required": [
 {
 "@value": true
 }
 ],
-"http://a.ml/vocabularies/http#binding": [
+"http://a.ml/vocabularies/apiContract#binding": [
 {
 "@value": "path"
 }
 ],
-"http://a.ml/vocabularies/http#schema": [
+"http://a.ml/vocabularies/apiContract#schema": [
 {
-"@id": "amf://id#320",
+"@id": "amf://id#335",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -6231,7 +6266,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#319/source-map",
+"@id": "amf://id#334/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -6239,7 +6274,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#319"
+"@value": "amf://id#334"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -6253,39 +6288,39 @@
 ]
 },
 {
-"@id": "amf://id#321",
+"@id": "amf://id#336",
 "@type": [
-"http://a.ml/vocabularies/http#Parameter",
+"http://a.ml/vocabularies/apiContract#Parameter",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://schema.org/name": [
+"http://a.ml/vocabularies/core#name": [
 {
 "@value": "propertyKey"
 }
 ],
-"http://a.ml/vocabularies/http#paramName": [
+"http://a.ml/vocabularies/apiContract#paramName": [
 {
 "@value": "propertyKey"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "The key of the property."
 }
 ],
-"http://www.w3.org/ns/hydra/core#required": [
+"http://a.ml/vocabularies/apiContract#required": [
 {
 "@value": true
 }
 ],
-"http://a.ml/vocabularies/http#binding": [
+"http://a.ml/vocabularies/apiContract#binding": [
 {
 "@value": "path"
 }
 ],
-"http://a.ml/vocabularies/http#schema": [
+"http://a.ml/vocabularies/apiContract#schema": [
 {
-"@id": "amf://id#322",
+"@id": "amf://id#337",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -6302,14 +6337,14 @@
 "@value": "schema"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "The key of the property."
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#322/source-map",
+"@id": "amf://id#337/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -6317,7 +6352,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#322"
+"@value": "amf://id#337"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -6331,7 +6366,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -6343,7 +6378,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#322"
+"@value": "amf://id#337"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -6371,7 +6406,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#321/source-map",
+"@id": "amf://id#336/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -6379,7 +6414,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -6391,7 +6426,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#321"
+"@value": "amf://id#336"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -6407,7 +6442,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#314/source-map",
+"@id": "amf://id#329/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -6415,7 +6450,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#314"
+"@value": "amf://id#329"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -6429,7 +6464,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://a.ml/vocabularies/http#parameter"
+"@value": "http://a.ml/vocabularies/apiContract#parameter"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -6441,7 +6476,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#314"
+"@value": "amf://id#329"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -6455,36 +6490,36 @@
 ]
 },
 {
-"@id": "amf://id#323",
+"@id": "amf://id#338",
 "@type": [
-"http://a.ml/vocabularies/http#EndPoint",
+"http://a.ml/vocabularies/apiContract#EndPoint",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://a.ml/vocabularies/http#path": [
+"http://a.ml/vocabularies/apiContract#path": [
 {
 "@value": "/files/trash"
 }
 ],
-"http://www.w3.org/ns/hydra/core#supportedOperation": [
+"http://a.ml/vocabularies/apiContract#supportedOperation": [
 {
-"@id": "amf://id#324",
+"@id": "amf://id#339",
 "@type": [
-"http://www.w3.org/ns/hydra/core#Operation",
+"http://a.ml/vocabularies/apiContract#Operation",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://www.w3.org/ns/hydra/core#method": [
+"http://a.ml/vocabularies/apiContract#method": [
 {
 "@value": "delete"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "Permanently deletes all of the user's trashed files."
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#324/source-map",
+"@id": "amf://id#339/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -6492,7 +6527,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -6504,7 +6539,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#324"
+"@value": "amf://id#339"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -6520,7 +6555,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#323/source-map",
+"@id": "amf://id#338/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -6528,7 +6563,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#323"
+"@value": "amf://id#338"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -6542,7 +6577,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#323"
+"@value": "amf://id#338"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -6556,36 +6591,36 @@
 ]
 },
 {
-"@id": "amf://id#325",
+"@id": "amf://id#340",
 "@type": [
-"http://a.ml/vocabularies/http#EndPoint",
+"http://a.ml/vocabularies/apiContract#EndPoint",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://a.ml/vocabularies/http#path": [
+"http://a.ml/vocabularies/apiContract#path": [
 {
 "@value": "/files/{folderId}/children"
 }
 ],
-"http://www.w3.org/ns/hydra/core#supportedOperation": [
+"http://a.ml/vocabularies/apiContract#supportedOperation": [
 {
-"@id": "amf://id#326",
+"@id": "amf://id#341",
 "@type": [
-"http://www.w3.org/ns/hydra/core#Operation",
+"http://a.ml/vocabularies/apiContract#Operation",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://www.w3.org/ns/hydra/core#method": [
+"http://a.ml/vocabularies/apiContract#method": [
 {
 "@value": "post"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "Inserts a file into a folder."
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#326/source-map",
+"@id": "amf://id#341/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -6593,7 +6628,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -6605,7 +6640,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#326"
+"@value": "amf://id#341"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -6619,24 +6654,24 @@
 ]
 },
 {
-"@id": "amf://id#327",
+"@id": "amf://id#342",
 "@type": [
-"http://www.w3.org/ns/hydra/core#Operation",
+"http://a.ml/vocabularies/apiContract#Operation",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://www.w3.org/ns/hydra/core#method": [
+"http://a.ml/vocabularies/apiContract#method": [
 {
 "@value": "get"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "Lists a folder's children. To list all children of the root folder, use the alias root for the folderId value."
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#327/source-map",
+"@id": "amf://id#342/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -6644,7 +6679,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -6656,7 +6691,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#327"
+"@value": "amf://id#342"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -6670,36 +6705,36 @@
 ]
 }
 ],
-"http://a.ml/vocabularies/http#parameter": [
+"http://a.ml/vocabularies/apiContract#parameter": [
 {
-"@id": "amf://id#328",
+"@id": "amf://id#343",
 "@type": [
-"http://a.ml/vocabularies/http#Parameter",
+"http://a.ml/vocabularies/apiContract#Parameter",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://schema.org/name": [
+"http://a.ml/vocabularies/core#name": [
 {
 "@value": "folderId"
 }
 ],
-"http://a.ml/vocabularies/http#paramName": [
+"http://a.ml/vocabularies/apiContract#paramName": [
 {
 "@value": "folderId"
 }
 ],
-"http://www.w3.org/ns/hydra/core#required": [
+"http://a.ml/vocabularies/apiContract#required": [
 {
 "@value": true
 }
 ],
-"http://a.ml/vocabularies/http#binding": [
+"http://a.ml/vocabularies/apiContract#binding": [
 {
 "@value": "path"
 }
 ],
-"http://a.ml/vocabularies/http#schema": [
+"http://a.ml/vocabularies/apiContract#schema": [
 {
-"@id": "amf://id#329",
+"@id": "amf://id#344",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -6720,7 +6755,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#328/source-map",
+"@id": "amf://id#343/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -6728,7 +6763,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#328"
+"@value": "amf://id#343"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -6744,7 +6779,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#325/source-map",
+"@id": "amf://id#340/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -6752,7 +6787,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#325"
+"@value": "amf://id#340"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -6766,7 +6801,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#325"
+"@value": "amf://id#340"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -6780,36 +6815,36 @@
 ]
 },
 {
-"@id": "amf://id#330",
+"@id": "amf://id#345",
 "@type": [
-"http://a.ml/vocabularies/http#EndPoint",
+"http://a.ml/vocabularies/apiContract#EndPoint",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://a.ml/vocabularies/http#path": [
+"http://a.ml/vocabularies/apiContract#path": [
 {
 "@value": "/files/{folderId}/children/{childId}"
 }
 ],
-"http://www.w3.org/ns/hydra/core#supportedOperation": [
+"http://a.ml/vocabularies/apiContract#supportedOperation": [
 {
-"@id": "amf://id#331",
+"@id": "amf://id#346",
 "@type": [
-"http://www.w3.org/ns/hydra/core#Operation",
+"http://a.ml/vocabularies/apiContract#Operation",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://www.w3.org/ns/hydra/core#method": [
+"http://a.ml/vocabularies/apiContract#method": [
 {
 "@value": "delete"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "Removes a child from a folder."
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#331/source-map",
+"@id": "amf://id#346/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -6817,7 +6852,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -6829,7 +6864,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#331"
+"@value": "amf://id#346"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -6843,24 +6878,24 @@
 ]
 },
 {
-"@id": "amf://id#332",
+"@id": "amf://id#347",
 "@type": [
-"http://www.w3.org/ns/hydra/core#Operation",
+"http://a.ml/vocabularies/apiContract#Operation",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://www.w3.org/ns/hydra/core#method": [
+"http://a.ml/vocabularies/apiContract#method": [
 {
 "@value": "get"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "Gets a specific child reference."
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#332/source-map",
+"@id": "amf://id#347/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -6868,7 +6903,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -6880,7 +6915,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#332"
+"@value": "amf://id#347"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -6894,36 +6929,36 @@
 ]
 }
 ],
-"http://a.ml/vocabularies/http#parameter": [
+"http://a.ml/vocabularies/apiContract#parameter": [
 {
-"@id": "amf://id#333",
+"@id": "amf://id#348",
 "@type": [
-"http://a.ml/vocabularies/http#Parameter",
+"http://a.ml/vocabularies/apiContract#Parameter",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://schema.org/name": [
+"http://a.ml/vocabularies/core#name": [
 {
 "@value": "folderId"
 }
 ],
-"http://a.ml/vocabularies/http#paramName": [
+"http://a.ml/vocabularies/apiContract#paramName": [
 {
 "@value": "folderId"
 }
 ],
-"http://www.w3.org/ns/hydra/core#required": [
+"http://a.ml/vocabularies/apiContract#required": [
 {
 "@value": true
 }
 ],
-"http://a.ml/vocabularies/http#binding": [
+"http://a.ml/vocabularies/apiContract#binding": [
 {
 "@value": "path"
 }
 ],
-"http://a.ml/vocabularies/http#schema": [
+"http://a.ml/vocabularies/apiContract#schema": [
 {
-"@id": "amf://id#334",
+"@id": "amf://id#349",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -6944,7 +6979,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#333/source-map",
+"@id": "amf://id#348/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -6952,7 +6987,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#333"
+"@value": "amf://id#348"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -6966,34 +7001,34 @@
 ]
 },
 {
-"@id": "amf://id#335",
+"@id": "amf://id#350",
 "@type": [
-"http://a.ml/vocabularies/http#Parameter",
+"http://a.ml/vocabularies/apiContract#Parameter",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://schema.org/name": [
+"http://a.ml/vocabularies/core#name": [
 {
 "@value": "childId"
 }
 ],
-"http://a.ml/vocabularies/http#paramName": [
+"http://a.ml/vocabularies/apiContract#paramName": [
 {
 "@value": "childId"
 }
 ],
-"http://www.w3.org/ns/hydra/core#required": [
+"http://a.ml/vocabularies/apiContract#required": [
 {
 "@value": true
 }
 ],
-"http://a.ml/vocabularies/http#binding": [
+"http://a.ml/vocabularies/apiContract#binding": [
 {
 "@value": "path"
 }
 ],
-"http://a.ml/vocabularies/http#schema": [
+"http://a.ml/vocabularies/apiContract#schema": [
 {
-"@id": "amf://id#336",
+"@id": "amf://id#351",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -7014,7 +7049,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#335/source-map",
+"@id": "amf://id#350/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -7022,7 +7057,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#335"
+"@value": "amf://id#350"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -7038,7 +7073,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#330/source-map",
+"@id": "amf://id#345/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -7046,7 +7081,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#330"
+"@value": "amf://id#345"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -7060,7 +7095,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#330"
+"@value": "amf://id#345"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -7074,41 +7109,41 @@
 ]
 },
 {
-"@id": "amf://id#337",
+"@id": "amf://id#352",
 "@type": [
-"http://a.ml/vocabularies/http#EndPoint",
+"http://a.ml/vocabularies/apiContract#EndPoint",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://a.ml/vocabularies/http#path": [
+"http://a.ml/vocabularies/apiContract#path": [
 {
 "@value": "/about"
 }
 ],
-"http://schema.org/name": [
+"http://a.ml/vocabularies/core#name": [
 {
 "@value": "About"
 }
 ],
-"http://www.w3.org/ns/hydra/core#supportedOperation": [
+"http://a.ml/vocabularies/apiContract#supportedOperation": [
 {
-"@id": "amf://id#338",
+"@id": "amf://id#353",
 "@type": [
-"http://www.w3.org/ns/hydra/core#Operation",
+"http://a.ml/vocabularies/apiContract#Operation",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://www.w3.org/ns/hydra/core#method": [
+"http://a.ml/vocabularies/apiContract#method": [
 {
 "@value": "get"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "Gets the information about the current user along with Drive API settings."
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#338/source-map",
+"@id": "amf://id#353/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -7116,7 +7151,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -7128,7 +7163,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#338"
+"@value": "amf://id#353"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -7144,7 +7179,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#337/source-map",
+"@id": "amf://id#352/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -7152,7 +7187,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/name"
+"@value": "http://a.ml/vocabularies/core#name"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -7164,7 +7199,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#337"
+"@value": "amf://id#352"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -7178,36 +7213,36 @@
 ]
 },
 {
-"@id": "amf://id#339",
+"@id": "amf://id#354",
 "@type": [
-"http://a.ml/vocabularies/http#EndPoint",
+"http://a.ml/vocabularies/apiContract#EndPoint",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://a.ml/vocabularies/http#path": [
+"http://a.ml/vocabularies/apiContract#path": [
 {
 "@value": "/changes"
 }
 ],
-"http://schema.org/name": [
+"http://a.ml/vocabularies/core#name": [
 {
 "@value": "Changes"
 }
 ],
-"http://www.w3.org/ns/hydra/core#supportedOperation": [
+"http://a.ml/vocabularies/apiContract#supportedOperation": [
 {
-"@id": "amf://id#340",
+"@id": "amf://id#355",
 "@type": [
-"http://www.w3.org/ns/hydra/core#Operation",
+"http://a.ml/vocabularies/apiContract#Operation",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://www.w3.org/ns/hydra/core#method": [
+"http://a.ml/vocabularies/apiContract#method": [
 {
 "@value": "get"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#340/source-map",
+"@id": "amf://id#355/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -7215,7 +7250,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#340"
+"@value": "amf://id#355"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -7231,7 +7266,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#339/source-map",
+"@id": "amf://id#354/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -7239,7 +7274,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/name"
+"@value": "http://a.ml/vocabularies/core#name"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -7251,7 +7286,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#339"
+"@value": "amf://id#354"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -7265,36 +7300,36 @@
 ]
 },
 {
-"@id": "amf://id#341",
+"@id": "amf://id#356",
 "@type": [
-"http://a.ml/vocabularies/http#EndPoint",
+"http://a.ml/vocabularies/apiContract#EndPoint",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://a.ml/vocabularies/http#path": [
+"http://a.ml/vocabularies/apiContract#path": [
 {
 "@value": "/changes/{changeId}"
 }
 ],
-"http://www.w3.org/ns/hydra/core#supportedOperation": [
+"http://a.ml/vocabularies/apiContract#supportedOperation": [
 {
-"@id": "amf://id#342",
+"@id": "amf://id#357",
 "@type": [
-"http://www.w3.org/ns/hydra/core#Operation",
+"http://a.ml/vocabularies/apiContract#Operation",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://www.w3.org/ns/hydra/core#method": [
+"http://a.ml/vocabularies/apiContract#method": [
 {
 "@value": "get"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "Gets a specific change."
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#342/source-map",
+"@id": "amf://id#357/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -7302,7 +7337,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -7314,7 +7349,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#342"
+"@value": "amf://id#357"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -7328,41 +7363,41 @@
 ]
 }
 ],
-"http://a.ml/vocabularies/http#parameter": [
+"http://a.ml/vocabularies/apiContract#parameter": [
 {
-"@id": "amf://id#343",
+"@id": "amf://id#358",
 "@type": [
-"http://a.ml/vocabularies/http#Parameter",
+"http://a.ml/vocabularies/apiContract#Parameter",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://schema.org/name": [
+"http://a.ml/vocabularies/core#name": [
 {
 "@value": "changeId"
 }
 ],
-"http://a.ml/vocabularies/http#paramName": [
+"http://a.ml/vocabularies/apiContract#paramName": [
 {
 "@value": "changeId"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "The ID of the change."
 }
 ],
-"http://www.w3.org/ns/hydra/core#required": [
+"http://a.ml/vocabularies/apiContract#required": [
 {
 "@value": true
 }
 ],
-"http://a.ml/vocabularies/http#binding": [
+"http://a.ml/vocabularies/apiContract#binding": [
 {
 "@value": "path"
 }
 ],
-"http://a.ml/vocabularies/http#schema": [
+"http://a.ml/vocabularies/apiContract#schema": [
 {
-"@id": "amf://id#344",
+"@id": "amf://id#359",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -7379,14 +7414,14 @@
 "@value": "schema"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "The ID of the change."
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#344/source-map",
+"@id": "amf://id#359/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -7394,7 +7429,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#344"
+"@value": "amf://id#359"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -7408,7 +7443,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -7420,7 +7455,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#344"
+"@value": "amf://id#359"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -7448,7 +7483,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#343/source-map",
+"@id": "amf://id#358/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -7456,7 +7491,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -7468,7 +7503,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#343"
+"@value": "amf://id#358"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -7484,7 +7519,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#341/source-map",
+"@id": "amf://id#356/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -7492,7 +7527,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#341"
+"@value": "amf://id#356"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -7506,7 +7541,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://a.ml/vocabularies/http#parameter"
+"@value": "http://a.ml/vocabularies/apiContract#parameter"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -7518,7 +7553,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#341"
+"@value": "amf://id#356"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -7532,75 +7567,75 @@
 ]
 },
 {
-"@id": "amf://id#345",
+"@id": "amf://id#360",
 "@type": [
-"http://a.ml/vocabularies/http#EndPoint",
+"http://a.ml/vocabularies/apiContract#EndPoint",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://a.ml/vocabularies/http#path": [
+"http://a.ml/vocabularies/apiContract#path": [
 {
 "@value": "/changes/watch"
 }
 ],
-"http://www.w3.org/ns/hydra/core#supportedOperation": [
+"http://a.ml/vocabularies/apiContract#supportedOperation": [
 {
-"@id": "amf://id#346",
+"@id": "amf://id#361",
 "@type": [
-"http://www.w3.org/ns/hydra/core#Operation",
+"http://a.ml/vocabularies/apiContract#Operation",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://www.w3.org/ns/hydra/core#method": [
+"http://a.ml/vocabularies/apiContract#method": [
 {
 "@value": "post"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "Watch for all changes to a user's Drive."
 }
 ],
-"http://www.w3.org/ns/hydra/core#expects": [
+"http://a.ml/vocabularies/apiContract#expects": [
 {
-"@id": "amf://id#347",
+"@id": "amf://id#362",
 "@type": [
-"http://a.ml/vocabularies/http#Request",
+"http://a.ml/vocabularies/apiContract#Request",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://a.ml/vocabularies/http#parameter": [
+"http://a.ml/vocabularies/apiContract#parameter": [
 {
-"@id": "amf://id#348",
+"@id": "amf://id#363",
 "@type": [
-"http://a.ml/vocabularies/http#Parameter",
+"http://a.ml/vocabularies/apiContract#Parameter",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://schema.org/name": [
+"http://a.ml/vocabularies/core#name": [
 {
 "@value": "spaces"
 }
 ],
-"http://a.ml/vocabularies/http#paramName": [
+"http://a.ml/vocabularies/apiContract#paramName": [
 {
 "@value": "spaces"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "A comma-separated list of spaces to query. Supported values are:\n\n- **drive**\n- **appDataFolder**\n- **photos**\n"
 }
 ],
-"http://www.w3.org/ns/hydra/core#required": [
+"http://a.ml/vocabularies/apiContract#required": [
 {
 "@value": false
 }
 ],
-"http://a.ml/vocabularies/http#binding": [
+"http://a.ml/vocabularies/apiContract#binding": [
 {
 "@value": "query"
 }
 ],
-"http://a.ml/vocabularies/http#schema": [
+"http://a.ml/vocabularies/apiContract#schema": [
 {
-"@id": "amf://id#349",
+"@id": "amf://id#364",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -7617,14 +7652,14 @@
 "@value": "schema"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "A comma-separated list of spaces to query. Supported values are:\n\n- **drive**\n- **appDataFolder**\n- **photos**\n"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#349/source-map",
+"@id": "amf://id#364/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -7632,7 +7667,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#349"
+"@value": "amf://id#364"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -7646,7 +7681,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -7658,7 +7693,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#349"
+"@value": "amf://id#364"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -7686,7 +7721,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#348/source-map",
+"@id": "amf://id#363/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -7694,7 +7729,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://www.w3.org/ns/hydra/core#required"
+"@value": "http://a.ml/vocabularies/apiContract#required"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -7706,7 +7741,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#348"
+"@value": "amf://id#363"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -7718,7 +7753,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -7732,36 +7767,36 @@
 ]
 }
 ],
-"http://a.ml/vocabularies/http#header": [
+"http://a.ml/vocabularies/apiContract#header": [
 {
-"@id": "amf://id#350",
+"@id": "amf://id#365",
 "@type": [
-"http://a.ml/vocabularies/http#Parameter",
+"http://a.ml/vocabularies/apiContract#Parameter",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://schema.org/name": [
+"http://a.ml/vocabularies/core#name": [
 {
 "@value": "x-test"
 }
 ],
-"http://a.ml/vocabularies/http#paramName": [
+"http://a.ml/vocabularies/apiContract#paramName": [
 {
 "@value": "x-test"
 }
 ],
-"http://www.w3.org/ns/hydra/core#required": [
+"http://a.ml/vocabularies/apiContract#required": [
 {
 "@value": true
 }
 ],
-"http://a.ml/vocabularies/http#binding": [
+"http://a.ml/vocabularies/apiContract#binding": [
 {
 "@value": "header"
 }
 ],
-"http://a.ml/vocabularies/http#schema": [
+"http://a.ml/vocabularies/apiContract#schema": [
 {
-"@id": "amf://id#351",
+"@id": "amf://id#366",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -7782,7 +7817,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#350/source-map",
+"@id": "amf://id#365/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -7790,7 +7825,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#350"
+"@value": "amf://id#365"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -7804,10 +7839,10 @@
 ]
 }
 ],
-"http://a.ml/vocabularies/http#payload": [],
+"http://a.ml/vocabularies/apiContract#payload": [],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#347/source-map",
+"@id": "amf://id#362/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -7815,7 +7850,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://a.ml/vocabularies/http#header"
+"@value": "http://a.ml/vocabularies/apiContract#header"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -7827,7 +7862,19 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://a.ml/vocabularies/http#parameter"
+"@value": "amf://id#362"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(319,0)-(332,0)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/apiContract#parameter"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -7843,7 +7890,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#346/source-map",
+"@id": "amf://id#361/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -7851,7 +7898,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -7863,7 +7910,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#346"
+"@value": "amf://id#361"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -7877,24 +7924,24 @@
 ]
 },
 {
-"@id": "amf://id#352",
+"@id": "amf://id#367",
 "@type": [
-"http://www.w3.org/ns/hydra/core#Operation",
+"http://a.ml/vocabularies/apiContract#Operation",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://www.w3.org/ns/hydra/core#method": [
+"http://a.ml/vocabularies/apiContract#method": [
 {
 "@value": "get"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "Dummy function"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#352/source-map",
+"@id": "amf://id#367/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -7902,7 +7949,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -7914,7 +7961,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#352"
+"@value": "amf://id#367"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -7930,7 +7977,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#345/source-map",
+"@id": "amf://id#360/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -7938,7 +7985,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#345"
+"@value": "amf://id#360"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -7952,7 +7999,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#345"
+"@value": "amf://id#360"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -7966,36 +8013,36 @@
 ]
 },
 {
-"@id": "amf://id#353",
+"@id": "amf://id#368",
 "@type": [
-"http://a.ml/vocabularies/http#EndPoint",
+"http://a.ml/vocabularies/apiContract#EndPoint",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://a.ml/vocabularies/http#path": [
+"http://a.ml/vocabularies/apiContract#path": [
 {
 "@value": "/permissionIds/{email}"
 }
 ],
-"http://www.w3.org/ns/hydra/core#supportedOperation": [
+"http://a.ml/vocabularies/apiContract#supportedOperation": [
 {
-"@id": "amf://id#354",
+"@id": "amf://id#369",
 "@type": [
-"http://www.w3.org/ns/hydra/core#Operation",
+"http://a.ml/vocabularies/apiContract#Operation",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://www.w3.org/ns/hydra/core#method": [
+"http://a.ml/vocabularies/apiContract#method": [
 {
 "@value": "get"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "Returns the permission ID for an email address."
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#354/source-map",
+"@id": "amf://id#369/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -8003,7 +8050,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -8015,7 +8062,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#354"
+"@value": "amf://id#369"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -8029,41 +8076,41 @@
 ]
 }
 ],
-"http://a.ml/vocabularies/http#parameter": [
+"http://a.ml/vocabularies/apiContract#parameter": [
 {
-"@id": "amf://id#355",
+"@id": "amf://id#370",
 "@type": [
-"http://a.ml/vocabularies/http#Parameter",
+"http://a.ml/vocabularies/apiContract#Parameter",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://schema.org/name": [
+"http://a.ml/vocabularies/core#name": [
 {
 "@value": "email"
 }
 ],
-"http://a.ml/vocabularies/http#paramName": [
+"http://a.ml/vocabularies/apiContract#paramName": [
 {
 "@value": "email"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "The email address for which to return a permission ID"
 }
 ],
-"http://www.w3.org/ns/hydra/core#required": [
+"http://a.ml/vocabularies/apiContract#required": [
 {
 "@value": true
 }
 ],
-"http://a.ml/vocabularies/http#binding": [
+"http://a.ml/vocabularies/apiContract#binding": [
 {
 "@value": "path"
 }
 ],
-"http://a.ml/vocabularies/http#schema": [
+"http://a.ml/vocabularies/apiContract#schema": [
 {
-"@id": "amf://id#356",
+"@id": "amf://id#371",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -8080,14 +8127,14 @@
 "@value": "schema"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "The email address for which to return a permission ID"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#356/source-map",
+"@id": "amf://id#371/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -8095,7 +8142,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#356"
+"@value": "amf://id#371"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -8109,7 +8156,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -8121,7 +8168,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#356"
+"@value": "amf://id#371"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -8149,7 +8196,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#355/source-map",
+"@id": "amf://id#370/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -8157,7 +8204,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -8169,7 +8216,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#355"
+"@value": "amf://id#370"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -8185,7 +8232,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#353/source-map",
+"@id": "amf://id#368/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -8193,7 +8240,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://a.ml/vocabularies/http#parameter"
+"@value": "http://a.ml/vocabularies/apiContract#parameter"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -8205,7 +8252,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#353"
+"@value": "amf://id#368"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -8219,41 +8266,41 @@
 ]
 },
 {
-"@id": "amf://id#357",
+"@id": "amf://id#372",
 "@type": [
-"http://a.ml/vocabularies/http#EndPoint",
+"http://a.ml/vocabularies/apiContract#EndPoint",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://a.ml/vocabularies/http#path": [
+"http://a.ml/vocabularies/apiContract#path": [
 {
 "@value": "/apps"
 }
 ],
-"http://schema.org/name": [
+"http://a.ml/vocabularies/core#name": [
 {
 "@value": "Apps"
 }
 ],
-"http://www.w3.org/ns/hydra/core#supportedOperation": [
+"http://a.ml/vocabularies/apiContract#supportedOperation": [
 {
-"@id": "amf://id#358",
+"@id": "amf://id#373",
 "@type": [
-"http://www.w3.org/ns/hydra/core#Operation",
+"http://a.ml/vocabularies/apiContract#Operation",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://www.w3.org/ns/hydra/core#method": [
+"http://a.ml/vocabularies/apiContract#method": [
 {
 "@value": "get"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "Lists a user's installed apps."
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#358/source-map",
+"@id": "amf://id#373/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -8261,7 +8308,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -8273,7 +8320,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#358"
+"@value": "amf://id#373"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -8289,7 +8336,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#357/source-map",
+"@id": "amf://id#372/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -8297,7 +8344,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/name"
+"@value": "http://a.ml/vocabularies/core#name"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -8309,7 +8356,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#357"
+"@value": "amf://id#372"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -8323,36 +8370,36 @@
 ]
 },
 {
-"@id": "amf://id#359",
+"@id": "amf://id#374",
 "@type": [
-"http://a.ml/vocabularies/http#EndPoint",
+"http://a.ml/vocabularies/apiContract#EndPoint",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://a.ml/vocabularies/http#path": [
+"http://a.ml/vocabularies/apiContract#path": [
 {
 "@value": "/apps/{appId}"
 }
 ],
-"http://www.w3.org/ns/hydra/core#supportedOperation": [
+"http://a.ml/vocabularies/apiContract#supportedOperation": [
 {
-"@id": "amf://id#360",
+"@id": "amf://id#375",
 "@type": [
-"http://www.w3.org/ns/hydra/core#Operation",
+"http://a.ml/vocabularies/apiContract#Operation",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://www.w3.org/ns/hydra/core#method": [
+"http://a.ml/vocabularies/apiContract#method": [
 {
 "@value": "get"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "Gets a specific app."
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#360/source-map",
+"@id": "amf://id#375/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -8360,7 +8407,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -8372,7 +8419,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#360"
+"@value": "amf://id#375"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -8386,41 +8433,41 @@
 ]
 }
 ],
-"http://a.ml/vocabularies/http#parameter": [
+"http://a.ml/vocabularies/apiContract#parameter": [
 {
-"@id": "amf://id#361",
+"@id": "amf://id#376",
 "@type": [
-"http://a.ml/vocabularies/http#Parameter",
+"http://a.ml/vocabularies/apiContract#Parameter",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://schema.org/name": [
+"http://a.ml/vocabularies/core#name": [
 {
 "@value": "appId"
 }
 ],
-"http://a.ml/vocabularies/http#paramName": [
+"http://a.ml/vocabularies/apiContract#paramName": [
 {
 "@value": "appId"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "The ID of the app."
 }
 ],
-"http://www.w3.org/ns/hydra/core#required": [
+"http://a.ml/vocabularies/apiContract#required": [
 {
 "@value": true
 }
 ],
-"http://a.ml/vocabularies/http#binding": [
+"http://a.ml/vocabularies/apiContract#binding": [
 {
 "@value": "path"
 }
 ],
-"http://a.ml/vocabularies/http#schema": [
+"http://a.ml/vocabularies/apiContract#schema": [
 {
-"@id": "amf://id#362",
+"@id": "amf://id#377",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -8437,14 +8484,14 @@
 "@value": "schema"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "The ID of the app."
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#362/source-map",
+"@id": "amf://id#377/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -8452,7 +8499,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#362"
+"@value": "amf://id#377"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -8466,7 +8513,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -8478,7 +8525,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#362"
+"@value": "amf://id#377"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -8506,7 +8553,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#361/source-map",
+"@id": "amf://id#376/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -8514,7 +8561,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -8526,7 +8573,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#361"
+"@value": "amf://id#376"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -8542,7 +8589,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#359/source-map",
+"@id": "amf://id#374/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -8550,7 +8597,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#359"
+"@value": "amf://id#374"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -8564,7 +8611,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://a.ml/vocabularies/http#parameter"
+"@value": "http://a.ml/vocabularies/apiContract#parameter"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -8576,7 +8623,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#359"
+"@value": "amf://id#374"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -8590,36 +8637,36 @@
 ]
 },
 {
-"@id": "amf://id#363",
+"@id": "amf://id#378",
 "@type": [
-"http://a.ml/vocabularies/http#EndPoint",
+"http://a.ml/vocabularies/apiContract#EndPoint",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://a.ml/vocabularies/http#path": [
+"http://a.ml/vocabularies/apiContract#path": [
 {
 "@value": "/channels/stop"
 }
 ],
-"http://www.w3.org/ns/hydra/core#supportedOperation": [
+"http://a.ml/vocabularies/apiContract#supportedOperation": [
 {
-"@id": "amf://id#364",
+"@id": "amf://id#379",
 "@type": [
-"http://www.w3.org/ns/hydra/core#Operation",
+"http://a.ml/vocabularies/apiContract#Operation",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://www.w3.org/ns/hydra/core#method": [
+"http://a.ml/vocabularies/apiContract#method": [
 {
 "@value": "post"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "Stop watching for changes to a resource.\nIf successful, this method returns an empty response body.\n"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#364/source-map",
+"@id": "amf://id#379/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -8627,7 +8674,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -8639,7 +8686,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#364"
+"@value": "amf://id#379"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -8655,668 +8702,6 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#363/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#363"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(353,0)-(358,0)]"
-}
-]
-}
-]
-}
-]
-},
-{
-"@id": "amf://id#365",
-"@type": [
-"http://a.ml/vocabularies/http#EndPoint",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://a.ml/vocabularies/http#path": [
-{
-"@value": "/teamdrives"
-}
-],
-"http://schema.org/name": [
-{
-"@value": "Teamdrives"
-}
-],
-"http://www.w3.org/ns/hydra/core#supportedOperation": [
-{
-"@id": "amf://id#366",
-"@type": [
-"http://www.w3.org/ns/hydra/core#Operation",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://www.w3.org/ns/hydra/core#method": [
-{
-"@value": "post"
-}
-],
-"http://schema.org/name": [
-{
-"@value": "insert"
-}
-],
-"http://schema.org/description": [
-{
-"@value": "Creates a new Team Drive."
-}
-],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "amf://id#366/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "http://schema.org/description"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(362,4)-(364,0)]"
-}
-]
-},
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#366"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(360,2)-(364,0)]"
-}
-]
-},
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "http://schema.org/name"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(361,4)-(362,0)]"
-}
-]
-}
-]
-}
-]
-},
-{
-"@id": "amf://id#367",
-"@type": [
-"http://www.w3.org/ns/hydra/core#Operation",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://www.w3.org/ns/hydra/core#method": [
-{
-"@value": "get"
-}
-],
-"http://schema.org/name": [
-{
-"@value": "list"
-}
-],
-"http://schema.org/description": [
-{
-"@value": "Lists the user's Team Drives."
-}
-],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "amf://id#367/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "http://schema.org/description"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(366,4)-(367,0)]"
-}
-]
-},
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#367"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(364,2)-(367,0)]"
-}
-]
-},
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "http://schema.org/name"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(365,4)-(366,0)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "amf://id#365/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "http://schema.org/name"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(359,2)-(360,0)]"
-}
-]
-},
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#365"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(358,0)-(378,0)]"
-}
-]
-}
-]
-}
-]
-},
-{
-"@id": "amf://id#368",
-"@type": [
-"http://a.ml/vocabularies/http#EndPoint",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://a.ml/vocabularies/http#path": [
-{
-"@value": "/teamdrives/{teamDriveId}"
-}
-],
-"http://www.w3.org/ns/hydra/core#supportedOperation": [
-{
-"@id": "amf://id#369",
-"@type": [
-"http://www.w3.org/ns/hydra/core#Operation",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://www.w3.org/ns/hydra/core#method": [
-{
-"@value": "delete"
-}
-],
-"http://schema.org/description": [
-{
-"@value": "Permanently deletes a Team Drive for which the user is an organizer. The Team Drive cannot contain any untrashed items.\n"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "amf://id#369/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "http://schema.org/description"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(372,6)-(374,0)]"
-}
-]
-},
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#369"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(371,4)-(374,0)]"
-}
-]
-}
-]
-}
-]
-},
-{
-"@id": "amf://id#370",
-"@type": [
-"http://www.w3.org/ns/hydra/core#Operation",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://www.w3.org/ns/hydra/core#method": [
-{
-"@value": "get"
-}
-],
-"http://schema.org/description": [
-{
-"@value": "Gets a Team Drive's metadata by ID."
-}
-],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "amf://id#370/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "http://schema.org/description"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(375,6)-(376,0)]"
-}
-]
-},
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#370"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(374,4)-(376,0)]"
-}
-]
-}
-]
-}
-]
-},
-{
-"@id": "amf://id#371",
-"@type": [
-"http://www.w3.org/ns/hydra/core#Operation",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://www.w3.org/ns/hydra/core#method": [
-{
-"@value": "put"
-}
-],
-"http://schema.org/description": [
-{
-"@value": "Updates a Team Drive's metadata"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "amf://id#371/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "http://schema.org/description"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(377,6)-(378,0)]"
-}
-]
-},
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#371"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(376,4)-(378,0)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"http://a.ml/vocabularies/http#parameter": [
-{
-"@id": "amf://id#372",
-"@type": [
-"http://a.ml/vocabularies/http#Parameter",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://schema.org/name": [
-{
-"@value": "teamDriveId"
-}
-],
-"http://a.ml/vocabularies/http#paramName": [
-{
-"@value": "teamDriveId"
-}
-],
-"http://schema.org/description": [
-{
-"@value": "The ID of the Team Drive"
-}
-],
-"http://www.w3.org/ns/hydra/core#required": [
-{
-"@value": true
-}
-],
-"http://a.ml/vocabularies/http#binding": [
-{
-"@value": "path"
-}
-],
-"http://a.ml/vocabularies/http#schema": [
-{
-"@id": "amf://id#373",
-"@type": [
-"http://a.ml/vocabularies/shapes#ScalarShape",
-"http://www.w3.org/ns/shacl#Shape",
-"http://a.ml/vocabularies/shapes#Shape",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://www.w3.org/ns/shacl#datatype": [
-{
-"@id": "http://www.w3.org/2001/XMLSchema#string"
-}
-],
-"http://www.w3.org/ns/shacl#name": [
-{
-"@value": "schema"
-}
-],
-"http://schema.org/description": [
-{
-"@value": "The ID of the Team Drive"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "amf://id#373/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "http://schema.org/description"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(370,8)-(371,0)]"
-}
-]
-},
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#373"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(369,6)-(371,0)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "amf://id#372/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "http://schema.org/description"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(370,8)-(371,0)]"
-}
-]
-},
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#372"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(369,6)-(371,0)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "amf://id#368/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#parent-end-point": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#368"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "file://test/demo-api/demo-api.raml#/web-api/end-points/%2Fteamdrives"
-}
-]
-}
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "http://a.ml/vocabularies/http#parameter"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(368,18)-(371,0)]"
-}
-]
-},
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#368"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(367,2)-(378,0)]"
-}
-]
-}
-]
-}
-]
-},
-{
-"@id": "amf://id#374",
-"@type": [
-"http://a.ml/vocabularies/http#EndPoint",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://a.ml/vocabularies/http#path": [
-{
-"@value": "/typeFromLibraryEndpoint"
-}
-],
-"http://www.w3.org/ns/hydra/core#supportedOperation": [
-{
-"@id": "amf://id#375",
-"@type": [
-"http://www.w3.org/ns/hydra/core#Operation",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://www.w3.org/ns/hydra/core#method": [
-{
-"@value": "post"
-}
-],
-"http://www.w3.org/ns/hydra/core#expects": [
-{
-"@id": "amf://id#376",
-"@type": [
-"http://a.ml/vocabularies/http#Request",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://a.ml/vocabularies/http#payload": [
-{
-"@id": "amf://id#377",
-"@type": [
-"http://a.ml/vocabularies/http#Payload",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://a.ml/vocabularies/http#mediaType": [
-{
-"@value": "application/json"
-}
-],
-"http://a.ml/vocabularies/http#schema": [
-{
-"@id": "amf://id#27/linked_2",
-"@type": [
-"http://www.w3.org/ns/shacl#NodeShape",
-"http://www.w3.org/ns/shacl#Shape",
-"http://a.ml/vocabularies/shapes#Shape",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://a.ml/vocabularies/document#link-target": [
-{
-"@id": "amf://id#27"
-}
-],
-"http://a.ml/vocabularies/document#link-label": [
-{
-"@value": "TypeFromLibray"
-}
-]
-}
-],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "amf://id#377/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#377"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(380,4)-(382,0)]"
-}
-]
-}
-]
-}
-]
-}
-]
-}
-],
-"http://www.w3.org/ns/hydra/core#returns": [
-{
-"@id": "amf://id#378",
-"@type": [
-"http://a.ml/vocabularies/http#Response",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://schema.org/name": [
-{
-"@value": "200"
-}
-],
-"http://www.w3.org/ns/hydra/core#statusCode": [
-{
-"@value": "200"
-}
-],
-"http://a.ml/vocabularies/http#payload": [],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
 "@id": "amf://id#378/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
@@ -9330,67 +8715,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
 {
-"@value": "[(383,6)-(384,0)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "amf://id#375/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "http://www.w3.org/ns/hydra/core#returns"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(382,4)-(384,0)]"
-}
-]
-},
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#375"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(379,2)-(384,0)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "amf://id#374/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#374"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(378,0)-(384,0)]"
+"@value": "[(353,0)-(358,0)]"
 }
 ]
 }
@@ -9398,67 +8723,110 @@
 }
 ]
 },
-{
-"@id": "amf://id#379",
-"@type": [
-"http://a.ml/vocabularies/http#EndPoint",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://a.ml/vocabularies/http#path": [
-{
-"@value": "/referenceId"
-}
-],
-"http://www.w3.org/ns/hydra/core#supportedOperation": [
 {
 "@id": "amf://id#380",
 "@type": [
-"http://www.w3.org/ns/hydra/core#Operation",
+"http://a.ml/vocabularies/apiContract#EndPoint",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://www.w3.org/ns/hydra/core#method": [
+"http://a.ml/vocabularies/apiContract#path": [
+{
+"@value": "/teamdrives"
+}
+],
+"http://a.ml/vocabularies/core#name": [
+{
+"@value": "Teamdrives"
+}
+],
+"http://a.ml/vocabularies/apiContract#supportedOperation": [
+{
+"@id": "amf://id#381",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Operation",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/apiContract#method": [
 {
 "@value": "post"
 }
 ],
-"http://www.w3.org/ns/hydra/core#expects": [
+"http://a.ml/vocabularies/core#name": [
 {
-"@id": "amf://id#381",
-"@type": [
-"http://a.ml/vocabularies/http#Request",
-"http://a.ml/vocabularies/document#DomainElement"
+"@value": "insert"
+}
 ],
-"http://a.ml/vocabularies/http#payload": [
+"http://a.ml/vocabularies/core#description": [
+{
+"@value": "Creates a new Team Drive."
+}
+],
+"http://a.ml/vocabularies/document-source-maps#sources": [
+{
+"@id": "amf://id#381/source-map",
+"@type": [
+"http://a.ml/vocabularies/document-source-maps#SourceMap"
+],
+"http://a.ml/vocabularies/document-source-maps#lexical": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/core#description"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(362,4)-(364,0)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#381"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(360,2)-(364,0)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/core#name"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(361,4)-(362,0)]"
+}
+]
+}
+]
+}
+]
+},
 {
 "@id": "amf://id#382",
 "@type": [
-"http://a.ml/vocabularies/http#Payload",
+"http://a.ml/vocabularies/apiContract#Operation",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://a.ml/vocabularies/http#mediaType": [
+"http://a.ml/vocabularies/apiContract#method": [
 {
-"@value": "application/json"
+"@value": "get"
 }
 ],
-"http://a.ml/vocabularies/http#schema": [
+"http://a.ml/vocabularies/core#name": [
 {
-"@id": "amf://id#128/linked_3",
-"@type": [
-"http://www.w3.org/ns/shacl#NodeShape",
-"http://www.w3.org/ns/shacl#Shape",
-"http://a.ml/vocabularies/shapes#Shape",
-"http://a.ml/vocabularies/document#DomainElement"
-],
-"http://a.ml/vocabularies/document#link-target": [
-{
-"@id": "amf://id#128"
+"@value": "list"
 }
 ],
-"http://a.ml/vocabularies/document#link-label": [
+"http://a.ml/vocabularies/core#description": [
 {
-"@value": "SchemaPerson"
-}
-]
+"@value": "Lists the user's Team Drives."
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
@@ -9471,14 +8839,36 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
+"@value": "http://a.ml/vocabularies/core#description"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(366,4)-(367,0)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
 "@value": "amf://id#382"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
 {
-"@value": "[(387,6)-(389,0)]"
+"@value": "[(364,2)-(367,0)]"
 }
 ]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/core#name"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(365,4)-(366,0)]"
 }
 ]
 }
@@ -9497,7 +8887,708 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
+"@value": "http://a.ml/vocabularies/core#name"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(359,2)-(360,0)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
 "@value": "amf://id#380"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(358,0)-(378,0)]"
+}
+]
+}
+]
+}
+]
+},
+{
+"@id": "amf://id#383",
+"@type": [
+"http://a.ml/vocabularies/apiContract#EndPoint",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/apiContract#path": [
+{
+"@value": "/teamdrives/{teamDriveId}"
+}
+],
+"http://a.ml/vocabularies/apiContract#supportedOperation": [
+{
+"@id": "amf://id#384",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Operation",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/apiContract#method": [
+{
+"@value": "delete"
+}
+],
+"http://a.ml/vocabularies/core#description": [
+{
+"@value": "Permanently deletes a Team Drive for which the user is an organizer. The Team Drive cannot contain any untrashed items.\n"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#sources": [
+{
+"@id": "amf://id#384/source-map",
+"@type": [
+"http://a.ml/vocabularies/document-source-maps#SourceMap"
+],
+"http://a.ml/vocabularies/document-source-maps#lexical": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/core#description"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(372,6)-(374,0)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#384"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(371,4)-(374,0)]"
+}
+]
+}
+]
+}
+]
+},
+{
+"@id": "amf://id#385",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Operation",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/apiContract#method": [
+{
+"@value": "get"
+}
+],
+"http://a.ml/vocabularies/core#description": [
+{
+"@value": "Gets a Team Drive's metadata by ID."
+}
+],
+"http://a.ml/vocabularies/document-source-maps#sources": [
+{
+"@id": "amf://id#385/source-map",
+"@type": [
+"http://a.ml/vocabularies/document-source-maps#SourceMap"
+],
+"http://a.ml/vocabularies/document-source-maps#lexical": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/core#description"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(375,6)-(376,0)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#385"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(374,4)-(376,0)]"
+}
+]
+}
+]
+}
+]
+},
+{
+"@id": "amf://id#386",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Operation",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/apiContract#method": [
+{
+"@value": "put"
+}
+],
+"http://a.ml/vocabularies/core#description": [
+{
+"@value": "Updates a Team Drive's metadata"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#sources": [
+{
+"@id": "amf://id#386/source-map",
+"@type": [
+"http://a.ml/vocabularies/document-source-maps#SourceMap"
+],
+"http://a.ml/vocabularies/document-source-maps#lexical": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/core#description"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(377,6)-(378,0)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#386"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(376,4)-(378,0)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"http://a.ml/vocabularies/apiContract#parameter": [
+{
+"@id": "amf://id#387",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Parameter",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/core#name": [
+{
+"@value": "teamDriveId"
+}
+],
+"http://a.ml/vocabularies/apiContract#paramName": [
+{
+"@value": "teamDriveId"
+}
+],
+"http://a.ml/vocabularies/core#description": [
+{
+"@value": "The ID of the Team Drive"
+}
+],
+"http://a.ml/vocabularies/apiContract#required": [
+{
+"@value": true
+}
+],
+"http://a.ml/vocabularies/apiContract#binding": [
+{
+"@value": "path"
+}
+],
+"http://a.ml/vocabularies/apiContract#schema": [
+{
+"@id": "amf://id#388",
+"@type": [
+"http://a.ml/vocabularies/shapes#ScalarShape",
+"http://www.w3.org/ns/shacl#Shape",
+"http://a.ml/vocabularies/shapes#Shape",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://www.w3.org/ns/shacl#datatype": [
+{
+"@id": "http://www.w3.org/2001/XMLSchema#string"
+}
+],
+"http://www.w3.org/ns/shacl#name": [
+{
+"@value": "schema"
+}
+],
+"http://a.ml/vocabularies/core#description": [
+{
+"@value": "The ID of the Team Drive"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#sources": [
+{
+"@id": "amf://id#388/source-map",
+"@type": [
+"http://a.ml/vocabularies/document-source-maps#SourceMap"
+],
+"http://a.ml/vocabularies/document-source-maps#lexical": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/core#description"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(370,8)-(371,0)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#388"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(369,6)-(371,0)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"http://a.ml/vocabularies/document-source-maps#sources": [
+{
+"@id": "amf://id#387/source-map",
+"@type": [
+"http://a.ml/vocabularies/document-source-maps#SourceMap"
+],
+"http://a.ml/vocabularies/document-source-maps#lexical": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/core#description"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(370,8)-(371,0)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#387"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(369,6)-(371,0)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"http://a.ml/vocabularies/document-source-maps#sources": [
+{
+"@id": "amf://id#383/source-map",
+"@type": [
+"http://a.ml/vocabularies/document-source-maps#SourceMap"
+],
+"http://a.ml/vocabularies/document-source-maps#parent-end-point": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#383"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "file://test/demo-api/demo-api.raml#/web-api/end-points/%2Fteamdrives"
+}
+]
+}
+],
+"http://a.ml/vocabularies/document-source-maps#lexical": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/apiContract#parameter"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(368,18)-(371,0)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#383"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(367,2)-(378,0)]"
+}
+]
+}
+]
+}
+]
+},
+{
+"@id": "amf://id#389",
+"@type": [
+"http://a.ml/vocabularies/apiContract#EndPoint",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/apiContract#path": [
+{
+"@value": "/typeFromLibraryEndpoint"
+}
+],
+"http://a.ml/vocabularies/apiContract#supportedOperation": [
+{
+"@id": "amf://id#390",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Operation",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/apiContract#method": [
+{
+"@value": "post"
+}
+],
+"http://a.ml/vocabularies/apiContract#expects": [
+{
+"@id": "amf://id#391",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Request",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/apiContract#payload": [
+{
+"@id": "amf://id#392",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Payload",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/apiContract#mediaType": [
+{
+"@value": "application/json"
+}
+],
+"http://a.ml/vocabularies/apiContract#schema": [
+{
+"@id": "amf://id#29/linked_2",
+"@type": [
+"http://www.w3.org/ns/shacl#NodeShape",
+"http://www.w3.org/ns/shacl#Shape",
+"http://a.ml/vocabularies/shapes#Shape",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/document#link-target": [
+{
+"@id": "amf://id#29"
+}
+],
+"http://a.ml/vocabularies/document#link-label": [
+{
+"@value": "TypeFromLibray"
+}
+]
+}
+],
+"http://a.ml/vocabularies/document-source-maps#sources": [
+{
+"@id": "amf://id#392/source-map",
+"@type": [
+"http://a.ml/vocabularies/document-source-maps#SourceMap"
+],
+"http://a.ml/vocabularies/document-source-maps#lexical": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#392"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(380,4)-(382,0)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"http://a.ml/vocabularies/document-source-maps#sources": [
+{
+"@id": "amf://id#391/source-map",
+"@type": [
+"http://a.ml/vocabularies/document-source-maps#SourceMap"
+],
+"http://a.ml/vocabularies/document-source-maps#lexical": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#391"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(380,0)-(384,0)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"http://a.ml/vocabularies/apiContract#returns": [
+{
+"@id": "amf://id#393",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Response",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/core#name": [
+{
+"@value": "200"
+}
+],
+"http://a.ml/vocabularies/apiContract#statusCode": [
+{
+"@value": "200"
+}
+],
+"http://a.ml/vocabularies/apiContract#payload": [],
+"http://a.ml/vocabularies/document-source-maps#sources": [
+{
+"@id": "amf://id#393/source-map",
+"@type": [
+"http://a.ml/vocabularies/document-source-maps#SourceMap"
+],
+"http://a.ml/vocabularies/document-source-maps#lexical": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#393"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(383,6)-(384,0)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"http://a.ml/vocabularies/document-source-maps#sources": [
+{
+"@id": "amf://id#390/source-map",
+"@type": [
+"http://a.ml/vocabularies/document-source-maps#SourceMap"
+],
+"http://a.ml/vocabularies/document-source-maps#lexical": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/apiContract#returns"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(382,4)-(384,0)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#390"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(379,2)-(384,0)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"http://a.ml/vocabularies/document-source-maps#sources": [
+{
+"@id": "amf://id#389/source-map",
+"@type": [
+"http://a.ml/vocabularies/document-source-maps#SourceMap"
+],
+"http://a.ml/vocabularies/document-source-maps#lexical": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#389"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(378,0)-(384,0)]"
+}
+]
+}
+]
+}
+]
+},
+{
+"@id": "amf://id#394",
+"@type": [
+"http://a.ml/vocabularies/apiContract#EndPoint",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/apiContract#path": [
+{
+"@value": "/referenceId"
+}
+],
+"http://a.ml/vocabularies/apiContract#supportedOperation": [
+{
+"@id": "amf://id#395",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Operation",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/apiContract#method": [
+{
+"@value": "post"
+}
+],
+"http://a.ml/vocabularies/apiContract#expects": [
+{
+"@id": "amf://id#396",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Request",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/apiContract#payload": [
+{
+"@id": "amf://id#397",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Payload",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/apiContract#mediaType": [
+{
+"@value": "application/json"
+}
+],
+"http://a.ml/vocabularies/apiContract#schema": [
+{
+"@id": "amf://id#141/linked_3",
+"@type": [
+"http://www.w3.org/ns/shacl#NodeShape",
+"http://www.w3.org/ns/shacl#Shape",
+"http://a.ml/vocabularies/shapes#Shape",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/document#link-target": [
+{
+"@id": "amf://id#141"
+}
+],
+"http://a.ml/vocabularies/document#link-label": [
+{
+"@value": "SchemaPerson"
+}
+]
+}
+],
+"http://a.ml/vocabularies/document-source-maps#sources": [
+{
+"@id": "amf://id#397/source-map",
+"@type": [
+"http://a.ml/vocabularies/document-source-maps#SourceMap"
+],
+"http://a.ml/vocabularies/document-source-maps#lexical": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#397"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(387,6)-(389,0)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"http://a.ml/vocabularies/document-source-maps#sources": [
+{
+"@id": "amf://id#396/source-map",
+"@type": [
+"http://a.ml/vocabularies/document-source-maps#SourceMap"
+],
+"http://a.ml/vocabularies/document-source-maps#lexical": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#396"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(386,0)-(389,0)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"http://a.ml/vocabularies/document-source-maps#sources": [
+{
+"@id": "amf://id#395/source-map",
+"@type": [
+"http://a.ml/vocabularies/document-source-maps#SourceMap"
+],
+"http://a.ml/vocabularies/document-source-maps#lexical": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#395"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -9513,7 +9604,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#379/source-map",
+"@id": "amf://id#394/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -9521,7 +9612,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#379"
+"@value": "amf://id#394"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -9537,7 +9628,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#202/source-map",
+"@id": "amf://id#216/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -9545,7 +9636,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#202"
+"@value": "amf://id#216"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -9559,7 +9650,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/documentation"
+"@value": "http://a.ml/vocabularies/core#documentation"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -9571,7 +9662,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://a.ml/vocabularies/http#scheme"
+"@value": "http://a.ml/vocabularies/apiContract#scheme"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -9583,7 +9674,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/name"
+"@value": "http://a.ml/vocabularies/core#name"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -9595,7 +9686,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#202"
+"@value": "amf://id#216"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -9607,7 +9698,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://a.ml/vocabularies/http#server"
+"@value": "http://a.ml/vocabularies/apiContract#server"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -9619,7 +9710,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/version"
+"@value": "http://a.ml/vocabularies/core#version"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -9687,7 +9778,7 @@
 "@value": "width"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "Width of the shape.\n"
 }
@@ -9716,7 +9807,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -9818,7 +9909,7 @@
 "@value": "height"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "Height of the shape.\n"
 }
@@ -9847,7 +9938,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -9949,7 +10040,7 @@
 "@value": "unit?"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "A unit that describes the dimension. It can be, for example, `px` for\npixels, `pt` for points, `%` for percentage.\n"
 }
@@ -9958,7 +10049,9 @@
 {
 "@id": "amf://id#9",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -10055,7 +10148,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -10108,16 +10201,23 @@
 "@value": "dimension"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "A dimmensions of an object like image.\n"
 }
 ],
-"http://a.ml/vocabularies/document#examples": [
+"http://a.ml/vocabularies/apiContract#examples": [
 {
 "@id": "amf://id#10",
 "@type": [
-"http://a.ml/vocabularies/document#Example",
+"http://a.ml/vocabularies/apiContract#NamedExamples",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/apiContract#examples": [
+{
+"@id": "amf://id#11",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Example",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/document#strict": [
@@ -10127,55 +10227,23 @@
 ],
 "http://a.ml/vocabularies/document#structuredValue": [
 {
-"@id": "amf://id#10",
+"@id": "amf://id#11",
 "@type": [
-"http://a.ml/vocabularies/data#Object"
+"http://a.ml/vocabularies/data#Object",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#height": [
 {
-"@id": "amf://id#11",
+"@id": "amf://id#12",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
 "@value": "160",
-"@type": "http://www.w3.org/2001/XMLSchema#integer"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "amf://id#11/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#11"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(24,10)-(24,13)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"http://a.ml/vocabularies/data#width": [
-{
-"@id": "amf://id#12",
-"@type": [
-"http://a.ml/vocabularies/data#Scalar"
-],
-"http://a.ml/vocabularies/data#value": [
-{
-"@value": "200",
 "@type": "http://www.w3.org/2001/XMLSchema#integer"
 }
 ],
@@ -10194,6 +10262,44 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
 {
+"@value": "[(24,10)-(24,13)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"http://a.ml/vocabularies/data#width": [
+{
+"@id": "amf://id#13",
+"@type": [
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/data#value": [
+{
+"@value": "200",
+"@type": "http://www.w3.org/2001/XMLSchema#integer"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#sources": [
+{
+"@id": "amf://id#13/source-map",
+"@type": [
+"http://a.ml/vocabularies/document-source-maps#SourceMap"
+],
+"http://a.ml/vocabularies/document-source-maps#lexical": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#13"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
 "@value": "[(23,9)-(23,12)]"
 }
 ]
@@ -10205,7 +10311,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#10/source-map",
+"@id": "amf://id#11/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -10213,12 +10319,36 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#10"
+"@value": "http://a.ml/vocabularies/data#width"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(23,9)-(23,12)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#11"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
 {
 "@value": "[(23,0)-(25,0)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/data#height"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(24,10)-(24,13)]"
 }
 ]
 }
@@ -10227,7 +10357,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#10"
+"@value": "amf://id#11"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -10248,7 +10378,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#10/source-map",
+"@id": "amf://id#11/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -10282,12 +10412,14 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#10"
+"@value": "amf://id#11"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
 {
 "@value": "[(22,0)-(25,0)]"
+}
+]
 }
 ]
 }
@@ -10320,7 +10452,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -10384,7 +10516,7 @@
 ]
 },
 {
-"@id": "amf://id#13",
+"@id": "amf://id#14",
 "@type": [
 "http://a.ml/vocabularies/document#ExternalFragment",
 "http://a.ml/vocabularies/document#Fragment",
@@ -10392,7 +10524,7 @@
 ],
 "http://a.ml/vocabularies/document#encodes": [
 {
-"@id": "amf://id#14",
+"@id": "amf://id#15",
 "@type": [
 "http://a.ml/vocabularies/document#ExternalDomainElement",
 "http://a.ml/vocabularies/document#DomainElement"
@@ -10402,7 +10534,7 @@
 "@value": "{\n  \"$id\": \"http://example.com/example.json\",\n  \"type\": \"object\",\n  \"definitions\": {},\n  \"$schema\": \"http://json-schema.org/draft-07/schema#\",\n  \"properties\": {\n    \"id\": {\n      \"$id\": \"/properties/id\",\n      \"type\": \"string\",\n      \"title\": \"The Id Schema \",\n      \"default\": \"\",\n      \"examples\": [\n        \"R34fg663H9KW9MMSKISI\"\n      ]\n    },\n    \"name\": {\n      \"$id\": \"/properties/name\",\n      \"type\": \"string\",\n      \"title\": \"The Name Schema \",\n      \"default\": \"\",\n      \"examples\": [\n        \"Pawel Psztyc\"\n      ]\n    },\n    \"birthday\": {\n      \"$id\": \"/properties/birthday\",\n      \"type\": \"string\",\n      \"title\": \"The Birthday Schema \",\n      \"default\": \"\",\n      \"examples\": [\n        \"1983-10-20\"\n      ]\n    },\n    \"gender\": {\n      \"$id\": \"/properties/gender\",\n      \"type\": \"string\",\n      \"title\": \"The Gender Schema \",\n      \"default\": \"\",\n      \"examples\": [\n        \"male\"\n      ]\n    },\n    \"url\": {\n      \"$id\": \"/properties/url\",\n      \"type\": \"string\",\n      \"title\": \"The Url Schema \",\n      \"default\": \"\",\n      \"examples\": [\n        \"https://domain.com/profile/pawel.psztyc\"\n      ]\n    },\n    \"image\": {\n      \"$id\": \"/properties/image\",\n      \"type\": \"object\",\n      \"properties\": {\n        \"url\": {\n          \"$id\": \"/properties/image/properties/url\",\n          \"type\": \"string\",\n          \"title\": \"The Url Schema \",\n          \"default\": \"\",\n          \"examples\": [\n            \"https://domain.com/profile/pawel.psztyc/image\"\n          ]\n        },\n        \"thumb\": {\n          \"$id\": \"/properties/image/properties/thumb\",\n          \"type\": \"string\",\n          \"title\": \"The Thumb Schema \",\n          \"default\": \"\",\n          \"examples\": [\n            \"https://domain.com/profile/pawel.psztyc/image/thumb\"\n          ]\n        }\n      }\n    },\n    \"tagline\": {\n      \"$id\": \"/properties/tagline\",\n      \"type\": \"string\",\n      \"title\": \"The Tagline Schema \",\n      \"default\": \"\",\n      \"examples\": [\n        \"Some text about me.\"\n      ]\n    },\n    \"language\": {\n      \"$id\": \"/properties/language\",\n      \"type\": \"string\",\n      \"title\": \"The Language Schema \",\n      \"default\": \"\",\n      \"examples\": [\n        \"en_GB\"\n      ]\n    },\n    \"etag\": {\n      \"$id\": \"/properties/etag\",\n      \"type\": \"string\",\n      \"title\": \"The Etag Schema \",\n      \"default\": \"\",\n      \"examples\": [\n        \"W\\\\244m4n5kj3gbn2nj4k4n4\"\n      ]\n    }\n  }\n}\n"
 }
 ],
-"http://a.ml/vocabularies/http#mediaType": [
+"http://a.ml/vocabularies/core#mediaType": [
 {
 "@value": "application/json"
 }
@@ -10411,7 +10543,7 @@
 ]
 },
 {
-"@id": "amf://id#15",
+"@id": "amf://id#16",
 "@type": [
 "http://a.ml/vocabularies/document#ExternalFragment",
 "http://a.ml/vocabularies/document#Fragment",
@@ -10419,7 +10551,7 @@
 ],
 "http://a.ml/vocabularies/document#encodes": [
 {
-"@id": "amf://id#16",
+"@id": "amf://id#17",
 "@type": [
 "http://a.ml/vocabularies/document#ExternalDomainElement",
 "http://a.ml/vocabularies/document#DomainElement"
@@ -10429,7 +10561,7 @@
 "@value": "{\n  \"id\": \"R34fg663H9KW9MMSKISI\",\n  \"name\": \"Pawel Psztyc\",\n  \"birthday\": \"1983-10-20\",\n  \"gender\": \"male\",\n  \"url\": \"https://domain.com/profile/pawel.psztyc\",\n  \"image\": {\n    \"url\": \"https://domain.com/profile/pawel.psztyc/image\",\n    \"thumb\": \"https://domain.com/profile/pawel.psztyc/image/thumb\"\n  },\n  \"tagline\": \"Some text about me.\",\n  \"language\": \"en_GB\",\n  \"etag\": \"W\\\\244m4n5kj3gbn2nj4k4n4\"\n}\n"
 }
 ],
-"http://a.ml/vocabularies/http#mediaType": [
+"http://a.ml/vocabularies/core#mediaType": [
 {
 "@value": "application/json"
 }
@@ -10438,7 +10570,7 @@
 ]
 },
 {
-"@id": "amf://id#17",
+"@id": "amf://id#18",
 "@type": [
 "http://a.ml/vocabularies/document#DataType",
 "http://a.ml/vocabularies/document#Fragment",
@@ -10446,7 +10578,7 @@
 ],
 "http://a.ml/vocabularies/document#encodes": [
 {
-"@id": "amf://id#18",
+"@id": "amf://id#19",
 "@type": [
 "http://www.w3.org/ns/shacl#NodeShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -10460,7 +10592,7 @@
 ],
 "http://www.w3.org/ns/shacl#property": [
 {
-"@id": "amf://id#19",
+"@id": "amf://id#20",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -10473,7 +10605,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#20",
+"@id": "amf://id#21",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -10490,14 +10622,14 @@
 "@value": "url"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "The URL of the image.\nTo resize the image and crop it to a square, append the query string **?sz=x**, where x is the dimension in pixels of each side.\n"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#20/source-map",
+"@id": "amf://id#21/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -10505,7 +10637,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#20"
+"@value": "amf://id#21"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -10519,7 +10651,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -10531,7 +10663,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#20"
+"@value": "amf://id#21"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -10569,7 +10701,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#19/source-map",
+"@id": "amf://id#20/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -10577,7 +10709,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#19"
+"@value": "amf://id#20"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -10591,7 +10723,7 @@
 ]
 },
 {
-"@id": "amf://id#21",
+"@id": "amf://id#22",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -10604,7 +10736,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#22",
+"@id": "amf://id#23",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -10621,19 +10753,19 @@
 "@value": "thumb"
 }
 ],
-"http://schema.org/name": [
+"http://a.ml/vocabularies/core#name": [
 {
 "@value": "Thumbnail"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "An URL to the thumbnail of the image. Thumbnails are 60x60px cropped images of the original image.\n"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#22/source-map",
+"@id": "amf://id#23/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -10641,7 +10773,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#22"
+"@value": "amf://id#23"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -10655,7 +10787,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -10679,7 +10811,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#22"
+"@value": "amf://id#23"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -10691,7 +10823,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/name"
+"@value": "http://a.ml/vocabularies/core#name"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -10717,7 +10849,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#21/source-map",
+"@id": "amf://id#22/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -10725,7 +10857,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#21"
+"@value": "amf://id#22"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -10744,16 +10876,23 @@
 "@value": "image"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "An image object representing an image object strored in the file store.\nThe image can be only included in the response. It has no effect if the Image appear in the\nrequest. Endpoint handles image creation on it's own and clients can't process images\nexcept of sending image data.\n"
 }
 ],
-"http://a.ml/vocabularies/document#examples": [
+"http://a.ml/vocabularies/apiContract#examples": [
 {
-"@id": "amf://id#23",
+"@id": "amf://id#24",
 "@type": [
-"http://a.ml/vocabularies/document#Example",
+"http://a.ml/vocabularies/apiContract#NamedExamples",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/apiContract#examples": [
+{
+"@id": "amf://id#25",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Example",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/document#strict": [
@@ -10763,15 +10902,19 @@
 ],
 "http://a.ml/vocabularies/document#structuredValue": [
 {
-"@id": "amf://id#23",
+"@id": "amf://id#25",
 "@type": [
-"http://a.ml/vocabularies/data#Object"
+"http://a.ml/vocabularies/data#Object",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#thumb": [
 {
-"@id": "amf://id#24",
+"@id": "amf://id#26",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -10781,7 +10924,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#24/source-map",
+"@id": "amf://id#26/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -10789,7 +10932,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#24"
+"@value": "amf://id#26"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -10805,9 +10948,11 @@
 ],
 "http://a.ml/vocabularies/data#url": [
 {
-"@id": "amf://id#25",
+"@id": "amf://id#27",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -10817,7 +10962,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#25/source-map",
+"@id": "amf://id#27/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -10825,7 +10970,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#25"
+"@value": "amf://id#27"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -10841,7 +10986,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#23/source-map",
+"@id": "amf://id#25/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -10849,12 +10994,36 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#23"
+"@value": "http://a.ml/vocabularies/data#url"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(22,7)-(22,52)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#25"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
 {
 "@value": "[(22,0)-(24,0)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/data#thumb"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(23,9)-(23,60)]"
 }
 ]
 }
@@ -10863,7 +11032,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#23"
+"@value": "amf://id#25"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -10884,7 +11053,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#23/source-map",
+"@id": "amf://id#25/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -10918,7 +11087,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#23"
+"@value": "amf://id#25"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -10931,10 +11100,12 @@
 }
 ]
 }
+]
+}
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#18/source-map",
+"@id": "amf://id#19/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -10942,7 +11113,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#18"
+"@value": "amf://id#19"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -10956,7 +11127,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -10968,7 +11139,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#18"
+"@value": "amf://id#19"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -10982,7 +11153,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#18"
+"@value": "amf://id#19"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -10998,7 +11169,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#17/source-map",
+"@id": "amf://id#18/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -11006,7 +11177,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#17"
+"@value": "amf://id#18"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -11020,7 +11191,7 @@
 ]
 },
 {
-"@id": "amf://id#26",
+"@id": "amf://id#28",
 "@type": [
 "http://a.ml/vocabularies/document#Module",
 "http://a.ml/vocabularies/document#Unit"
@@ -11028,7 +11199,7 @@
 "http://a.ml/vocabularies/document#declares": [
 [
 {
-"@id": "amf://id#27/linked_3",
+"@id": "amf://id#29/linked_3",
 "@type": [
 "http://www.w3.org/ns/shacl#NodeShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -11037,7 +11208,7 @@
 ],
 "http://a.ml/vocabularies/document#link-target": [
 {
-"@id": "amf://id#27"
+"@id": "amf://id#29"
 }
 ],
 "http://a.ml/vocabularies/document#link-label": [
@@ -11055,7 +11226,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#26/source-map",
+"@id": "amf://id#28/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -11063,7 +11234,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#26"
+"@value": "amf://id#28"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -11089,7 +11260,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#26"
+"@value": "amf://id#28"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -11103,7 +11274,7 @@
 ]
 },
 {
-"@id": "amf://id#30",
+"@id": "amf://id#32",
 "@type": [
 "http://a.ml/vocabularies/document#DataType",
 "http://a.ml/vocabularies/document#Fragment",
@@ -11111,7 +11282,7 @@
 ],
 "http://a.ml/vocabularies/document#encodes": [
 {
-"@id": "amf://id#31",
+"@id": "amf://id#37",
 "@type": [
 "http://www.w3.org/ns/shacl#NodeShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -11125,7 +11296,7 @@
 ],
 "http://www.w3.org/ns/shacl#property": [
 {
-"@id": "amf://id#32",
+"@id": "amf://id#38",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -11138,7 +11309,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#33",
+"@id": "amf://id#39",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -11155,14 +11326,14 @@
 "@value": "favouriteTime"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "The person's favourite time of day"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#33/source-map",
+"@id": "amf://id#39/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -11170,7 +11341,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#33"
+"@value": "amf://id#39"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -11184,7 +11355,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -11196,7 +11367,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#33"
+"@value": "amf://id#39"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -11234,7 +11405,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#32/source-map",
+"@id": "amf://id#38/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -11242,7 +11413,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#32"
+"@value": "amf://id#38"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -11256,7 +11427,7 @@
 ]
 },
 {
-"@id": "amf://id#34",
+"@id": "amf://id#40",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -11269,7 +11440,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#35",
+"@id": "amf://id#41",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -11301,16 +11472,23 @@
 "@value": "favouriteNumber"
 }
 ],
-"http://schema.org/name": [
+"http://a.ml/vocabularies/core#name": [
 {
 "@value": "Favourite number"
 }
 ],
-"http://a.ml/vocabularies/document#examples": [
+"http://a.ml/vocabularies/apiContract#examples": [
 {
-"@id": "amf://id#36",
+"@id": "amf://id#42",
 "@type": [
-"http://a.ml/vocabularies/document#Example",
+"http://a.ml/vocabularies/apiContract#NamedExamples",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/apiContract#examples": [
+{
+"@id": "amf://id#43",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Example",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/document#strict": [
@@ -11320,9 +11498,11 @@
 ],
 "http://a.ml/vocabularies/document#structuredValue": [
 {
-"@id": "amf://id#36",
+"@id": "amf://id#43",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -11332,7 +11512,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#36/source-map",
+"@id": "amf://id#43/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -11340,7 +11520,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#36"
+"@value": "amf://id#43"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -11361,7 +11541,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#36/source-map",
+"@id": "amf://id#43/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -11395,7 +11575,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#36"
+"@value": "amf://id#43"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -11408,10 +11588,12 @@
 }
 ]
 }
+]
+}
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#35/source-map",
+"@id": "amf://id#41/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -11419,7 +11601,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#35"
+"@value": "amf://id#41"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -11433,7 +11615,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/name"
+"@value": "http://a.ml/vocabularies/core#name"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -11469,7 +11651,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#35"
+"@value": "amf://id#41"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -11519,7 +11701,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#34/source-map",
+"@id": "amf://id#40/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -11539,7 +11721,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#34"
+"@value": "amf://id#40"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -11553,7 +11735,7 @@
 ]
 },
 {
-"@id": "amf://id#37",
+"@id": "amf://id#44",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -11566,7 +11748,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#38",
+"@id": "amf://id#45",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -11585,9 +11767,11 @@
 ],
 "http://www.w3.org/ns/shacl#defaultValue": [
 {
-"@id": "amf://id#39",
+"@id": "amf://id#46",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -11597,7 +11781,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#39/source-map",
+"@id": "amf://id#46/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -11605,7 +11789,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#39"
+"@value": "amf://id#46"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -11626,7 +11810,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#38/source-map",
+"@id": "amf://id#45/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -11634,7 +11818,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#38"
+"@value": "amf://id#45"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -11660,7 +11844,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#38"
+"@value": "amf://id#45"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -11698,7 +11882,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#37/source-map",
+"@id": "amf://id#44/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -11718,7 +11902,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#37"
+"@value": "amf://id#44"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -11732,7 +11916,7 @@
 ]
 },
 {
-"@id": "amf://id#40",
+"@id": "amf://id#47",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -11745,7 +11929,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#41",
+"@id": "amf://id#48",
 "@type": [
 "http://a.ml/vocabularies/shapes#FileShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -11777,7 +11961,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#41/source-map",
+"@id": "amf://id#48/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -11785,7 +11969,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#41"
+"@value": "amf://id#48"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -11823,7 +12007,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#41"
+"@value": "amf://id#48"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -11861,7 +12045,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#40/source-map",
+"@id": "amf://id#47/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -11881,7 +12065,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#40"
+"@value": "amf://id#47"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -11895,7 +12079,7 @@
 ]
 },
 {
-"@id": "amf://id#42",
+"@id": "amf://id#35",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -11908,7 +12092,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#43",
+"@id": "amf://id#36",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -11925,14 +12109,14 @@
 "@value": "etag"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "ETag of this resource for caching purposes.\n__This property will be ignored when creating an object.__\n"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#43/source-map",
+"@id": "amf://id#36/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -11940,7 +12124,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#43"
+"@value": "amf://id#36"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -11954,7 +12138,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -11966,7 +12150,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#43"
+"@value": "amf://id#36"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -12004,7 +12188,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#42/source-map",
+"@id": "amf://id#35/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -12012,7 +12196,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#42"
+"@value": "amf://id#35"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -12026,7 +12210,7 @@
 ]
 },
 {
-"@id": "amf://id#44",
+"@id": "amf://id#49",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -12039,7 +12223,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#45",
+"@id": "amf://id#50",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -12056,14 +12240,14 @@
 "@value": "tagline"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "The brief description (tagline) of this person."
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#45/source-map",
+"@id": "amf://id#50/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -12071,7 +12255,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#45"
+"@value": "amf://id#50"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -12085,7 +12269,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -12097,7 +12281,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#45"
+"@value": "amf://id#50"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -12135,7 +12319,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#44/source-map",
+"@id": "amf://id#49/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -12143,7 +12327,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#44"
+"@value": "amf://id#49"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -12157,7 +12341,7 @@
 ]
 },
 {
-"@id": "amf://id#46",
+"@id": "amf://id#51",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -12170,7 +12354,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#47",
+"@id": "amf://id#52",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -12192,16 +12376,23 @@
 "@value": "name"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "Person full name. The input will be rejected if this property is not set while creating new object."
 }
 ],
-"http://a.ml/vocabularies/document#examples": [
+"http://a.ml/vocabularies/apiContract#examples": [
 {
-"@id": "amf://id#48",
+"@id": "amf://id#53",
 "@type": [
-"http://a.ml/vocabularies/document#Example",
+"http://a.ml/vocabularies/apiContract#NamedExamples",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/apiContract#examples": [
+{
+"@id": "amf://id#54",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Example",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/document#strict": [
@@ -12211,9 +12402,11 @@
 ],
 "http://a.ml/vocabularies/document#structuredValue": [
 {
-"@id": "amf://id#48",
+"@id": "amf://id#54",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -12223,7 +12416,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#48/source-map",
+"@id": "amf://id#54/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -12231,7 +12424,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#48"
+"@value": "amf://id#54"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -12252,7 +12445,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#48/source-map",
+"@id": "amf://id#54/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -12286,7 +12479,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#48"
+"@value": "amf://id#54"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -12299,10 +12492,12 @@
 }
 ]
 }
+]
+}
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#47/source-map",
+"@id": "amf://id#52/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -12310,7 +12505,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#47"
+"@value": "amf://id#52"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -12324,7 +12519,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -12348,7 +12543,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#47"
+"@value": "amf://id#52"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -12386,7 +12581,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#46/source-map",
+"@id": "amf://id#51/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -12406,7 +12601,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#46"
+"@value": "amf://id#51"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -12420,7 +12615,7 @@
 ]
 },
 {
-"@id": "amf://id#49",
+"@id": "amf://id#55",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -12433,7 +12628,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#50",
+"@id": "amf://id#56",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -12450,11 +12645,18 @@
 "@value": "created"
 }
 ],
-"http://a.ml/vocabularies/document#examples": [
+"http://a.ml/vocabularies/apiContract#examples": [
 {
-"@id": "amf://id#51",
+"@id": "amf://id#57",
 "@type": [
-"http://a.ml/vocabularies/document#Example",
+"http://a.ml/vocabularies/apiContract#NamedExamples",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/apiContract#examples": [
+{
+"@id": "amf://id#58",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Example",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/document#strict": [
@@ -12464,9 +12666,11 @@
 ],
 "http://a.ml/vocabularies/document#structuredValue": [
 {
-"@id": "amf://id#51",
+"@id": "amf://id#58",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -12476,7 +12680,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#51/source-map",
+"@id": "amf://id#58/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -12484,7 +12688,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#51"
+"@value": "amf://id#58"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -12505,7 +12709,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#51/source-map",
+"@id": "amf://id#58/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -12539,7 +12743,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#51"
+"@value": "amf://id#58"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -12552,10 +12756,12 @@
 }
 ]
 }
+]
+}
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#50/source-map",
+"@id": "amf://id#56/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -12563,7 +12769,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#50"
+"@value": "amf://id#56"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -12589,7 +12795,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#50"
+"@value": "amf://id#56"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -12615,7 +12821,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#49/source-map",
+"@id": "amf://id#55/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -12635,7 +12841,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#49"
+"@value": "amf://id#55"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -12649,7 +12855,7 @@
 ]
 },
 {
-"@id": "amf://id#52",
+"@id": "amf://id#59",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -12662,7 +12868,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#53",
+"@id": "amf://id#60",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -12679,14 +12885,14 @@
 "@value": "url"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "The URL of this person's profile."
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#53/source-map",
+"@id": "amf://id#60/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -12694,7 +12900,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#53"
+"@value": "amf://id#60"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -12708,7 +12914,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -12720,7 +12926,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#53"
+"@value": "amf://id#60"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -12758,7 +12964,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#52/source-map",
+"@id": "amf://id#59/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -12766,7 +12972,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#52"
+"@value": "amf://id#59"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -12780,7 +12986,7 @@
 ]
 },
 {
-"@id": "amf://id#54",
+"@id": "amf://id#61",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -12793,7 +12999,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#55",
+"@id": "amf://id#62",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -12825,14 +13031,14 @@
 "@value": "id"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "A unique identifier of a person.\n\nIt is a 32 bit string containing alphanumeric characters.\n"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#55/source-map",
+"@id": "amf://id#62/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -12840,7 +13046,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -12864,7 +13070,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#55"
+"@value": "amf://id#62"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -12914,7 +13120,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#54/source-map",
+"@id": "amf://id#61/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -12922,7 +13128,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#54"
+"@value": "amf://id#61"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -12936,7 +13142,7 @@
 ]
 },
 {
-"@id": "amf://id#56",
+"@id": "amf://id#63",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -12949,7 +13155,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#57",
+"@id": "amf://id#64",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -12966,14 +13172,14 @@
 "@value": "language"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "The user's preferred language for rendering."
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#57/source-map",
+"@id": "amf://id#64/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -12981,7 +13187,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#57"
+"@value": "amf://id#64"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -12995,7 +13201,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -13007,7 +13213,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#57"
+"@value": "amf://id#64"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -13045,7 +13251,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#56/source-map",
+"@id": "amf://id#63/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -13053,7 +13259,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#56"
+"@value": "amf://id#63"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -13067,7 +13273,7 @@
 ]
 },
 {
-"@id": "amf://id#58",
+"@id": "amf://id#65",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -13080,7 +13286,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#59",
+"@id": "amf://id#66",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -13097,14 +13303,14 @@
 "@value": "age"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "Very unpractical property to have in a data store.\n"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#59/source-map",
+"@id": "amf://id#66/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -13112,7 +13318,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#59"
+"@value": "amf://id#66"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -13126,7 +13332,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -13138,7 +13344,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#59"
+"@value": "amf://id#66"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -13176,7 +13382,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#58/source-map",
+"@id": "amf://id#65/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -13196,7 +13402,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#58"
+"@value": "amf://id#65"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -13210,7 +13416,7 @@
 ]
 },
 {
-"@id": "amf://id#60",
+"@id": "amf://id#67",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -13223,7 +13429,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#61/linked_1",
+"@id": "amf://id#68/linked_1",
 "@type": [
 "http://a.ml/vocabularies/shapes#UnionShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -13231,7 +13437,7 @@
 ],
 "http://a.ml/vocabularies/document#link-target": [
 {
-"@id": "amf://id#61"
+"@id": "amf://id#68"
 }
 ],
 "http://a.ml/vocabularies/document#link-label": [
@@ -13253,7 +13459,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#60/source-map",
+"@id": "amf://id#67/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -13261,7 +13467,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#60"
+"@value": "amf://id#67"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -13275,7 +13481,7 @@
 ]
 },
 {
-"@id": "amf://id#64",
+"@id": "amf://id#71",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -13288,7 +13494,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#65",
+"@id": "amf://id#72",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -13305,14 +13511,14 @@
 "@value": "birthday"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "The person's date of birth, represented as YYYY-MM-DD."
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#65/source-map",
+"@id": "amf://id#72/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -13320,7 +13526,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#65"
+"@value": "amf://id#72"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -13334,7 +13540,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -13346,7 +13552,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#65"
+"@value": "amf://id#72"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -13384,7 +13590,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#64/source-map",
+"@id": "amf://id#71/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -13392,7 +13598,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#64"
+"@value": "amf://id#71"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -13406,7 +13612,7 @@
 ]
 },
 {
-"@id": "amf://id#66",
+"@id": "amf://id#73",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -13419,7 +13625,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#18/linked_3",
+"@id": "amf://id#19/linked_3",
 "@type": [
 "http://www.w3.org/ns/shacl#NodeShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -13428,7 +13634,7 @@
 ],
 "http://a.ml/vocabularies/document#link-target": [
 {
-"@id": "amf://id#18"
+"@id": "amf://id#19"
 }
 ],
 "http://a.ml/vocabularies/document#link-label": [
@@ -13450,7 +13656,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#66/source-map",
+"@id": "amf://id#73/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -13458,7 +13664,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#66"
+"@value": "amf://id#73"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -13472,7 +13678,7 @@
 ]
 },
 {
-"@id": "amf://id#67",
+"@id": "amf://id#74",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -13485,7 +13691,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#68",
+"@id": "amf://id#75",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -13502,20 +13708,22 @@
 "@value": "gender?"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "The person's gender. Possible values includes, but are not limited to, the following values:\n* \"male\" - Male gender.\n* \"female\" - Female gender.\n* \"other\" - Other.\n"
 }
 ],
 "http://www.w3.org/ns/shacl#in": [
 {
-"@id": "amf://id#68/list",
+"@id": "amf://id#75/list",
 "@type": "http://www.w3.org/2000/01/rdf-schema#Seq",
 "http://www.w3.org/2000/01/rdf-schema#_1": [
 {
-"@id": "amf://id#69",
+"@id": "amf://id#76",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -13525,7 +13733,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#69/source-map",
+"@id": "amf://id#76/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -13533,7 +13741,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#69"
+"@value": "amf://id#76"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -13549,9 +13757,11 @@
 ],
 "http://www.w3.org/2000/01/rdf-schema#_2": [
 {
-"@id": "amf://id#70",
+"@id": "amf://id#77",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -13561,7 +13771,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#70/source-map",
+"@id": "amf://id#77/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -13569,7 +13779,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#70"
+"@value": "amf://id#77"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -13585,9 +13795,11 @@
 ],
 "http://www.w3.org/2000/01/rdf-schema#_3": [
 {
-"@id": "amf://id#71",
+"@id": "amf://id#78",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -13597,7 +13809,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#71/source-map",
+"@id": "amf://id#78/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -13605,7 +13817,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#71"
+"@value": "amf://id#78"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -13621,14 +13833,21 @@
 ]
 }
 ],
-"http://a.ml/vocabularies/document#examples": [
+"http://a.ml/vocabularies/apiContract#examples": [
 {
-"@id": "amf://id#72",
+"@id": "amf://id#79",
 "@type": [
-"http://a.ml/vocabularies/document#Example",
+"http://a.ml/vocabularies/apiContract#NamedExamples",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://schema.org/name": [
+"http://a.ml/vocabularies/apiContract#examples": [
+{
+"@id": "amf://id#80",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Example",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/core#name": [
 {
 "@value": "Women"
 }
@@ -13640,9 +13859,11 @@
 ],
 "http://a.ml/vocabularies/document#structuredValue": [
 {
-"@id": "amf://id#72",
+"@id": "amf://id#80",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -13652,7 +13873,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#72/source-map",
+"@id": "amf://id#80/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -13660,7 +13881,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#72"
+"@value": "amf://id#80"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -13681,7 +13902,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#72/source-map",
+"@id": "amf://id#80/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -13715,7 +13936,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#72"
+"@value": "amf://id#80"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -13727,7 +13948,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/name"
+"@value": "http://a.ml/vocabularies/core#name"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -13741,12 +13962,12 @@
 ]
 },
 {
-"@id": "amf://id#73",
+"@id": "amf://id#81",
 "@type": [
-"http://a.ml/vocabularies/document#Example",
+"http://a.ml/vocabularies/apiContract#Example",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://schema.org/name": [
+"http://a.ml/vocabularies/core#name": [
 {
 "@value": "Man"
 }
@@ -13758,9 +13979,11 @@
 ],
 "http://a.ml/vocabularies/document#structuredValue": [
 {
-"@id": "amf://id#73",
+"@id": "amf://id#81",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -13770,7 +13993,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#73/source-map",
+"@id": "amf://id#81/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -13778,7 +14001,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#73"
+"@value": "amf://id#81"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -13799,7 +14022,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#73/source-map",
+"@id": "amf://id#81/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -13833,7 +14056,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#73"
+"@value": "amf://id#81"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -13845,7 +14068,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/name"
+"@value": "http://a.ml/vocabularies/core#name"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -13859,12 +14082,12 @@
 ]
 },
 {
-"@id": "amf://id#74",
+"@id": "amf://id#82",
 "@type": [
-"http://a.ml/vocabularies/document#Example",
+"http://a.ml/vocabularies/apiContract#Example",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://schema.org/name": [
+"http://a.ml/vocabularies/core#name": [
 {
 "@value": "Elmo"
 }
@@ -13876,9 +14099,11 @@
 ],
 "http://a.ml/vocabularies/document#structuredValue": [
 {
-"@id": "amf://id#74",
+"@id": "amf://id#82",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -13888,7 +14113,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#74/source-map",
+"@id": "amf://id#82/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -13896,7 +14121,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#74"
+"@value": "amf://id#82"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -13917,7 +14142,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#74/source-map",
+"@id": "amf://id#82/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -13951,7 +14176,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#74"
+"@value": "amf://id#82"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -13963,7 +14188,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/name"
+"@value": "http://a.ml/vocabularies/core#name"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -13976,10 +14201,12 @@
 }
 ]
 }
+]
+}
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#68/source-map",
+"@id": "amf://id#75/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -13987,7 +14214,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#68"
+"@value": "amf://id#75"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -14025,7 +14252,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#68"
+"@value": "amf://id#75"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -14037,7 +14264,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -14063,7 +14290,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#67/source-map",
+"@id": "amf://id#74/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -14071,7 +14298,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#67"
+"@value": "amf://id#74"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -14090,21 +14317,28 @@
 "@value": "type"
 }
 ],
-"http://schema.org/name": [
+"http://a.ml/vocabularies/core#name": [
 {
 "@value": "A person resource"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "An object representing a person in the API.\nThis object will be used in all methods returning a Person or list of people.\n"
 }
 ],
-"http://a.ml/vocabularies/document#examples": [
+"http://a.ml/vocabularies/apiContract#examples": [
 {
-"@id": "amf://id#75",
+"@id": "amf://id#83",
 "@type": [
-"http://a.ml/vocabularies/document#Example",
+"http://a.ml/vocabularies/apiContract#NamedExamples",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/apiContract#examples": [
+{
+"@id": "amf://id#84",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Example",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/document#strict": [
@@ -14114,351 +14348,23 @@
 ],
 "http://a.ml/vocabularies/document#structuredValue": [
 {
-"@id": "amf://id#75",
+"@id": "amf://id#84",
 "@type": [
-"http://a.ml/vocabularies/data#Object"
+"http://a.ml/vocabularies/data#Object",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#birthday": [
 {
-"@id": "amf://id#76",
+"@id": "amf://id#85",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
 "@value": "1983-10-20",
-"@type": "http://www.w3.org/2001/XMLSchema#string"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "amf://id#76/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#76"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(12,12)-(12,24)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"http://a.ml/vocabularies/data#etag": [
-{
-"@id": "amf://id#77",
-"@type": [
-"http://a.ml/vocabularies/data#Scalar"
-],
-"http://a.ml/vocabularies/data#value": [
-{
-"@value": "W\\244m4n5kj3gbn2nj4k4n4",
-"@type": "http://www.w3.org/2001/XMLSchema#string"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "amf://id#77/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#77"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(20,8)-(20,34)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"http://a.ml/vocabularies/data#favouriteNumber": [
-{
-"@id": "amf://id#78",
-"@type": [
-"http://a.ml/vocabularies/data#Scalar"
-],
-"http://a.ml/vocabularies/data#value": [
-{
-"@value": "10",
-"@type": "http://www.w3.org/2001/XMLSchema#integer"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "amf://id#78/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#78"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(21,19)-(21,21)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"http://a.ml/vocabularies/data#favouriteTime": [
-{
-"@id": "amf://id#79",
-"@type": [
-"http://a.ml/vocabularies/data#Scalar"
-],
-"http://a.ml/vocabularies/data#value": [
-{
-"@value": "10:29:52",
-"@type": "http://www.w3.org/2001/XMLSchema#string"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "amf://id#79/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#79"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(22,17)-(22,25)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"http://a.ml/vocabularies/data#gender": [
-{
-"@id": "amf://id#80",
-"@type": [
-"http://a.ml/vocabularies/data#Scalar"
-],
-"http://a.ml/vocabularies/data#value": [
-{
-"@value": "male",
-"@type": "http://www.w3.org/2001/XMLSchema#string"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "amf://id#80/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#80"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(13,10)-(13,14)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"http://a.ml/vocabularies/data#id": [
-{
-"@id": "amf://id#81",
-"@type": [
-"http://a.ml/vocabularies/data#Scalar"
-],
-"http://a.ml/vocabularies/data#value": [
-{
-"@value": "R34fg663H9KW9MMSKISIhTs1dR7Hss7e",
-"@type": "http://www.w3.org/2001/XMLSchema#string"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "amf://id#81/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#81"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(10,6)-(10,40)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"http://a.ml/vocabularies/data#image": [
-{
-"@id": "amf://id#82",
-"@type": [
-"http://a.ml/vocabularies/data#Object"
-],
-"http://a.ml/vocabularies/data#thumb": [
-{
-"@id": "amf://id#83",
-"@type": [
-"http://a.ml/vocabularies/data#Scalar"
-],
-"http://a.ml/vocabularies/data#value": [
-{
-"@value": "https://domain.com/profile/pawel.psztyc/image/thumb",
-"@type": "http://www.w3.org/2001/XMLSchema#string"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "amf://id#83/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#83"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(17,11)-(17,62)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"http://a.ml/vocabularies/data#url": [
-{
-"@id": "amf://id#84",
-"@type": [
-"http://a.ml/vocabularies/data#Scalar"
-],
-"http://a.ml/vocabularies/data#value": [
-{
-"@value": "https://domain.com/profile/pawel.psztyc/image",
-"@type": "http://www.w3.org/2001/XMLSchema#string"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "amf://id#84/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#84"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(16,9)-(16,54)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "amf://id#82/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#data-node-properties": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#82"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "url->[(16,4)-(17,0)]#thumb->[(17,4)-(18,0)]"
-}
-]
-}
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#82"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(16,0)-(18,0)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"http://a.ml/vocabularies/data#language": [
-{
-"@id": "amf://id#85",
-"@type": [
-"http://a.ml/vocabularies/data#Scalar"
-],
-"http://a.ml/vocabularies/data#value": [
-{
-"@value": "en_GB",
 "@type": "http://www.w3.org/2001/XMLSchema#string"
 }
 ],
@@ -14477,7 +14383,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
 {
-"@value": "[(19,12)-(19,17)]"
+"@value": "[(12,12)-(12,24)]"
 }
 ]
 }
@@ -14486,15 +14392,17 @@
 ]
 }
 ],
-"http://a.ml/vocabularies/data#name": [
+"http://a.ml/vocabularies/data#etag": [
 {
 "@id": "amf://id#86",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
-"@value": "Pawel Psztyc",
+"@value": "W\\244m4n5kj3gbn2nj4k4n4",
 "@type": "http://www.w3.org/2001/XMLSchema#string"
 }
 ],
@@ -14513,7 +14421,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
 {
-"@value": "[(11,8)-(11,22)]"
+"@value": "[(20,8)-(20,34)]"
 }
 ]
 }
@@ -14522,16 +14430,18 @@
 ]
 }
 ],
-"http://a.ml/vocabularies/data#nillable": [
+"http://a.ml/vocabularies/data#favouriteNumber": [
 {
 "@id": "amf://id#87",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
-"@value": "null",
-"@type": "http://www.w3.org/2001/XMLSchema#nil"
+"@value": "10",
+"@type": "http://www.w3.org/2001/XMLSchema#integer"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
@@ -14549,7 +14459,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
 {
-"@value": "[(23,12)-(23,16)]"
+"@value": "[(21,19)-(21,21)]"
 }
 ]
 }
@@ -14558,15 +14468,17 @@
 ]
 }
 ],
-"http://a.ml/vocabularies/data#tagline": [
+"http://a.ml/vocabularies/data#favouriteTime": [
 {
 "@id": "amf://id#88",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
-"@value": "Some text about me.",
+"@value": "10:29:52",
 "@type": "http://www.w3.org/2001/XMLSchema#string"
 }
 ],
@@ -14585,7 +14497,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
 {
-"@value": "[(18,11)-(18,30)]"
+"@value": "[(22,17)-(22,25)]"
 }
 ]
 }
@@ -14594,15 +14506,17 @@
 ]
 }
 ],
-"http://a.ml/vocabularies/data#url": [
+"http://a.ml/vocabularies/data#gender": [
 {
 "@id": "amf://id#89",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
-"@value": "https://domain.com/profile/pawel.psztyc",
+"@value": "male",
 "@type": "http://www.w3.org/2001/XMLSchema#string"
 }
 ],
@@ -14621,6 +14535,380 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
 {
+"@value": "[(13,10)-(13,14)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"http://a.ml/vocabularies/data#id": [
+{
+"@id": "amf://id#90",
+"@type": [
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/data#value": [
+{
+"@value": "R34fg663H9KW9MMSKISIhTs1dR7Hss7e",
+"@type": "http://www.w3.org/2001/XMLSchema#string"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#sources": [
+{
+"@id": "amf://id#90/source-map",
+"@type": [
+"http://a.ml/vocabularies/document-source-maps#SourceMap"
+],
+"http://a.ml/vocabularies/document-source-maps#lexical": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#90"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(10,6)-(10,40)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"http://a.ml/vocabularies/data#image": [
+{
+"@id": "amf://id#91",
+"@type": [
+"http://a.ml/vocabularies/data#Object",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/data#thumb": [
+{
+"@id": "amf://id#92",
+"@type": [
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/data#value": [
+{
+"@value": "https://domain.com/profile/pawel.psztyc/image/thumb",
+"@type": "http://www.w3.org/2001/XMLSchema#string"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#sources": [
+{
+"@id": "amf://id#92/source-map",
+"@type": [
+"http://a.ml/vocabularies/document-source-maps#SourceMap"
+],
+"http://a.ml/vocabularies/document-source-maps#lexical": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#92"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(17,11)-(17,62)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"http://a.ml/vocabularies/data#url": [
+{
+"@id": "amf://id#93",
+"@type": [
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/data#value": [
+{
+"@value": "https://domain.com/profile/pawel.psztyc/image",
+"@type": "http://www.w3.org/2001/XMLSchema#string"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#sources": [
+{
+"@id": "amf://id#93/source-map",
+"@type": [
+"http://a.ml/vocabularies/document-source-maps#SourceMap"
+],
+"http://a.ml/vocabularies/document-source-maps#lexical": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#93"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(16,9)-(16,54)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"http://a.ml/vocabularies/document-source-maps#sources": [
+{
+"@id": "amf://id#91/source-map",
+"@type": [
+"http://a.ml/vocabularies/document-source-maps#SourceMap"
+],
+"http://a.ml/vocabularies/document-source-maps#data-node-properties": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#91"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "url->[(16,4)-(17,0)]#thumb->[(17,4)-(18,0)]"
+}
+]
+}
+],
+"http://a.ml/vocabularies/document-source-maps#lexical": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/data#url"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(16,9)-(16,54)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#91"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(16,0)-(18,0)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/data#thumb"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(17,11)-(17,62)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"http://a.ml/vocabularies/data#language": [
+{
+"@id": "amf://id#94",
+"@type": [
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/data#value": [
+{
+"@value": "en_GB",
+"@type": "http://www.w3.org/2001/XMLSchema#string"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#sources": [
+{
+"@id": "amf://id#94/source-map",
+"@type": [
+"http://a.ml/vocabularies/document-source-maps#SourceMap"
+],
+"http://a.ml/vocabularies/document-source-maps#lexical": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#94"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(19,12)-(19,17)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"http://a.ml/vocabularies/data#name": [
+{
+"@id": "amf://id#95",
+"@type": [
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/data#value": [
+{
+"@value": "Pawel Psztyc",
+"@type": "http://www.w3.org/2001/XMLSchema#string"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#sources": [
+{
+"@id": "amf://id#95/source-map",
+"@type": [
+"http://a.ml/vocabularies/document-source-maps#SourceMap"
+],
+"http://a.ml/vocabularies/document-source-maps#lexical": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#95"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(11,8)-(11,22)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"http://a.ml/vocabularies/data#nillable": [
+{
+"@id": "amf://id#96",
+"@type": [
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/data#value": [
+{
+"@value": "null",
+"@type": "http://www.w3.org/2001/XMLSchema#nil"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#sources": [
+{
+"@id": "amf://id#96/source-map",
+"@type": [
+"http://a.ml/vocabularies/document-source-maps#SourceMap"
+],
+"http://a.ml/vocabularies/document-source-maps#lexical": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#96"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(23,12)-(23,16)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"http://a.ml/vocabularies/data#tagline": [
+{
+"@id": "amf://id#97",
+"@type": [
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/data#value": [
+{
+"@value": "Some text about me.",
+"@type": "http://www.w3.org/2001/XMLSchema#string"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#sources": [
+{
+"@id": "amf://id#97/source-map",
+"@type": [
+"http://a.ml/vocabularies/document-source-maps#SourceMap"
+],
+"http://a.ml/vocabularies/document-source-maps#lexical": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#97"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(18,11)-(18,30)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"http://a.ml/vocabularies/data#url": [
+{
+"@id": "amf://id#98",
+"@type": [
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/data#value": [
+{
+"@value": "https://domain.com/profile/pawel.psztyc",
+"@type": "http://www.w3.org/2001/XMLSchema#string"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#sources": [
+{
+"@id": "amf://id#98/source-map",
+"@type": [
+"http://a.ml/vocabularies/document-source-maps#SourceMap"
+],
+"http://a.ml/vocabularies/document-source-maps#lexical": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#98"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
 "@value": "[(14,7)-(14,48)]"
 }
 ]
@@ -14632,7 +14920,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#75/source-map",
+"@id": "amf://id#84/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -14640,12 +14928,156 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#75"
+"@value": "http://a.ml/vocabularies/data#url"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(14,7)-(14,48)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/data#nillable"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(23,12)-(23,16)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/data#language"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(19,12)-(19,17)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/data#id"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(10,6)-(10,40)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/data#favouriteTime"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(22,17)-(22,25)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/data#etag"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(20,8)-(20,34)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#84"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
 {
 "@value": "[(10,0)-(25,0)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/data#birthday"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(12,12)-(12,24)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/data#favouriteNumber"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(21,19)-(21,21)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/data#gender"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(13,10)-(13,14)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/data#image"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(16,0)-(18,0)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/data#name"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(11,8)-(11,22)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/data#tagline"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(18,11)-(18,30)]"
 }
 ]
 }
@@ -14654,7 +15086,19 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#75"
+"@value": "http://a.ml/vocabularies/data#image"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "url->[(16,4)-(17,0)]#thumb->[(17,4)-(18,0)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#84"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -14675,7 +15119,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#75/source-map",
+"@id": "amf://id#84/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -14709,7 +15153,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#75"
+"@value": "amf://id#84"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -14722,10 +15166,12 @@
 }
 ]
 }
+]
+}
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#31/source-map",
+"@id": "amf://id#37/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -14733,7 +15179,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#31"
+"@value": "amf://id#37"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -14747,7 +15193,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -14759,7 +15205,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#31"
+"@value": "amf://id#37"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -14771,7 +15217,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/name"
+"@value": "http://a.ml/vocabularies/core#name"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -14785,7 +15231,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#31"
+"@value": "amf://id#37"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -14801,7 +15247,7 @@
 ],
 "http://a.ml/vocabularies/document#references": [
 {
-"@id": "amf://id#17",
+"@id": "amf://id#18",
 "@type": [
 "http://a.ml/vocabularies/document#DataType",
 "http://a.ml/vocabularies/document#Fragment",
@@ -14809,7 +15255,7 @@
 ],
 "http://a.ml/vocabularies/document#encodes": [
 {
-"@id": "amf://id#18",
+"@id": "amf://id#19",
 "@type": [
 "http://www.w3.org/ns/shacl#NodeShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -14823,7 +15269,7 @@
 ],
 "http://www.w3.org/ns/shacl#property": [
 {
-"@id": "amf://id#19",
+"@id": "amf://id#20",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -14836,7 +15282,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#20",
+"@id": "amf://id#21",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -14853,14 +15299,14 @@
 "@value": "url"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "The URL of the image.\nTo resize the image and crop it to a square, append the query string **?sz=x**, where x is the dimension in pixels of each side.\n"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#20/source-map",
+"@id": "amf://id#21/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -14868,7 +15314,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#20"
+"@value": "amf://id#21"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -14882,7 +15328,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -14894,7 +15340,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#20"
+"@value": "amf://id#21"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -14932,7 +15378,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#19/source-map",
+"@id": "amf://id#20/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -14940,7 +15386,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#19"
+"@value": "amf://id#20"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -14954,7 +15400,7 @@
 ]
 },
 {
-"@id": "amf://id#21",
+"@id": "amf://id#22",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -14967,7 +15413,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#22",
+"@id": "amf://id#23",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -14984,19 +15430,19 @@
 "@value": "thumb"
 }
 ],
-"http://schema.org/name": [
+"http://a.ml/vocabularies/core#name": [
 {
 "@value": "Thumbnail"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "An URL to the thumbnail of the image. Thumbnails are 60x60px cropped images of the original image.\n"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#22/source-map",
+"@id": "amf://id#23/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -15004,7 +15450,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#22"
+"@value": "amf://id#23"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -15018,7 +15464,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -15042,7 +15488,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#22"
+"@value": "amf://id#23"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -15054,7 +15500,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/name"
+"@value": "http://a.ml/vocabularies/core#name"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -15080,7 +15526,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#21/source-map",
+"@id": "amf://id#22/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -15088,7 +15534,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#21"
+"@value": "amf://id#22"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -15107,16 +15553,23 @@
 "@value": "amf_inline_type_2"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "An image object representing an image object strored in the file store.\nThe image can be only included in the response. It has no effect if the Image appear in the\nrequest. Endpoint handles image creation on it's own and clients can't process images\nexcept of sending image data.\n"
 }
 ],
-"http://a.ml/vocabularies/document#examples": [
+"http://a.ml/vocabularies/apiContract#examples": [
 {
-"@id": "amf://id#23",
+"@id": "amf://id#24",
 "@type": [
-"http://a.ml/vocabularies/document#Example",
+"http://a.ml/vocabularies/apiContract#NamedExamples",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/apiContract#examples": [
+{
+"@id": "amf://id#25",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Example",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/document#strict": [
@@ -15126,15 +15579,19 @@
 ],
 "http://a.ml/vocabularies/document#structuredValue": [
 {
-"@id": "amf://id#23",
+"@id": "amf://id#25",
 "@type": [
-"http://a.ml/vocabularies/data#Object"
+"http://a.ml/vocabularies/data#Object",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#thumb": [
 {
-"@id": "amf://id#24",
+"@id": "amf://id#26",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -15144,7 +15601,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#24/source-map",
+"@id": "amf://id#26/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -15152,7 +15609,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#24"
+"@value": "amf://id#26"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -15168,9 +15625,11 @@
 ],
 "http://a.ml/vocabularies/data#url": [
 {
-"@id": "amf://id#25",
+"@id": "amf://id#27",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -15180,7 +15639,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#25/source-map",
+"@id": "amf://id#27/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -15188,7 +15647,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#25"
+"@value": "amf://id#27"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -15204,7 +15663,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#23/source-map",
+"@id": "amf://id#25/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -15212,12 +15671,36 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#23"
+"@value": "http://a.ml/vocabularies/data#url"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(22,7)-(22,52)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#25"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
 {
 "@value": "[(22,0)-(24,0)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/data#thumb"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(23,9)-(23,60)]"
 }
 ]
 }
@@ -15226,7 +15709,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#23"
+"@value": "amf://id#25"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -15247,7 +15730,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#23/source-map",
+"@id": "amf://id#25/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -15281,7 +15764,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#23"
+"@value": "amf://id#25"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -15294,10 +15777,12 @@
 }
 ]
 }
+]
+}
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#18/source-map",
+"@id": "amf://id#19/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -15305,7 +15790,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#18"
+"@value": "amf://id#19"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -15319,7 +15804,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#18"
+"@value": "amf://id#19"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -15333,7 +15818,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -15345,7 +15830,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#18"
+"@value": "amf://id#19"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -15359,7 +15844,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#18"
+"@value": "amf://id#19"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -15375,7 +15860,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#17/source-map",
+"@id": "amf://id#18/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -15383,7 +15868,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#17"
+"@value": "amf://id#18"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -15397,7 +15882,7 @@
 ]
 },
 {
-"@id": "amf://id#90",
+"@id": "amf://id#33",
 "@type": [
 "http://a.ml/vocabularies/document#DataType",
 "http://a.ml/vocabularies/document#Fragment",
@@ -15405,7 +15890,7 @@
 ],
 "http://a.ml/vocabularies/document#encodes": [
 {
-"@id": "amf://id#91",
+"@id": "amf://id#34",
 "@type": [
 "http://www.w3.org/ns/shacl#NodeShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -15419,7 +15904,7 @@
 ],
 "http://www.w3.org/ns/shacl#property": [
 {
-"@id": "amf://id#42",
+"@id": "amf://id#35",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -15432,7 +15917,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#43",
+"@id": "amf://id#36",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -15449,14 +15934,14 @@
 "@value": "etag"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "ETag of this resource for caching purposes.\n__This property will be ignored when creating an object.__\n"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#43/source-map",
+"@id": "amf://id#36/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -15464,7 +15949,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#43"
+"@value": "amf://id#36"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -15478,7 +15963,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -15490,7 +15975,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#43"
+"@value": "amf://id#36"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -15528,7 +16013,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#42/source-map",
+"@id": "amf://id#35/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -15536,7 +16021,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#42"
+"@value": "amf://id#35"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -15555,14 +16040,14 @@
 "@value": "type"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "Common properties for all resources returned by the API.\n"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#91/source-map",
+"@id": "amf://id#34/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -15570,7 +16055,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#91"
+"@value": "amf://id#34"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -15584,7 +16069,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -15596,7 +16081,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#91"
+"@value": "amf://id#34"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -15610,7 +16095,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#91"
+"@value": "amf://id#34"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -15626,7 +16111,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#90/source-map",
+"@id": "amf://id#33/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -15634,7 +16119,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#90"
+"@value": "amf://id#33"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -15650,7 +16135,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#30/source-map",
+"@id": "amf://id#32/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -15658,7 +16143,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#30"
+"@value": "amf://id#32"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -15672,7 +16157,7 @@
 ]
 },
 {
-"@id": "amf://id#92",
+"@id": "amf://id#99",
 "@type": [
 "http://a.ml/vocabularies/document#DataType",
 "http://a.ml/vocabularies/document#Fragment",
@@ -15680,7 +16165,7 @@
 ],
 "http://a.ml/vocabularies/document#encodes": [
 {
-"@id": "amf://id#93",
+"@id": "amf://id#100",
 "@type": [
 "http://www.w3.org/ns/shacl#NodeShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -15694,7 +16179,7 @@
 ],
 "http://www.w3.org/ns/shacl#property": [
 {
-"@id": "amf://id#94",
+"@id": "amf://id#101",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -15707,7 +16192,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#95",
+"@id": "amf://id#102",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -15729,16 +16214,23 @@
 "@value": "upc"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "The Universal Produc Code. It consists of 12 numerical digits. However, because of the\ninteger precision limitation in JavaScript it is represented as a string.\n"
 }
 ],
-"http://a.ml/vocabularies/document#examples": [
+"http://a.ml/vocabularies/apiContract#examples": [
 {
-"@id": "amf://id#96",
+"@id": "amf://id#103",
 "@type": [
-"http://a.ml/vocabularies/document#Example",
+"http://a.ml/vocabularies/apiContract#NamedExamples",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/apiContract#examples": [
+{
+"@id": "amf://id#104",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Example",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/document#strict": [
@@ -15748,9 +16240,11 @@
 ],
 "http://a.ml/vocabularies/document#structuredValue": [
 {
-"@id": "amf://id#96",
+"@id": "amf://id#104",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -15760,7 +16254,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#96/source-map",
+"@id": "amf://id#104/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -15768,7 +16262,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#96"
+"@value": "amf://id#104"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -15789,7 +16283,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#96/source-map",
+"@id": "amf://id#104/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -15823,7 +16317,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#96"
+"@value": "amf://id#104"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -15836,10 +16330,12 @@
 }
 ]
 }
+]
+}
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#95/source-map",
+"@id": "amf://id#102/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -15847,7 +16343,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#95"
+"@value": "amf://id#102"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -15861,7 +16357,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -15885,7 +16381,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#95"
+"@value": "amf://id#102"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -15923,7 +16419,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#94/source-map",
+"@id": "amf://id#101/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -15943,7 +16439,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#94"
+"@value": "amf://id#101"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -15957,7 +16453,7 @@
 ]
 },
 {
-"@id": "amf://id#42",
+"@id": "amf://id#35",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -15970,7 +16466,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#43",
+"@id": "amf://id#36",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -15987,14 +16483,14 @@
 "@value": "etag"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "ETag of this resource for caching purposes.\n__This property will be ignored when creating an object.__\n"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#43/source-map",
+"@id": "amf://id#36/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -16002,7 +16498,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#43"
+"@value": "amf://id#36"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -16016,7 +16512,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -16028,7 +16524,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#43"
+"@value": "amf://id#36"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -16066,7 +16562,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#42/source-map",
+"@id": "amf://id#35/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -16074,7 +16570,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#42"
+"@value": "amf://id#35"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -16088,7 +16584,7 @@
 ]
 },
 {
-"@id": "amf://id#97",
+"@id": "amf://id#105",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -16101,7 +16597,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#98",
+"@id": "amf://id#106",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -16118,16 +16614,23 @@
 "@value": "name"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "Product name"
 }
 ],
-"http://a.ml/vocabularies/document#examples": [
+"http://a.ml/vocabularies/apiContract#examples": [
 {
-"@id": "amf://id#99",
+"@id": "amf://id#107",
 "@type": [
-"http://a.ml/vocabularies/document#Example",
+"http://a.ml/vocabularies/apiContract#NamedExamples",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/apiContract#examples": [
+{
+"@id": "amf://id#108",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Example",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/document#strict": [
@@ -16137,9 +16640,11 @@
 ],
 "http://a.ml/vocabularies/document#structuredValue": [
 {
-"@id": "amf://id#99",
+"@id": "amf://id#108",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -16149,7 +16654,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#99/source-map",
+"@id": "amf://id#108/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -16157,7 +16662,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#99"
+"@value": "amf://id#108"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -16178,7 +16683,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#99/source-map",
+"@id": "amf://id#108/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -16212,7 +16717,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#99"
+"@value": "amf://id#108"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -16225,10 +16730,12 @@
 }
 ]
 }
+]
+}
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#98/source-map",
+"@id": "amf://id#106/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -16236,7 +16743,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#98"
+"@value": "amf://id#106"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -16250,7 +16757,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -16262,7 +16769,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#98"
+"@value": "amf://id#106"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -16300,7 +16807,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#97/source-map",
+"@id": "amf://id#105/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -16320,7 +16827,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#97"
+"@value": "amf://id#105"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -16334,7 +16841,7 @@
 ]
 },
 {
-"@id": "amf://id#100",
+"@id": "amf://id#109",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -16347,7 +16854,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#101",
+"@id": "amf://id#110",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -16369,14 +16876,14 @@
 "@value": "id"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "Product id. It is a UUID of the database record.\n__This property will be ignored when creating an object.__\nIt will be available when the product is stored in the datastore.\n"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#101/source-map",
+"@id": "amf://id#110/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -16384,7 +16891,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -16396,7 +16903,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#101"
+"@value": "amf://id#110"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -16434,7 +16941,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#100/source-map",
+"@id": "amf://id#109/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -16442,7 +16949,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#100"
+"@value": "amf://id#109"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -16456,7 +16963,7 @@
 ]
 },
 {
-"@id": "amf://id#102",
+"@id": "amf://id#111",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -16469,7 +16976,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#103",
+"@id": "amf://id#112",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -16486,16 +16993,23 @@
 "@value": "unit"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "The unit of measuremet for the quantity property."
 }
 ],
-"http://a.ml/vocabularies/document#examples": [
+"http://a.ml/vocabularies/apiContract#examples": [
 {
-"@id": "amf://id#104",
+"@id": "amf://id#113",
 "@type": [
-"http://a.ml/vocabularies/document#Example",
+"http://a.ml/vocabularies/apiContract#NamedExamples",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/apiContract#examples": [
+{
+"@id": "amf://id#114",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Example",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/document#strict": [
@@ -16505,9 +17019,11 @@
 ],
 "http://a.ml/vocabularies/document#structuredValue": [
 {
-"@id": "amf://id#104",
+"@id": "amf://id#114",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -16517,7 +17033,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#104/source-map",
+"@id": "amf://id#114/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -16525,7 +17041,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#104"
+"@value": "amf://id#114"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -16546,7 +17062,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#104/source-map",
+"@id": "amf://id#114/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -16580,7 +17096,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#104"
+"@value": "amf://id#114"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -16593,10 +17109,12 @@
 }
 ]
 }
+]
+}
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#103/source-map",
+"@id": "amf://id#112/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -16604,7 +17122,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#103"
+"@value": "amf://id#112"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -16618,7 +17136,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -16630,7 +17148,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#103"
+"@value": "amf://id#112"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -16668,7 +17186,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#102/source-map",
+"@id": "amf://id#111/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -16688,7 +17206,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#102"
+"@value": "amf://id#111"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -16702,7 +17220,7 @@
 ]
 },
 {
-"@id": "amf://id#105",
+"@id": "amf://id#115",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -16715,7 +17233,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#106",
+"@id": "amf://id#116",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -16732,16 +17250,23 @@
 "@value": "available"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "Product current availability in the store.\nProduct may be not available but the users still can order it with later delivery date.\n"
 }
 ],
-"http://a.ml/vocabularies/document#examples": [
+"http://a.ml/vocabularies/apiContract#examples": [
 {
-"@id": "amf://id#107",
+"@id": "amf://id#117",
 "@type": [
-"http://a.ml/vocabularies/document#Example",
+"http://a.ml/vocabularies/apiContract#NamedExamples",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/apiContract#examples": [
+{
+"@id": "amf://id#118",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Example",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/document#strict": [
@@ -16751,9 +17276,11 @@
 ],
 "http://a.ml/vocabularies/document#structuredValue": [
 {
-"@id": "amf://id#107",
+"@id": "amf://id#118",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -16763,7 +17290,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#107/source-map",
+"@id": "amf://id#118/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -16771,7 +17298,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#107"
+"@value": "amf://id#118"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -16792,7 +17319,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#107/source-map",
+"@id": "amf://id#118/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -16826,7 +17353,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#107"
+"@value": "amf://id#118"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -16839,10 +17366,12 @@
 }
 ]
 }
+]
+}
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#106/source-map",
+"@id": "amf://id#116/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -16850,7 +17379,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#106"
+"@value": "amf://id#116"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -16864,7 +17393,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -16876,7 +17405,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#106"
+"@value": "amf://id#116"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -16914,7 +17443,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#105/source-map",
+"@id": "amf://id#115/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -16934,7 +17463,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#105"
+"@value": "amf://id#115"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -16948,7 +17477,7 @@
 ]
 },
 {
-"@id": "amf://id#108",
+"@id": "amf://id#119",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -16961,7 +17490,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#109",
+"@id": "amf://id#120",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -16978,16 +17507,23 @@
 "@value": "quantity"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "The quantity of the product in the one unit of measurement.\nSee `unit` property for more information.\n"
 }
 ],
-"http://a.ml/vocabularies/document#examples": [
+"http://a.ml/vocabularies/apiContract#examples": [
 {
-"@id": "amf://id#110",
+"@id": "amf://id#121",
 "@type": [
-"http://a.ml/vocabularies/document#Example",
+"http://a.ml/vocabularies/apiContract#NamedExamples",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/apiContract#examples": [
+{
+"@id": "amf://id#122",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Example",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/document#strict": [
@@ -16997,9 +17533,11 @@
 ],
 "http://a.ml/vocabularies/document#structuredValue": [
 {
-"@id": "amf://id#110",
+"@id": "amf://id#122",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -17009,7 +17547,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#110/source-map",
+"@id": "amf://id#122/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -17017,7 +17555,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#110"
+"@value": "amf://id#122"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -17038,7 +17576,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#110/source-map",
+"@id": "amf://id#122/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -17072,7 +17610,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#110"
+"@value": "amf://id#122"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -17085,10 +17623,12 @@
 }
 ]
 }
+]
+}
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#109/source-map",
+"@id": "amf://id#120/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -17096,7 +17636,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#109"
+"@value": "amf://id#120"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -17110,7 +17650,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -17122,7 +17662,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#109"
+"@value": "amf://id#120"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -17160,7 +17700,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#108/source-map",
+"@id": "amf://id#119/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -17180,7 +17720,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#108"
+"@value": "amf://id#119"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -17199,21 +17739,28 @@
 "@value": "Product"
 }
 ],
-"http://schema.org/name": [
+"http://a.ml/vocabularies/core#name": [
 {
 "@value": "A product resource"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "A single product representing an item in the store."
 }
 ],
-"http://a.ml/vocabularies/document#examples": [
+"http://a.ml/vocabularies/apiContract#examples": [
 {
-"@id": "amf://id#111",
+"@id": "amf://id#123",
 "@type": [
-"http://a.ml/vocabularies/document#Example",
+"http://a.ml/vocabularies/apiContract#NamedExamples",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/apiContract#examples": [
+{
+"@id": "amf://id#124",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Example",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/document#strict": [
@@ -17223,15 +17770,19 @@
 ],
 "http://a.ml/vocabularies/document#structuredValue": [
 {
-"@id": "amf://id#111",
+"@id": "amf://id#124",
 "@type": [
-"http://a.ml/vocabularies/data#Object"
+"http://a.ml/vocabularies/data#Object",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#available": [
 {
-"@id": "amf://id#112",
+"@id": "amf://id#125",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -17241,7 +17792,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#112/source-map",
+"@id": "amf://id#125/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -17249,7 +17800,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#112"
+"@value": "amf://id#125"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -17265,9 +17816,11 @@
 ],
 "http://a.ml/vocabularies/data#etag": [
 {
-"@id": "amf://id#113",
+"@id": "amf://id#126",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -17277,7 +17830,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#113/source-map",
+"@id": "amf://id#126/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -17285,7 +17838,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#113"
+"@value": "amf://id#126"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -17301,9 +17854,11 @@
 ],
 "http://a.ml/vocabularies/data#id": [
 {
-"@id": "amf://id#114",
+"@id": "amf://id#127",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -17313,7 +17868,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#114/source-map",
+"@id": "amf://id#127/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -17321,7 +17876,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#114"
+"@value": "amf://id#127"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -17337,9 +17892,11 @@
 ],
 "http://a.ml/vocabularies/data#name": [
 {
-"@id": "amf://id#115",
+"@id": "amf://id#128",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -17349,7 +17906,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#115/source-map",
+"@id": "amf://id#128/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -17357,7 +17914,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#115"
+"@value": "amf://id#128"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -17373,9 +17930,11 @@
 ],
 "http://a.ml/vocabularies/data#quantity": [
 {
-"@id": "amf://id#116",
+"@id": "amf://id#129",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -17385,7 +17944,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#116/source-map",
+"@id": "amf://id#129/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -17393,7 +17952,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#116"
+"@value": "amf://id#129"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -17409,9 +17968,11 @@
 ],
 "http://a.ml/vocabularies/data#unit": [
 {
-"@id": "amf://id#117",
+"@id": "amf://id#130",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -17421,7 +17982,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#117/source-map",
+"@id": "amf://id#130/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -17429,7 +17990,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#117"
+"@value": "amf://id#130"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -17445,9 +18006,11 @@
 ],
 "http://a.ml/vocabularies/data#upc": [
 {
-"@id": "amf://id#118",
+"@id": "amf://id#131",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -17457,7 +18020,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#118/source-map",
+"@id": "amf://id#131/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -17465,7 +18028,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#118"
+"@value": "amf://id#131"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -17481,7 +18044,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#111/source-map",
+"@id": "amf://id#124/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -17489,12 +18052,96 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#111"
+"@value": "http://a.ml/vocabularies/data#upc"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(50,7)-(50,21)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/data#quantity"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(48,12)-(48,15)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/data#id"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(46,6)-(46,34)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/data#available"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(51,13)-(51,17)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#124"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
 {
 "@value": "[(46,0)-(53,0)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/data#etag"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(52,8)-(52,28)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/data#name"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(47,8)-(47,20)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/data#unit"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(49,8)-(49,10)]"
 }
 ]
 }
@@ -17503,7 +18150,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#111"
+"@value": "amf://id#124"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -17524,7 +18171,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#111/source-map",
+"@id": "amf://id#124/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -17558,7 +18205,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#111"
+"@value": "amf://id#124"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -17571,10 +18218,12 @@
 }
 ]
 }
+]
+}
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#93/source-map",
+"@id": "amf://id#100/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -17582,7 +18231,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#93"
+"@value": "amf://id#100"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -17596,7 +18245,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#93"
+"@value": "amf://id#100"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -17610,7 +18259,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -17622,7 +18271,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#93"
+"@value": "amf://id#100"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -17634,7 +18283,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/name"
+"@value": "http://a.ml/vocabularies/core#name"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -17648,7 +18297,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#93"
+"@value": "amf://id#100"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -17664,7 +18313,7 @@
 ],
 "http://a.ml/vocabularies/document#references": [
 {
-"@id": "amf://id#90",
+"@id": "amf://id#33",
 "@type": [
 "http://a.ml/vocabularies/document#DataType",
 "http://a.ml/vocabularies/document#Fragment",
@@ -17672,7 +18321,7 @@
 ],
 "http://a.ml/vocabularies/document#encodes": [
 {
-"@id": "amf://id#91",
+"@id": "amf://id#34",
 "@type": [
 "http://www.w3.org/ns/shacl#NodeShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -17686,7 +18335,7 @@
 ],
 "http://www.w3.org/ns/shacl#property": [
 {
-"@id": "amf://id#42",
+"@id": "amf://id#35",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -17699,7 +18348,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#43",
+"@id": "amf://id#36",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -17716,14 +18365,14 @@
 "@value": "etag"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "ETag of this resource for caching purposes.\n__This property will be ignored when creating an object.__\n"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#43/source-map",
+"@id": "amf://id#36/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -17731,7 +18380,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#43"
+"@value": "amf://id#36"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -17745,7 +18394,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -17757,7 +18406,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#43"
+"@value": "amf://id#36"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -17795,7 +18444,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#42/source-map",
+"@id": "amf://id#35/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -17803,7 +18452,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#42"
+"@value": "amf://id#35"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -17822,14 +18471,14 @@
 "@value": "type"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "Common properties for all resources returned by the API.\n"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#91/source-map",
+"@id": "amf://id#34/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -17837,7 +18486,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#91"
+"@value": "amf://id#34"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -17851,7 +18500,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -17863,7 +18512,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#91"
+"@value": "amf://id#34"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -17877,7 +18526,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#91"
+"@value": "amf://id#34"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -17893,7 +18542,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#90/source-map",
+"@id": "amf://id#33/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -17901,7 +18550,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#90"
+"@value": "amf://id#33"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -17917,7 +18566,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#92/source-map",
+"@id": "amf://id#99/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -17925,7 +18574,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#92"
+"@value": "amf://id#99"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -17939,7 +18588,7 @@
 ]
 },
 {
-"@id": "amf://id#90",
+"@id": "amf://id#33",
 "@type": [
 "http://a.ml/vocabularies/document#DataType",
 "http://a.ml/vocabularies/document#Fragment",
@@ -17947,7 +18596,7 @@
 ],
 "http://a.ml/vocabularies/document#encodes": [
 {
-"@id": "amf://id#91",
+"@id": "amf://id#34",
 "@type": [
 "http://www.w3.org/ns/shacl#NodeShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -17961,7 +18610,7 @@
 ],
 "http://www.w3.org/ns/shacl#property": [
 {
-"@id": "amf://id#42",
+"@id": "amf://id#35",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -17974,7 +18623,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#43",
+"@id": "amf://id#36",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -17991,14 +18640,14 @@
 "@value": "etag"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "ETag of this resource for caching purposes.\n__This property will be ignored when creating an object.__\n"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#43/source-map",
+"@id": "amf://id#36/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -18006,7 +18655,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#43"
+"@value": "amf://id#36"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -18020,7 +18669,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -18032,7 +18681,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#43"
+"@value": "amf://id#36"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -18070,7 +18719,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#42/source-map",
+"@id": "amf://id#35/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -18078,7 +18727,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#42"
+"@value": "amf://id#35"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -18097,14 +18746,14 @@
 "@value": "type"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "Common properties for all resources returned by the API.\n"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#91/source-map",
+"@id": "amf://id#34/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -18112,7 +18761,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#91"
+"@value": "amf://id#34"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -18126,7 +18775,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -18138,7 +18787,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#91"
+"@value": "amf://id#34"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -18152,7 +18801,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#91"
+"@value": "amf://id#34"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -18168,7 +18817,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#90/source-map",
+"@id": "amf://id#33/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -18176,7 +18825,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#90"
+"@value": "amf://id#33"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -18205,7 +18854,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
 {
-"@value": "myLib->amf://id#26::library.raml"
+"@value": "myLib->amf://id#28::library.raml"
 }
 ]
 }
@@ -18214,7 +18863,7 @@
 ],
 "http://a.ml/vocabularies/document#declares": [
 {
-"@id": "amf://id#119",
+"@id": "amf://id#132",
 "@type": [
 "http://a.ml/vocabularies/shapes#ArrayShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -18223,7 +18872,7 @@
 ],
 "http://a.ml/vocabularies/shapes#items": [
 {
-"@id": "amf://id#120/linked_1",
+"@id": "amf://id#133/linked_1",
 "@type": [
 "http://www.w3.org/ns/shacl#NodeShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -18232,7 +18881,7 @@
 ],
 "http://a.ml/vocabularies/document#link-target": [
 {
-"@id": "amf://id#120"
+"@id": "amf://id#133"
 }
 ],
 "http://a.ml/vocabularies/document#link-label": [
@@ -18249,7 +18898,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#119/source-map",
+"@id": "amf://id#132/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -18257,7 +18906,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#119"
+"@value": "amf://id#132"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -18283,7 +18932,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#119"
+"@value": "amf://id#132"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -18297,7 +18946,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#119"
+"@value": "amf://id#132"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -18311,7 +18960,7 @@
 ]
 },
 {
-"@id": "amf://id#125",
+"@id": "amf://id#138",
 "@type": [
 "http://www.w3.org/ns/shacl#NodeShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -18325,7 +18974,7 @@
 ],
 "http://www.w3.org/ns/shacl#property": [
 {
-"@id": "amf://id#32",
+"@id": "amf://id#38",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -18338,7 +18987,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#33",
+"@id": "amf://id#39",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -18355,14 +19004,14 @@
 "@value": "favouriteTime"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "The person's favourite time of day"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#33/source-map",
+"@id": "amf://id#39/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -18370,7 +19019,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#33"
+"@value": "amf://id#39"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -18384,7 +19033,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -18396,7 +19045,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#33"
+"@value": "amf://id#39"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -18434,7 +19083,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#32/source-map",
+"@id": "amf://id#38/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -18442,7 +19091,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#32"
+"@value": "amf://id#38"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -18456,7 +19105,7 @@
 ]
 },
 {
-"@id": "amf://id#34",
+"@id": "amf://id#40",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -18469,7 +19118,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#35",
+"@id": "amf://id#41",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -18501,16 +19150,23 @@
 "@value": "favouriteNumber"
 }
 ],
-"http://schema.org/name": [
+"http://a.ml/vocabularies/core#name": [
 {
 "@value": "Favourite number"
 }
 ],
-"http://a.ml/vocabularies/document#examples": [
+"http://a.ml/vocabularies/apiContract#examples": [
 {
-"@id": "amf://id#36",
+"@id": "amf://id#42",
 "@type": [
-"http://a.ml/vocabularies/document#Example",
+"http://a.ml/vocabularies/apiContract#NamedExamples",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/apiContract#examples": [
+{
+"@id": "amf://id#43",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Example",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/document#strict": [
@@ -18520,9 +19176,11 @@
 ],
 "http://a.ml/vocabularies/document#structuredValue": [
 {
-"@id": "amf://id#36",
+"@id": "amf://id#43",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -18532,7 +19190,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#36/source-map",
+"@id": "amf://id#43/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -18540,7 +19198,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#36"
+"@value": "amf://id#43"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -18561,7 +19219,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#36/source-map",
+"@id": "amf://id#43/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -18595,7 +19253,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#36"
+"@value": "amf://id#43"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -18608,10 +19266,12 @@
 }
 ]
 }
+]
+}
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#35/source-map",
+"@id": "amf://id#41/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -18619,7 +19279,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#35"
+"@value": "amf://id#41"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -18633,7 +19293,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/name"
+"@value": "http://a.ml/vocabularies/core#name"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -18669,7 +19329,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#35"
+"@value": "amf://id#41"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -18719,7 +19379,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#34/source-map",
+"@id": "amf://id#40/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -18739,7 +19399,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#34"
+"@value": "amf://id#40"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -18753,7 +19413,7 @@
 ]
 },
 {
-"@id": "amf://id#37",
+"@id": "amf://id#44",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -18766,7 +19426,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#38",
+"@id": "amf://id#45",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -18785,9 +19445,11 @@
 ],
 "http://www.w3.org/ns/shacl#defaultValue": [
 {
-"@id": "amf://id#39",
+"@id": "amf://id#46",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -18797,7 +19459,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#39/source-map",
+"@id": "amf://id#46/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -18805,7 +19467,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#39"
+"@value": "amf://id#46"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -18826,7 +19488,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#38/source-map",
+"@id": "amf://id#45/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -18834,7 +19496,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#38"
+"@value": "amf://id#45"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -18860,7 +19522,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#38"
+"@value": "amf://id#45"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -18898,7 +19560,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#37/source-map",
+"@id": "amf://id#44/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -18918,7 +19580,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#37"
+"@value": "amf://id#44"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -18932,7 +19594,7 @@
 ]
 },
 {
-"@id": "amf://id#40",
+"@id": "amf://id#47",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -18945,7 +19607,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#41",
+"@id": "amf://id#48",
 "@type": [
 "http://a.ml/vocabularies/shapes#FileShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -18977,7 +19639,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#41/source-map",
+"@id": "amf://id#48/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -18985,7 +19647,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#41"
+"@value": "amf://id#48"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -19023,7 +19685,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#41"
+"@value": "amf://id#48"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -19061,7 +19723,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#40/source-map",
+"@id": "amf://id#47/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -19081,7 +19743,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#40"
+"@value": "amf://id#47"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -19095,7 +19757,7 @@
 ]
 },
 {
-"@id": "amf://id#42",
+"@id": "amf://id#35",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -19108,7 +19770,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#43",
+"@id": "amf://id#36",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -19125,14 +19787,14 @@
 "@value": "etag"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "ETag of this resource for caching purposes.\n__This property will be ignored when creating an object.__\n"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#43/source-map",
+"@id": "amf://id#36/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -19140,7 +19802,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#43"
+"@value": "amf://id#36"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -19154,7 +19816,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -19166,7 +19828,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#43"
+"@value": "amf://id#36"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -19204,7 +19866,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#42/source-map",
+"@id": "amf://id#35/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -19212,7 +19874,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#42"
+"@value": "amf://id#35"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -19226,7 +19888,7 @@
 ]
 },
 {
-"@id": "amf://id#44",
+"@id": "amf://id#49",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -19239,7 +19901,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#45",
+"@id": "amf://id#50",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -19256,14 +19918,14 @@
 "@value": "tagline"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "The brief description (tagline) of this person."
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#45/source-map",
+"@id": "amf://id#50/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -19271,7 +19933,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#45"
+"@value": "amf://id#50"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -19285,7 +19947,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -19297,7 +19959,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#45"
+"@value": "amf://id#50"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -19335,7 +19997,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#44/source-map",
+"@id": "amf://id#49/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -19343,7 +20005,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#44"
+"@value": "amf://id#49"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -19357,7 +20019,7 @@
 ]
 },
 {
-"@id": "amf://id#46",
+"@id": "amf://id#51",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -19370,7 +20032,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#47",
+"@id": "amf://id#52",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -19392,16 +20054,23 @@
 "@value": "name"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "Person full name. The input will be rejected if this property is not set while creating new object."
 }
 ],
-"http://a.ml/vocabularies/document#examples": [
+"http://a.ml/vocabularies/apiContract#examples": [
 {
-"@id": "amf://id#48",
+"@id": "amf://id#53",
 "@type": [
-"http://a.ml/vocabularies/document#Example",
+"http://a.ml/vocabularies/apiContract#NamedExamples",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/apiContract#examples": [
+{
+"@id": "amf://id#54",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Example",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/document#strict": [
@@ -19411,9 +20080,11 @@
 ],
 "http://a.ml/vocabularies/document#structuredValue": [
 {
-"@id": "amf://id#48",
+"@id": "amf://id#54",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -19423,7 +20094,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#48/source-map",
+"@id": "amf://id#54/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -19431,7 +20102,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#48"
+"@value": "amf://id#54"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -19452,7 +20123,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#48/source-map",
+"@id": "amf://id#54/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -19486,7 +20157,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#48"
+"@value": "amf://id#54"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -19499,10 +20170,12 @@
 }
 ]
 }
+]
+}
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#47/source-map",
+"@id": "amf://id#52/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -19510,7 +20183,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#47"
+"@value": "amf://id#52"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -19524,7 +20197,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -19548,7 +20221,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#47"
+"@value": "amf://id#52"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -19586,7 +20259,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#46/source-map",
+"@id": "amf://id#51/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -19606,7 +20279,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#46"
+"@value": "amf://id#51"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -19620,7 +20293,7 @@
 ]
 },
 {
-"@id": "amf://id#49",
+"@id": "amf://id#55",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -19633,7 +20306,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#50",
+"@id": "amf://id#56",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -19650,11 +20323,18 @@
 "@value": "created"
 }
 ],
-"http://a.ml/vocabularies/document#examples": [
+"http://a.ml/vocabularies/apiContract#examples": [
 {
-"@id": "amf://id#51",
+"@id": "amf://id#57",
 "@type": [
-"http://a.ml/vocabularies/document#Example",
+"http://a.ml/vocabularies/apiContract#NamedExamples",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/apiContract#examples": [
+{
+"@id": "amf://id#58",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Example",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/document#strict": [
@@ -19664,9 +20344,11 @@
 ],
 "http://a.ml/vocabularies/document#structuredValue": [
 {
-"@id": "amf://id#51",
+"@id": "amf://id#58",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -19676,7 +20358,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#51/source-map",
+"@id": "amf://id#58/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -19684,7 +20366,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#51"
+"@value": "amf://id#58"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -19705,7 +20387,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#51/source-map",
+"@id": "amf://id#58/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -19739,7 +20421,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#51"
+"@value": "amf://id#58"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -19752,10 +20434,12 @@
 }
 ]
 }
+]
+}
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#50/source-map",
+"@id": "amf://id#56/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -19763,7 +20447,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#50"
+"@value": "amf://id#56"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -19789,7 +20473,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#50"
+"@value": "amf://id#56"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -19815,7 +20499,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#49/source-map",
+"@id": "amf://id#55/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -19835,7 +20519,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#49"
+"@value": "amf://id#55"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -19849,7 +20533,7 @@
 ]
 },
 {
-"@id": "amf://id#52",
+"@id": "amf://id#59",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -19862,7 +20546,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#53",
+"@id": "amf://id#60",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -19879,14 +20563,14 @@
 "@value": "url"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "The URL of this person's profile."
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#53/source-map",
+"@id": "amf://id#60/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -19894,7 +20578,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#53"
+"@value": "amf://id#60"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -19908,7 +20592,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -19920,7 +20604,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#53"
+"@value": "amf://id#60"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -19958,7 +20642,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#52/source-map",
+"@id": "amf://id#59/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -19966,7 +20650,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#52"
+"@value": "amf://id#59"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -19980,7 +20664,7 @@
 ]
 },
 {
-"@id": "amf://id#54",
+"@id": "amf://id#61",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -19993,7 +20677,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#55",
+"@id": "amf://id#62",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -20025,14 +20709,14 @@
 "@value": "id"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "A unique identifier of a person.\n\nIt is a 32 bit string containing alphanumeric characters.\n"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#55/source-map",
+"@id": "amf://id#62/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -20040,7 +20724,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -20064,7 +20748,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#55"
+"@value": "amf://id#62"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -20114,7 +20798,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#54/source-map",
+"@id": "amf://id#61/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -20122,7 +20806,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#54"
+"@value": "amf://id#61"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -20136,7 +20820,7 @@
 ]
 },
 {
-"@id": "amf://id#56",
+"@id": "amf://id#63",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -20149,7 +20833,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#57",
+"@id": "amf://id#64",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -20166,14 +20850,14 @@
 "@value": "language"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "The user's preferred language for rendering."
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#57/source-map",
+"@id": "amf://id#64/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -20181,7 +20865,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#57"
+"@value": "amf://id#64"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -20195,7 +20879,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -20207,7 +20891,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#57"
+"@value": "amf://id#64"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -20245,7 +20929,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#56/source-map",
+"@id": "amf://id#63/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -20253,7 +20937,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#56"
+"@value": "amf://id#63"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -20267,7 +20951,7 @@
 ]
 },
 {
-"@id": "amf://id#58",
+"@id": "amf://id#65",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -20280,7 +20964,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#59",
+"@id": "amf://id#66",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -20297,14 +20981,14 @@
 "@value": "age"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "Very unpractical property to have in a data store.\n"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#59/source-map",
+"@id": "amf://id#66/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -20312,7 +20996,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#59"
+"@value": "amf://id#66"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -20326,7 +21010,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -20338,7 +21022,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#59"
+"@value": "amf://id#66"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -20376,7 +21060,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#58/source-map",
+"@id": "amf://id#65/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -20396,7 +21080,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#58"
+"@value": "amf://id#65"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -20410,7 +21094,7 @@
 ]
 },
 {
-"@id": "amf://id#60",
+"@id": "amf://id#67",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -20423,7 +21107,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#61",
+"@id": "amf://id#68",
 "@type": [
 "http://a.ml/vocabularies/shapes#UnionShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -20431,7 +21115,7 @@
 ],
 "http://a.ml/vocabularies/shapes#anyOf": [
 {
-"@id": "amf://id#62",
+"@id": "amf://id#69",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -20445,7 +21129,7 @@
 ]
 },
 {
-"@id": "amf://id#63",
+"@id": "amf://id#70",
 "@type": [
 "http://a.ml/vocabularies/shapes#NilShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -20460,7 +21144,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#61/source-map",
+"@id": "amf://id#68/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -20468,7 +21152,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#61"
+"@value": "amf://id#68"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -20482,7 +21166,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#61"
+"@value": "amf://id#68"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -20508,7 +21192,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#60/source-map",
+"@id": "amf://id#67/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -20516,7 +21200,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#60"
+"@value": "amf://id#67"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -20530,7 +21214,7 @@
 ]
 },
 {
-"@id": "amf://id#64",
+"@id": "amf://id#71",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -20543,7 +21227,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#65",
+"@id": "amf://id#72",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -20560,14 +21244,14 @@
 "@value": "birthday"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "The person's date of birth, represented as YYYY-MM-DD."
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#65/source-map",
+"@id": "amf://id#72/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -20575,7 +21259,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#65"
+"@value": "amf://id#72"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -20589,7 +21273,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -20601,7 +21285,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#65"
+"@value": "amf://id#72"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -20639,7 +21323,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#64/source-map",
+"@id": "amf://id#71/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -20647,7 +21331,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#64"
+"@value": "amf://id#71"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -20661,7 +21345,7 @@
 ]
 },
 {
-"@id": "amf://id#66",
+"@id": "amf://id#73",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -20674,7 +21358,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#18",
+"@id": "amf://id#19",
 "@type": [
 "http://www.w3.org/ns/shacl#NodeShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -20688,7 +21372,7 @@
 ],
 "http://www.w3.org/ns/shacl#property": [
 {
-"@id": "amf://id#19",
+"@id": "amf://id#20",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -20701,7 +21385,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#20",
+"@id": "amf://id#21",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -20718,14 +21402,14 @@
 "@value": "url"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "The URL of the image.\nTo resize the image and crop it to a square, append the query string **?sz=x**, where x is the dimension in pixels of each side.\n"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#20/source-map",
+"@id": "amf://id#21/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -20733,7 +21417,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#20"
+"@value": "amf://id#21"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -20747,7 +21431,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -20759,7 +21443,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#20"
+"@value": "amf://id#21"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -20797,7 +21481,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#19/source-map",
+"@id": "amf://id#20/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -20805,7 +21489,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#19"
+"@value": "amf://id#20"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -20819,7 +21503,7 @@
 ]
 },
 {
-"@id": "amf://id#21",
+"@id": "amf://id#22",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -20832,7 +21516,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#22",
+"@id": "amf://id#23",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -20849,19 +21533,19 @@
 "@value": "thumb"
 }
 ],
-"http://schema.org/name": [
+"http://a.ml/vocabularies/core#name": [
 {
 "@value": "Thumbnail"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "An URL to the thumbnail of the image. Thumbnails are 60x60px cropped images of the original image.\n"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#22/source-map",
+"@id": "amf://id#23/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -20869,7 +21553,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#22"
+"@value": "amf://id#23"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -20883,7 +21567,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -20907,7 +21591,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#22"
+"@value": "amf://id#23"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -20919,7 +21603,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/name"
+"@value": "http://a.ml/vocabularies/core#name"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -20945,7 +21629,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#21/source-map",
+"@id": "amf://id#22/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -20953,7 +21637,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#21"
+"@value": "amf://id#22"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -20972,16 +21656,23 @@
 "@value": "amf_inline_type_2"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "An image object representing an image object strored in the file store.\nThe image can be only included in the response. It has no effect if the Image appear in the\nrequest. Endpoint handles image creation on it's own and clients can't process images\nexcept of sending image data.\n"
 }
 ],
-"http://a.ml/vocabularies/document#examples": [
+"http://a.ml/vocabularies/apiContract#examples": [
 {
-"@id": "amf://id#23",
+"@id": "amf://id#24",
 "@type": [
-"http://a.ml/vocabularies/document#Example",
+"http://a.ml/vocabularies/apiContract#NamedExamples",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/apiContract#examples": [
+{
+"@id": "amf://id#25",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Example",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/document#strict": [
@@ -20991,15 +21682,19 @@
 ],
 "http://a.ml/vocabularies/document#structuredValue": [
 {
-"@id": "amf://id#23",
+"@id": "amf://id#25",
 "@type": [
-"http://a.ml/vocabularies/data#Object"
+"http://a.ml/vocabularies/data#Object",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#thumb": [
 {
-"@id": "amf://id#24",
+"@id": "amf://id#26",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -21009,7 +21704,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#24/source-map",
+"@id": "amf://id#26/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -21017,7 +21712,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#24"
+"@value": "amf://id#26"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -21033,9 +21728,11 @@
 ],
 "http://a.ml/vocabularies/data#url": [
 {
-"@id": "amf://id#25",
+"@id": "amf://id#27",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -21045,7 +21742,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#25/source-map",
+"@id": "amf://id#27/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -21053,7 +21750,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#25"
+"@value": "amf://id#27"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -21069,7 +21766,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#23/source-map",
+"@id": "amf://id#25/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -21077,12 +21774,36 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#23"
+"@value": "http://a.ml/vocabularies/data#url"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(22,7)-(22,52)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#25"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
 {
 "@value": "[(22,0)-(24,0)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/data#thumb"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(23,9)-(23,60)]"
 }
 ]
 }
@@ -21091,7 +21812,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#23"
+"@value": "amf://id#25"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -21112,7 +21833,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#23/source-map",
+"@id": "amf://id#25/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -21146,7 +21867,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#23"
+"@value": "amf://id#25"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -21159,10 +21880,12 @@
 }
 ]
 }
+]
+}
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#18/source-map",
+"@id": "amf://id#19/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -21170,7 +21893,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#18"
+"@value": "amf://id#19"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -21184,7 +21907,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#18"
+"@value": "amf://id#19"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -21198,7 +21921,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -21210,7 +21933,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#18"
+"@value": "amf://id#19"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -21224,7 +21947,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#18"
+"@value": "amf://id#19"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -21250,7 +21973,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#66/source-map",
+"@id": "amf://id#73/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -21258,7 +21981,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#66"
+"@value": "amf://id#73"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -21272,7 +21995,7 @@
 ]
 },
 {
-"@id": "amf://id#67",
+"@id": "amf://id#74",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -21285,7 +22008,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#68",
+"@id": "amf://id#75",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -21302,20 +22025,22 @@
 "@value": "gender?"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "The person's gender. Possible values includes, but are not limited to, the following values:\n* \"male\" - Male gender.\n* \"female\" - Female gender.\n* \"other\" - Other.\n"
 }
 ],
 "http://www.w3.org/ns/shacl#in": [
 {
-"@id": "amf://id#68/list",
+"@id": "amf://id#75/list",
 "@type": "http://www.w3.org/2000/01/rdf-schema#Seq",
 "http://www.w3.org/2000/01/rdf-schema#_1": [
 {
-"@id": "amf://id#69",
+"@id": "amf://id#76",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -21325,7 +22050,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#69/source-map",
+"@id": "amf://id#76/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -21333,7 +22058,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#69"
+"@value": "amf://id#76"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -21349,9 +22074,11 @@
 ],
 "http://www.w3.org/2000/01/rdf-schema#_2": [
 {
-"@id": "amf://id#70",
+"@id": "amf://id#77",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -21361,7 +22088,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#70/source-map",
+"@id": "amf://id#77/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -21369,7 +22096,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#70"
+"@value": "amf://id#77"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -21385,9 +22112,11 @@
 ],
 "http://www.w3.org/2000/01/rdf-schema#_3": [
 {
-"@id": "amf://id#71",
+"@id": "amf://id#78",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -21397,7 +22126,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#71/source-map",
+"@id": "amf://id#78/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -21405,7 +22134,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#71"
+"@value": "amf://id#78"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -21421,14 +22150,21 @@
 ]
 }
 ],
-"http://a.ml/vocabularies/document#examples": [
+"http://a.ml/vocabularies/apiContract#examples": [
 {
-"@id": "amf://id#72",
+"@id": "amf://id#79",
 "@type": [
-"http://a.ml/vocabularies/document#Example",
+"http://a.ml/vocabularies/apiContract#NamedExamples",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://schema.org/name": [
+"http://a.ml/vocabularies/apiContract#examples": [
+{
+"@id": "amf://id#80",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Example",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/core#name": [
 {
 "@value": "Women"
 }
@@ -21440,9 +22176,11 @@
 ],
 "http://a.ml/vocabularies/document#structuredValue": [
 {
-"@id": "amf://id#72",
+"@id": "amf://id#80",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -21452,7 +22190,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#72/source-map",
+"@id": "amf://id#80/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -21460,7 +22198,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#72"
+"@value": "amf://id#80"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -21481,7 +22219,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#72/source-map",
+"@id": "amf://id#80/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -21515,7 +22253,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#72"
+"@value": "amf://id#80"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -21527,7 +22265,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/name"
+"@value": "http://a.ml/vocabularies/core#name"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -21541,12 +22279,12 @@
 ]
 },
 {
-"@id": "amf://id#73",
+"@id": "amf://id#81",
 "@type": [
-"http://a.ml/vocabularies/document#Example",
+"http://a.ml/vocabularies/apiContract#Example",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://schema.org/name": [
+"http://a.ml/vocabularies/core#name": [
 {
 "@value": "Man"
 }
@@ -21558,9 +22296,11 @@
 ],
 "http://a.ml/vocabularies/document#structuredValue": [
 {
-"@id": "amf://id#73",
+"@id": "amf://id#81",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -21570,7 +22310,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#73/source-map",
+"@id": "amf://id#81/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -21578,7 +22318,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#73"
+"@value": "amf://id#81"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -21599,7 +22339,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#73/source-map",
+"@id": "amf://id#81/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -21633,7 +22373,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#73"
+"@value": "amf://id#81"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -21645,7 +22385,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/name"
+"@value": "http://a.ml/vocabularies/core#name"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -21659,12 +22399,12 @@
 ]
 },
 {
-"@id": "amf://id#74",
+"@id": "amf://id#82",
 "@type": [
-"http://a.ml/vocabularies/document#Example",
+"http://a.ml/vocabularies/apiContract#Example",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://schema.org/name": [
+"http://a.ml/vocabularies/core#name": [
 {
 "@value": "Elmo"
 }
@@ -21676,9 +22416,11 @@
 ],
 "http://a.ml/vocabularies/document#structuredValue": [
 {
-"@id": "amf://id#74",
+"@id": "amf://id#82",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -21688,7 +22430,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#74/source-map",
+"@id": "amf://id#82/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -21696,7 +22438,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#74"
+"@value": "amf://id#82"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -21717,7 +22459,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#74/source-map",
+"@id": "amf://id#82/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -21751,7 +22493,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#74"
+"@value": "amf://id#82"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -21763,7 +22505,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/name"
+"@value": "http://a.ml/vocabularies/core#name"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -21776,10 +22518,12 @@
 }
 ]
 }
+]
+}
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#68/source-map",
+"@id": "amf://id#75/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -21787,7 +22531,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#68"
+"@value": "amf://id#75"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -21825,7 +22569,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#68"
+"@value": "amf://id#75"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -21837,7 +22581,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -21863,7 +22607,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#67/source-map",
+"@id": "amf://id#74/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -21871,7 +22615,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#67"
+"@value": "amf://id#74"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -21890,21 +22634,28 @@
 "@value": "AppPerson"
 }
 ],
-"http://schema.org/name": [
+"http://a.ml/vocabularies/core#name": [
 {
 "@value": "A person resource"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "An object representing a person in the API.\nThis object will be used in all methods returning a Person or list of people.\n"
 }
 ],
-"http://a.ml/vocabularies/document#examples": [
+"http://a.ml/vocabularies/apiContract#examples": [
 {
-"@id": "amf://id#75",
+"@id": "amf://id#83",
 "@type": [
-"http://a.ml/vocabularies/document#Example",
+"http://a.ml/vocabularies/apiContract#NamedExamples",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/apiContract#examples": [
+{
+"@id": "amf://id#84",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Example",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/document#strict": [
@@ -21914,351 +22665,23 @@
 ],
 "http://a.ml/vocabularies/document#structuredValue": [
 {
-"@id": "amf://id#75",
+"@id": "amf://id#84",
 "@type": [
-"http://a.ml/vocabularies/data#Object"
+"http://a.ml/vocabularies/data#Object",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#birthday": [
 {
-"@id": "amf://id#76",
+"@id": "amf://id#85",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
 "@value": "1983-10-20",
-"@type": "http://www.w3.org/2001/XMLSchema#string"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "amf://id#76/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#76"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(12,12)-(12,24)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"http://a.ml/vocabularies/data#etag": [
-{
-"@id": "amf://id#77",
-"@type": [
-"http://a.ml/vocabularies/data#Scalar"
-],
-"http://a.ml/vocabularies/data#value": [
-{
-"@value": "W\\244m4n5kj3gbn2nj4k4n4",
-"@type": "http://www.w3.org/2001/XMLSchema#string"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "amf://id#77/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#77"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(20,8)-(20,34)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"http://a.ml/vocabularies/data#favouriteNumber": [
-{
-"@id": "amf://id#78",
-"@type": [
-"http://a.ml/vocabularies/data#Scalar"
-],
-"http://a.ml/vocabularies/data#value": [
-{
-"@value": "10",
-"@type": "http://www.w3.org/2001/XMLSchema#integer"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "amf://id#78/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#78"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(21,19)-(21,21)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"http://a.ml/vocabularies/data#favouriteTime": [
-{
-"@id": "amf://id#79",
-"@type": [
-"http://a.ml/vocabularies/data#Scalar"
-],
-"http://a.ml/vocabularies/data#value": [
-{
-"@value": "10:29:52",
-"@type": "http://www.w3.org/2001/XMLSchema#string"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "amf://id#79/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#79"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(22,17)-(22,25)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"http://a.ml/vocabularies/data#gender": [
-{
-"@id": "amf://id#80",
-"@type": [
-"http://a.ml/vocabularies/data#Scalar"
-],
-"http://a.ml/vocabularies/data#value": [
-{
-"@value": "male",
-"@type": "http://www.w3.org/2001/XMLSchema#string"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "amf://id#80/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#80"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(13,10)-(13,14)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"http://a.ml/vocabularies/data#id": [
-{
-"@id": "amf://id#81",
-"@type": [
-"http://a.ml/vocabularies/data#Scalar"
-],
-"http://a.ml/vocabularies/data#value": [
-{
-"@value": "R34fg663H9KW9MMSKISIhTs1dR7Hss7e",
-"@type": "http://www.w3.org/2001/XMLSchema#string"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "amf://id#81/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#81"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(10,6)-(10,40)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"http://a.ml/vocabularies/data#image": [
-{
-"@id": "amf://id#82",
-"@type": [
-"http://a.ml/vocabularies/data#Object"
-],
-"http://a.ml/vocabularies/data#thumb": [
-{
-"@id": "amf://id#83",
-"@type": [
-"http://a.ml/vocabularies/data#Scalar"
-],
-"http://a.ml/vocabularies/data#value": [
-{
-"@value": "https://domain.com/profile/pawel.psztyc/image/thumb",
-"@type": "http://www.w3.org/2001/XMLSchema#string"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "amf://id#83/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#83"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(17,11)-(17,62)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"http://a.ml/vocabularies/data#url": [
-{
-"@id": "amf://id#84",
-"@type": [
-"http://a.ml/vocabularies/data#Scalar"
-],
-"http://a.ml/vocabularies/data#value": [
-{
-"@value": "https://domain.com/profile/pawel.psztyc/image",
-"@type": "http://www.w3.org/2001/XMLSchema#string"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "amf://id#84/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#84"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(16,9)-(16,54)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "amf://id#82/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#data-node-properties": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#82"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "url->[(16,4)-(17,0)]#thumb->[(17,4)-(18,0)]"
-}
-]
-}
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#82"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(16,0)-(18,0)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"http://a.ml/vocabularies/data#language": [
-{
-"@id": "amf://id#85",
-"@type": [
-"http://a.ml/vocabularies/data#Scalar"
-],
-"http://a.ml/vocabularies/data#value": [
-{
-"@value": "en_GB",
 "@type": "http://www.w3.org/2001/XMLSchema#string"
 }
 ],
@@ -22277,7 +22700,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
 {
-"@value": "[(19,12)-(19,17)]"
+"@value": "[(12,12)-(12,24)]"
 }
 ]
 }
@@ -22286,15 +22709,17 @@
 ]
 }
 ],
-"http://a.ml/vocabularies/data#name": [
+"http://a.ml/vocabularies/data#etag": [
 {
 "@id": "amf://id#86",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
-"@value": "Pawel Psztyc",
+"@value": "W\\244m4n5kj3gbn2nj4k4n4",
 "@type": "http://www.w3.org/2001/XMLSchema#string"
 }
 ],
@@ -22313,7 +22738,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
 {
-"@value": "[(11,8)-(11,22)]"
+"@value": "[(20,8)-(20,34)]"
 }
 ]
 }
@@ -22322,16 +22747,18 @@
 ]
 }
 ],
-"http://a.ml/vocabularies/data#nillable": [
+"http://a.ml/vocabularies/data#favouriteNumber": [
 {
 "@id": "amf://id#87",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
-"@value": "null",
-"@type": "http://www.w3.org/2001/XMLSchema#nil"
+"@value": "10",
+"@type": "http://www.w3.org/2001/XMLSchema#integer"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
@@ -22349,7 +22776,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
 {
-"@value": "[(23,12)-(23,16)]"
+"@value": "[(21,19)-(21,21)]"
 }
 ]
 }
@@ -22358,15 +22785,17 @@
 ]
 }
 ],
-"http://a.ml/vocabularies/data#tagline": [
+"http://a.ml/vocabularies/data#favouriteTime": [
 {
 "@id": "amf://id#88",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
-"@value": "Some text about me.",
+"@value": "10:29:52",
 "@type": "http://www.w3.org/2001/XMLSchema#string"
 }
 ],
@@ -22385,7 +22814,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
 {
-"@value": "[(18,11)-(18,30)]"
+"@value": "[(22,17)-(22,25)]"
 }
 ]
 }
@@ -22394,15 +22823,17 @@
 ]
 }
 ],
-"http://a.ml/vocabularies/data#url": [
+"http://a.ml/vocabularies/data#gender": [
 {
 "@id": "amf://id#89",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
-"@value": "https://domain.com/profile/pawel.psztyc",
+"@value": "male",
 "@type": "http://www.w3.org/2001/XMLSchema#string"
 }
 ],
@@ -22421,6 +22852,380 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
 {
+"@value": "[(13,10)-(13,14)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"http://a.ml/vocabularies/data#id": [
+{
+"@id": "amf://id#90",
+"@type": [
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/data#value": [
+{
+"@value": "R34fg663H9KW9MMSKISIhTs1dR7Hss7e",
+"@type": "http://www.w3.org/2001/XMLSchema#string"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#sources": [
+{
+"@id": "amf://id#90/source-map",
+"@type": [
+"http://a.ml/vocabularies/document-source-maps#SourceMap"
+],
+"http://a.ml/vocabularies/document-source-maps#lexical": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#90"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(10,6)-(10,40)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"http://a.ml/vocabularies/data#image": [
+{
+"@id": "amf://id#91",
+"@type": [
+"http://a.ml/vocabularies/data#Object",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/data#thumb": [
+{
+"@id": "amf://id#92",
+"@type": [
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/data#value": [
+{
+"@value": "https://domain.com/profile/pawel.psztyc/image/thumb",
+"@type": "http://www.w3.org/2001/XMLSchema#string"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#sources": [
+{
+"@id": "amf://id#92/source-map",
+"@type": [
+"http://a.ml/vocabularies/document-source-maps#SourceMap"
+],
+"http://a.ml/vocabularies/document-source-maps#lexical": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#92"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(17,11)-(17,62)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"http://a.ml/vocabularies/data#url": [
+{
+"@id": "amf://id#93",
+"@type": [
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/data#value": [
+{
+"@value": "https://domain.com/profile/pawel.psztyc/image",
+"@type": "http://www.w3.org/2001/XMLSchema#string"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#sources": [
+{
+"@id": "amf://id#93/source-map",
+"@type": [
+"http://a.ml/vocabularies/document-source-maps#SourceMap"
+],
+"http://a.ml/vocabularies/document-source-maps#lexical": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#93"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(16,9)-(16,54)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"http://a.ml/vocabularies/document-source-maps#sources": [
+{
+"@id": "amf://id#91/source-map",
+"@type": [
+"http://a.ml/vocabularies/document-source-maps#SourceMap"
+],
+"http://a.ml/vocabularies/document-source-maps#data-node-properties": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#91"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "url->[(16,4)-(17,0)]#thumb->[(17,4)-(18,0)]"
+}
+]
+}
+],
+"http://a.ml/vocabularies/document-source-maps#lexical": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/data#url"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(16,9)-(16,54)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#91"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(16,0)-(18,0)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/data#thumb"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(17,11)-(17,62)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"http://a.ml/vocabularies/data#language": [
+{
+"@id": "amf://id#94",
+"@type": [
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/data#value": [
+{
+"@value": "en_GB",
+"@type": "http://www.w3.org/2001/XMLSchema#string"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#sources": [
+{
+"@id": "amf://id#94/source-map",
+"@type": [
+"http://a.ml/vocabularies/document-source-maps#SourceMap"
+],
+"http://a.ml/vocabularies/document-source-maps#lexical": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#94"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(19,12)-(19,17)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"http://a.ml/vocabularies/data#name": [
+{
+"@id": "amf://id#95",
+"@type": [
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/data#value": [
+{
+"@value": "Pawel Psztyc",
+"@type": "http://www.w3.org/2001/XMLSchema#string"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#sources": [
+{
+"@id": "amf://id#95/source-map",
+"@type": [
+"http://a.ml/vocabularies/document-source-maps#SourceMap"
+],
+"http://a.ml/vocabularies/document-source-maps#lexical": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#95"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(11,8)-(11,22)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"http://a.ml/vocabularies/data#nillable": [
+{
+"@id": "amf://id#96",
+"@type": [
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/data#value": [
+{
+"@value": "null",
+"@type": "http://www.w3.org/2001/XMLSchema#nil"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#sources": [
+{
+"@id": "amf://id#96/source-map",
+"@type": [
+"http://a.ml/vocabularies/document-source-maps#SourceMap"
+],
+"http://a.ml/vocabularies/document-source-maps#lexical": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#96"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(23,12)-(23,16)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"http://a.ml/vocabularies/data#tagline": [
+{
+"@id": "amf://id#97",
+"@type": [
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/data#value": [
+{
+"@value": "Some text about me.",
+"@type": "http://www.w3.org/2001/XMLSchema#string"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#sources": [
+{
+"@id": "amf://id#97/source-map",
+"@type": [
+"http://a.ml/vocabularies/document-source-maps#SourceMap"
+],
+"http://a.ml/vocabularies/document-source-maps#lexical": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#97"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(18,11)-(18,30)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"http://a.ml/vocabularies/data#url": [
+{
+"@id": "amf://id#98",
+"@type": [
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/data#value": [
+{
+"@value": "https://domain.com/profile/pawel.psztyc",
+"@type": "http://www.w3.org/2001/XMLSchema#string"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#sources": [
+{
+"@id": "amf://id#98/source-map",
+"@type": [
+"http://a.ml/vocabularies/document-source-maps#SourceMap"
+],
+"http://a.ml/vocabularies/document-source-maps#lexical": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#98"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
 "@value": "[(14,7)-(14,48)]"
 }
 ]
@@ -22432,7 +23237,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#75/source-map",
+"@id": "amf://id#84/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -22440,12 +23245,156 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#75"
+"@value": "http://a.ml/vocabularies/data#url"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(14,7)-(14,48)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/data#nillable"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(23,12)-(23,16)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/data#language"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(19,12)-(19,17)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/data#id"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(10,6)-(10,40)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/data#favouriteTime"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(22,17)-(22,25)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/data#etag"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(20,8)-(20,34)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#84"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
 {
 "@value": "[(10,0)-(25,0)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/data#birthday"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(12,12)-(12,24)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/data#favouriteNumber"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(21,19)-(21,21)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/data#gender"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(13,10)-(13,14)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/data#image"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(16,0)-(18,0)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/data#name"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(11,8)-(11,22)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/data#tagline"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(18,11)-(18,30)]"
 }
 ]
 }
@@ -22454,7 +23403,19 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#75"
+"@value": "http://a.ml/vocabularies/data#image"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "url->[(16,4)-(17,0)]#thumb->[(17,4)-(18,0)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#84"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -22475,7 +23436,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#75/source-map",
+"@id": "amf://id#84/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -22509,7 +23470,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#75"
+"@value": "amf://id#84"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -22522,10 +23483,12 @@
 }
 ]
 }
+]
+}
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#125/source-map",
+"@id": "amf://id#138/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -22533,7 +23496,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#125"
+"@value": "amf://id#138"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -22547,7 +23510,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#125"
+"@value": "amf://id#138"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -22561,7 +23524,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -22573,7 +23536,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#125"
+"@value": "amf://id#138"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -22585,7 +23548,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/name"
+"@value": "http://a.ml/vocabularies/core#name"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -22599,7 +23562,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#125"
+"@value": "amf://id#138"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -22613,7 +23576,7 @@
 ]
 },
 {
-"@id": "amf://id#126",
+"@id": "amf://id#139",
 "@type": [
 "http://www.w3.org/ns/shacl#NodeShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -22627,7 +23590,7 @@
 ],
 "http://www.w3.org/ns/shacl#property": [
 {
-"@id": "amf://id#42",
+"@id": "amf://id#35",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -22640,7 +23603,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#43",
+"@id": "amf://id#36",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -22657,14 +23620,14 @@
 "@value": "etag"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "ETag of this resource for caching purposes.\n__This property will be ignored when creating an object.__\n"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#43/source-map",
+"@id": "amf://id#36/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -22672,7 +23635,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#43"
+"@value": "amf://id#36"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -22686,7 +23649,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -22698,7 +23661,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#43"
+"@value": "amf://id#36"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -22736,7 +23699,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#42/source-map",
+"@id": "amf://id#35/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -22744,7 +23707,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#42"
+"@value": "amf://id#35"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -22758,7 +23721,7 @@
 ]
 },
 {
-"@id": "amf://id#94",
+"@id": "amf://id#101",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -22771,7 +23734,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#95",
+"@id": "amf://id#102",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -22793,16 +23756,23 @@
 "@value": "upc"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "The Universal Produc Code. It consists of 12 numerical digits. However, because of the\ninteger precision limitation in JavaScript it is represented as a string.\n"
 }
 ],
-"http://a.ml/vocabularies/document#examples": [
+"http://a.ml/vocabularies/apiContract#examples": [
 {
-"@id": "amf://id#96",
+"@id": "amf://id#103",
 "@type": [
-"http://a.ml/vocabularies/document#Example",
+"http://a.ml/vocabularies/apiContract#NamedExamples",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/apiContract#examples": [
+{
+"@id": "amf://id#104",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Example",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/document#strict": [
@@ -22812,9 +23782,11 @@
 ],
 "http://a.ml/vocabularies/document#structuredValue": [
 {
-"@id": "amf://id#96",
+"@id": "amf://id#104",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -22824,7 +23796,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#96/source-map",
+"@id": "amf://id#104/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -22832,7 +23804,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#96"
+"@value": "amf://id#104"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -22853,7 +23825,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#96/source-map",
+"@id": "amf://id#104/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -22887,7 +23859,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#96"
+"@value": "amf://id#104"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -22900,10 +23872,12 @@
 }
 ]
 }
+]
+}
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#95/source-map",
+"@id": "amf://id#102/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -22911,7 +23885,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#95"
+"@value": "amf://id#102"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -22925,7 +23899,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -22949,7 +23923,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#95"
+"@value": "amf://id#102"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -22987,7 +23961,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#94/source-map",
+"@id": "amf://id#101/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -23007,7 +23981,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#94"
+"@value": "amf://id#101"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -23021,7 +23995,7 @@
 ]
 },
 {
-"@id": "amf://id#97",
+"@id": "amf://id#105",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -23034,7 +24008,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#98",
+"@id": "amf://id#106",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -23051,16 +24025,23 @@
 "@value": "name"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "Product name"
 }
 ],
-"http://a.ml/vocabularies/document#examples": [
+"http://a.ml/vocabularies/apiContract#examples": [
 {
-"@id": "amf://id#99",
+"@id": "amf://id#107",
 "@type": [
-"http://a.ml/vocabularies/document#Example",
+"http://a.ml/vocabularies/apiContract#NamedExamples",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/apiContract#examples": [
+{
+"@id": "amf://id#108",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Example",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/document#strict": [
@@ -23070,9 +24051,11 @@
 ],
 "http://a.ml/vocabularies/document#structuredValue": [
 {
-"@id": "amf://id#99",
+"@id": "amf://id#108",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -23082,7 +24065,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#99/source-map",
+"@id": "amf://id#108/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -23090,7 +24073,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#99"
+"@value": "amf://id#108"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -23111,7 +24094,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#99/source-map",
+"@id": "amf://id#108/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -23145,7 +24128,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#99"
+"@value": "amf://id#108"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -23158,10 +24141,12 @@
 }
 ]
 }
+]
+}
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#98/source-map",
+"@id": "amf://id#106/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -23169,7 +24154,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#98"
+"@value": "amf://id#106"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -23183,7 +24168,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -23195,7 +24180,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#98"
+"@value": "amf://id#106"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -23233,7 +24218,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#97/source-map",
+"@id": "amf://id#105/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -23253,7 +24238,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#97"
+"@value": "amf://id#105"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -23267,7 +24252,7 @@
 ]
 },
 {
-"@id": "amf://id#127",
+"@id": "amf://id#140",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -23324,7 +24309,7 @@
 "@value": "width"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "Width of the shape.\n"
 }
@@ -23353,7 +24338,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -23455,7 +24440,7 @@
 "@value": "height"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "Height of the shape.\n"
 }
@@ -23484,7 +24469,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -23586,7 +24571,7 @@
 "@value": "unit?"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "A unit that describes the dimension. It can be, for example, `px` for\npixels, `pt` for points, `%` for percentage.\n"
 }
@@ -23595,7 +24580,9 @@
 {
 "@id": "amf://id#9",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -23692,7 +24679,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -23745,16 +24732,23 @@
 "@value": "dimension"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "A dimmensions of an object like image.\n"
 }
 ],
-"http://a.ml/vocabularies/document#examples": [
+"http://a.ml/vocabularies/apiContract#examples": [
 {
 "@id": "amf://id#10",
 "@type": [
-"http://a.ml/vocabularies/document#Example",
+"http://a.ml/vocabularies/apiContract#NamedExamples",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/apiContract#examples": [
+{
+"@id": "amf://id#11",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Example",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/document#strict": [
@@ -23764,55 +24758,23 @@
 ],
 "http://a.ml/vocabularies/document#structuredValue": [
 {
-"@id": "amf://id#10",
+"@id": "amf://id#11",
 "@type": [
-"http://a.ml/vocabularies/data#Object"
+"http://a.ml/vocabularies/data#Object",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#height": [
 {
-"@id": "amf://id#11",
+"@id": "amf://id#12",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
 "@value": "160",
-"@type": "http://www.w3.org/2001/XMLSchema#integer"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "amf://id#11/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#11"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(24,10)-(24,13)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"http://a.ml/vocabularies/data#width": [
-{
-"@id": "amf://id#12",
-"@type": [
-"http://a.ml/vocabularies/data#Scalar"
-],
-"http://a.ml/vocabularies/data#value": [
-{
-"@value": "200",
 "@type": "http://www.w3.org/2001/XMLSchema#integer"
 }
 ],
@@ -23831,6 +24793,44 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
 {
+"@value": "[(24,10)-(24,13)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"http://a.ml/vocabularies/data#width": [
+{
+"@id": "amf://id#13",
+"@type": [
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/data#value": [
+{
+"@value": "200",
+"@type": "http://www.w3.org/2001/XMLSchema#integer"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#sources": [
+{
+"@id": "amf://id#13/source-map",
+"@type": [
+"http://a.ml/vocabularies/document-source-maps#SourceMap"
+],
+"http://a.ml/vocabularies/document-source-maps#lexical": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#13"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
 "@value": "[(23,9)-(23,12)]"
 }
 ]
@@ -23842,7 +24842,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#10/source-map",
+"@id": "amf://id#11/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -23850,12 +24850,36 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#10"
+"@value": "http://a.ml/vocabularies/data#width"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(23,9)-(23,12)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#11"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
 {
 "@value": "[(23,0)-(25,0)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/data#height"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(24,10)-(24,13)]"
 }
 ]
 }
@@ -23864,7 +24888,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#10"
+"@value": "amf://id#11"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -23885,7 +24909,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#10/source-map",
+"@id": "amf://id#11/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -23919,12 +24943,14 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#10"
+"@value": "amf://id#11"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
 {
 "@value": "[(22,0)-(25,0)]"
+}
+]
 }
 ]
 }
@@ -23957,7 +24983,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -24009,7 +25035,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#127/source-map",
+"@id": "amf://id#140/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -24017,7 +25043,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#127"
+"@value": "amf://id#140"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -24031,7 +25057,7 @@
 ]
 },
 {
-"@id": "amf://id#100",
+"@id": "amf://id#109",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -24044,7 +25070,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#101",
+"@id": "amf://id#110",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -24066,14 +25092,14 @@
 "@value": "id"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "Product id. It is a UUID of the database record.\n__This property will be ignored when creating an object.__\nIt will be available when the product is stored in the datastore.\n"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#101/source-map",
+"@id": "amf://id#110/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -24081,7 +25107,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -24093,7 +25119,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#101"
+"@value": "amf://id#110"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -24131,7 +25157,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#100/source-map",
+"@id": "amf://id#109/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -24139,7 +25165,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#100"
+"@value": "amf://id#109"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -24153,7 +25179,7 @@
 ]
 },
 {
-"@id": "amf://id#102",
+"@id": "amf://id#111",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -24166,7 +25192,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#103",
+"@id": "amf://id#112",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -24183,16 +25209,23 @@
 "@value": "unit"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "The unit of measuremet for the quantity property."
 }
 ],
-"http://a.ml/vocabularies/document#examples": [
+"http://a.ml/vocabularies/apiContract#examples": [
 {
-"@id": "amf://id#104",
+"@id": "amf://id#113",
 "@type": [
-"http://a.ml/vocabularies/document#Example",
+"http://a.ml/vocabularies/apiContract#NamedExamples",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/apiContract#examples": [
+{
+"@id": "amf://id#114",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Example",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/document#strict": [
@@ -24202,9 +25235,11 @@
 ],
 "http://a.ml/vocabularies/document#structuredValue": [
 {
-"@id": "amf://id#104",
+"@id": "amf://id#114",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -24214,7 +25249,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#104/source-map",
+"@id": "amf://id#114/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -24222,7 +25257,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#104"
+"@value": "amf://id#114"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -24243,7 +25278,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#104/source-map",
+"@id": "amf://id#114/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -24277,7 +25312,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#104"
+"@value": "amf://id#114"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -24290,10 +25325,12 @@
 }
 ]
 }
+]
+}
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#103/source-map",
+"@id": "amf://id#112/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -24301,7 +25338,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#103"
+"@value": "amf://id#112"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -24315,7 +25352,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -24327,7 +25364,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#103"
+"@value": "amf://id#112"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -24365,7 +25402,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#102/source-map",
+"@id": "amf://id#111/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -24385,7 +25422,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#102"
+"@value": "amf://id#111"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -24399,7 +25436,7 @@
 ]
 },
 {
-"@id": "amf://id#105",
+"@id": "amf://id#115",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -24412,7 +25449,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#106",
+"@id": "amf://id#116",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -24429,16 +25466,23 @@
 "@value": "available"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "Product current availability in the store.\nProduct may be not available but the users still can order it with later delivery date.\n"
 }
 ],
-"http://a.ml/vocabularies/document#examples": [
+"http://a.ml/vocabularies/apiContract#examples": [
 {
-"@id": "amf://id#107",
+"@id": "amf://id#117",
 "@type": [
-"http://a.ml/vocabularies/document#Example",
+"http://a.ml/vocabularies/apiContract#NamedExamples",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/apiContract#examples": [
+{
+"@id": "amf://id#118",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Example",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/document#strict": [
@@ -24448,9 +25492,11 @@
 ],
 "http://a.ml/vocabularies/document#structuredValue": [
 {
-"@id": "amf://id#107",
+"@id": "amf://id#118",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -24460,7 +25506,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#107/source-map",
+"@id": "amf://id#118/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -24468,7 +25514,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#107"
+"@value": "amf://id#118"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -24489,7 +25535,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#107/source-map",
+"@id": "amf://id#118/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -24523,7 +25569,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#107"
+"@value": "amf://id#118"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -24536,10 +25582,12 @@
 }
 ]
 }
+]
+}
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#106/source-map",
+"@id": "amf://id#116/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -24547,7 +25595,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#106"
+"@value": "amf://id#116"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -24561,7 +25609,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -24573,7 +25621,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#106"
+"@value": "amf://id#116"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -24611,7 +25659,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#105/source-map",
+"@id": "amf://id#115/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -24631,7 +25679,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#105"
+"@value": "amf://id#115"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -24645,7 +25693,7 @@
 ]
 },
 {
-"@id": "amf://id#108",
+"@id": "amf://id#119",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -24658,7 +25706,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#109",
+"@id": "amf://id#120",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -24675,16 +25723,23 @@
 "@value": "quantity"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "The quantity of the product in the one unit of measurement.\nSee `unit` property for more information.\n"
 }
 ],
-"http://a.ml/vocabularies/document#examples": [
+"http://a.ml/vocabularies/apiContract#examples": [
 {
-"@id": "amf://id#110",
+"@id": "amf://id#121",
 "@type": [
-"http://a.ml/vocabularies/document#Example",
+"http://a.ml/vocabularies/apiContract#NamedExamples",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/apiContract#examples": [
+{
+"@id": "amf://id#122",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Example",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/document#strict": [
@@ -24694,9 +25749,11 @@
 ],
 "http://a.ml/vocabularies/document#structuredValue": [
 {
-"@id": "amf://id#110",
+"@id": "amf://id#122",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -24706,7 +25763,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#110/source-map",
+"@id": "amf://id#122/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -24714,7 +25771,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#110"
+"@value": "amf://id#122"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -24735,7 +25792,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#110/source-map",
+"@id": "amf://id#122/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -24769,7 +25826,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#110"
+"@value": "amf://id#122"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -24782,10 +25839,12 @@
 }
 ]
 }
+]
+}
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#109/source-map",
+"@id": "amf://id#120/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -24793,7 +25852,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#109"
+"@value": "amf://id#120"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -24807,7 +25866,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -24819,7 +25878,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#109"
+"@value": "amf://id#120"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -24857,7 +25916,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#108/source-map",
+"@id": "amf://id#119/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -24877,7 +25936,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#108"
+"@value": "amf://id#119"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -24896,19 +25955,19 @@
 "@value": "ComplexInclusion"
 }
 ],
-"http://schema.org/name": [
+"http://a.ml/vocabularies/core#name": [
 {
 "@value": "A product resource"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "A single product representing an item in the store."
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#126/source-map",
+"@id": "amf://id#139/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -24916,7 +25975,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#126"
+"@value": "amf://id#139"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -24930,7 +25989,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -24954,7 +26013,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#126"
+"@value": "amf://id#139"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -24966,7 +26025,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/name"
+"@value": "http://a.ml/vocabularies/core#name"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -24980,7 +26039,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#126"
+"@value": "amf://id#139"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -24994,7 +26053,7 @@
 ]
 },
 {
-"@id": "amf://id#128",
+"@id": "amf://id#141",
 "@type": [
 "http://www.w3.org/ns/shacl#NodeShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -25008,7 +26067,7 @@
 ],
 "http://www.w3.org/ns/shacl#property": [
 {
-"@id": "amf://id#129",
+"@id": "amf://id#142",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -25021,7 +26080,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#130",
+"@id": "amf://id#143",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -25038,16 +26097,18 @@
 "@value": "id"
 }
 ],
-"http://schema.org/name": [
+"http://a.ml/vocabularies/core#name": [
 {
 "@value": "The Id Schema "
 }
 ],
 "http://www.w3.org/ns/shacl#defaultValue": [
 {
-"@id": "amf://id#131",
+"@id": "amf://id#144",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -25057,7 +26118,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#131/source-map",
+"@id": "amf://id#144/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -25065,7 +26126,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#131"
+"@value": "amf://id#144"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -25086,7 +26147,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#130/source-map",
+"@id": "amf://id#143/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -25094,7 +26155,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#130"
+"@value": "amf://id#143"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -25132,7 +26193,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#130"
+"@value": "amf://id#143"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -25144,7 +26205,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/name"
+"@value": "http://a.ml/vocabularies/core#name"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -25170,7 +26231,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#129/source-map",
+"@id": "amf://id#142/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -25178,7 +26239,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#129"
+"@value": "amf://id#142"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -25192,7 +26253,7 @@
 ]
 },
 {
-"@id": "amf://id#132",
+"@id": "amf://id#145",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -25205,7 +26266,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#133",
+"@id": "amf://id#146",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -25222,16 +26283,18 @@
 "@value": "name"
 }
 ],
-"http://schema.org/name": [
+"http://a.ml/vocabularies/core#name": [
 {
 "@value": "The Name Schema "
 }
 ],
 "http://www.w3.org/ns/shacl#defaultValue": [
 {
-"@id": "amf://id#134",
+"@id": "amf://id#147",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -25241,7 +26304,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#134/source-map",
+"@id": "amf://id#147/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -25249,7 +26312,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#134"
+"@value": "amf://id#147"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -25270,7 +26333,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#133/source-map",
+"@id": "amf://id#146/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -25278,7 +26341,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#133"
+"@value": "amf://id#146"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -25316,7 +26379,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#133"
+"@value": "amf://id#146"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -25328,7 +26391,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/name"
+"@value": "http://a.ml/vocabularies/core#name"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -25354,7 +26417,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#132/source-map",
+"@id": "amf://id#145/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -25362,7 +26425,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#132"
+"@value": "amf://id#145"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -25376,7 +26439,7 @@
 ]
 },
 {
-"@id": "amf://id#135",
+"@id": "amf://id#148",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -25389,7 +26452,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#136",
+"@id": "amf://id#149",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -25406,16 +26469,18 @@
 "@value": "birthday"
 }
 ],
-"http://schema.org/name": [
+"http://a.ml/vocabularies/core#name": [
 {
 "@value": "The Birthday Schema "
 }
 ],
 "http://www.w3.org/ns/shacl#defaultValue": [
 {
-"@id": "amf://id#137",
+"@id": "amf://id#150",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -25425,7 +26490,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#137/source-map",
+"@id": "amf://id#150/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -25433,7 +26498,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#137"
+"@value": "amf://id#150"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -25454,7 +26519,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#136/source-map",
+"@id": "amf://id#149/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -25462,7 +26527,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#136"
+"@value": "amf://id#149"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -25500,7 +26565,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#136"
+"@value": "amf://id#149"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -25512,7 +26577,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/name"
+"@value": "http://a.ml/vocabularies/core#name"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -25538,7 +26603,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#135/source-map",
+"@id": "amf://id#148/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -25546,7 +26611,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#135"
+"@value": "amf://id#148"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -25560,7 +26625,7 @@
 ]
 },
 {
-"@id": "amf://id#138",
+"@id": "amf://id#151",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -25573,7 +26638,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#139",
+"@id": "amf://id#152",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -25590,16 +26655,18 @@
 "@value": "gender"
 }
 ],
-"http://schema.org/name": [
+"http://a.ml/vocabularies/core#name": [
 {
 "@value": "The Gender Schema "
 }
 ],
 "http://www.w3.org/ns/shacl#defaultValue": [
 {
-"@id": "amf://id#140",
+"@id": "amf://id#153",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -25609,7 +26676,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#140/source-map",
+"@id": "amf://id#153/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -25617,7 +26684,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#140"
+"@value": "amf://id#153"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -25638,7 +26705,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#139/source-map",
+"@id": "amf://id#152/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -25646,7 +26713,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#139"
+"@value": "amf://id#152"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -25684,7 +26751,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#139"
+"@value": "amf://id#152"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -25696,7 +26763,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/name"
+"@value": "http://a.ml/vocabularies/core#name"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -25722,7 +26789,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#138/source-map",
+"@id": "amf://id#151/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -25730,7 +26797,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#138"
+"@value": "amf://id#151"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -25744,7 +26811,7 @@
 ]
 },
 {
-"@id": "amf://id#141",
+"@id": "amf://id#154",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -25757,7 +26824,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#142",
+"@id": "amf://id#155",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -25774,16 +26841,18 @@
 "@value": "url"
 }
 ],
-"http://schema.org/name": [
+"http://a.ml/vocabularies/core#name": [
 {
 "@value": "The Url Schema "
 }
 ],
 "http://www.w3.org/ns/shacl#defaultValue": [
 {
-"@id": "amf://id#143",
+"@id": "amf://id#156",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -25793,7 +26862,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#143/source-map",
+"@id": "amf://id#156/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -25801,7 +26870,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#143"
+"@value": "amf://id#156"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -25822,7 +26891,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#142/source-map",
+"@id": "amf://id#155/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -25830,7 +26899,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#142"
+"@value": "amf://id#155"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -25868,7 +26937,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#142"
+"@value": "amf://id#155"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -25880,7 +26949,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/name"
+"@value": "http://a.ml/vocabularies/core#name"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -25906,7 +26975,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#141/source-map",
+"@id": "amf://id#154/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -25914,7 +26983,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#141"
+"@value": "amf://id#154"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -25928,7 +26997,7 @@
 ]
 },
 {
-"@id": "amf://id#144",
+"@id": "amf://id#157",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -25941,7 +27010,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#145",
+"@id": "amf://id#158",
 "@type": [
 "http://www.w3.org/ns/shacl#NodeShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -25955,7 +27024,7 @@
 ],
 "http://www.w3.org/ns/shacl#property": [
 {
-"@id": "amf://id#146",
+"@id": "amf://id#159",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -25968,7 +27037,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#147",
+"@id": "amf://id#160",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -25985,16 +27054,18 @@
 "@value": "url"
 }
 ],
-"http://schema.org/name": [
+"http://a.ml/vocabularies/core#name": [
 {
 "@value": "The Url Schema "
 }
 ],
 "http://www.w3.org/ns/shacl#defaultValue": [
 {
-"@id": "amf://id#148",
+"@id": "amf://id#161",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -26004,7 +27075,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#148/source-map",
+"@id": "amf://id#161/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -26012,7 +27083,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#148"
+"@value": "amf://id#161"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -26033,7 +27104,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#147/source-map",
+"@id": "amf://id#160/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -26041,7 +27112,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#147"
+"@value": "amf://id#160"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -26079,7 +27150,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#147"
+"@value": "amf://id#160"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -26091,7 +27162,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/name"
+"@value": "http://a.ml/vocabularies/core#name"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -26117,7 +27188,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#146/source-map",
+"@id": "amf://id#159/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -26125,7 +27196,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#146"
+"@value": "amf://id#159"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -26139,7 +27210,7 @@
 ]
 },
 {
-"@id": "amf://id#149",
+"@id": "amf://id#162",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -26152,7 +27223,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#150",
+"@id": "amf://id#163",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -26169,16 +27240,18 @@
 "@value": "thumb"
 }
 ],
-"http://schema.org/name": [
+"http://a.ml/vocabularies/core#name": [
 {
 "@value": "The Thumb Schema "
 }
 ],
 "http://www.w3.org/ns/shacl#defaultValue": [
 {
-"@id": "amf://id#151",
+"@id": "amf://id#164",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -26188,7 +27261,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#151/source-map",
+"@id": "amf://id#164/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -26196,7 +27269,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#151"
+"@value": "amf://id#164"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -26217,7 +27290,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#150/source-map",
+"@id": "amf://id#163/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -26225,7 +27298,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#150"
+"@value": "amf://id#163"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -26263,7 +27336,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#150"
+"@value": "amf://id#163"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -26275,7 +27348,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/name"
+"@value": "http://a.ml/vocabularies/core#name"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -26301,7 +27374,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#149/source-map",
+"@id": "amf://id#162/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -26309,7 +27382,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#149"
+"@value": "amf://id#162"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -26330,7 +27403,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#145/source-map",
+"@id": "amf://id#158/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -26338,7 +27411,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#145"
+"@value": "amf://id#158"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -26352,7 +27425,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#145"
+"@value": "amf://id#158"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -26378,7 +27451,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#144/source-map",
+"@id": "amf://id#157/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -26386,7 +27459,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#144"
+"@value": "amf://id#157"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -26400,7 +27473,7 @@
 ]
 },
 {
-"@id": "amf://id#152",
+"@id": "amf://id#165",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -26413,7 +27486,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#153",
+"@id": "amf://id#166",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -26430,16 +27503,18 @@
 "@value": "tagline"
 }
 ],
-"http://schema.org/name": [
+"http://a.ml/vocabularies/core#name": [
 {
 "@value": "The Tagline Schema "
 }
 ],
 "http://www.w3.org/ns/shacl#defaultValue": [
 {
-"@id": "amf://id#154",
+"@id": "amf://id#167",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -26449,7 +27524,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#154/source-map",
+"@id": "amf://id#167/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -26457,7 +27532,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#154"
+"@value": "amf://id#167"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -26478,7 +27553,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#153/source-map",
+"@id": "amf://id#166/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -26486,7 +27561,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#153"
+"@value": "amf://id#166"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -26524,7 +27599,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#153"
+"@value": "amf://id#166"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -26536,7 +27611,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/name"
+"@value": "http://a.ml/vocabularies/core#name"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -26562,7 +27637,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#152/source-map",
+"@id": "amf://id#165/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -26570,7 +27645,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#152"
+"@value": "amf://id#165"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -26584,7 +27659,7 @@
 ]
 },
 {
-"@id": "amf://id#155",
+"@id": "amf://id#168",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -26597,7 +27672,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#156",
+"@id": "amf://id#169",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -26614,16 +27689,18 @@
 "@value": "language"
 }
 ],
-"http://schema.org/name": [
+"http://a.ml/vocabularies/core#name": [
 {
 "@value": "The Language Schema "
 }
 ],
 "http://www.w3.org/ns/shacl#defaultValue": [
 {
-"@id": "amf://id#157",
+"@id": "amf://id#170",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -26633,7 +27710,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#157/source-map",
+"@id": "amf://id#170/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -26641,7 +27718,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#157"
+"@value": "amf://id#170"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -26662,7 +27739,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#156/source-map",
+"@id": "amf://id#169/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -26670,7 +27747,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#156"
+"@value": "amf://id#169"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -26708,7 +27785,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#156"
+"@value": "amf://id#169"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -26720,7 +27797,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/name"
+"@value": "http://a.ml/vocabularies/core#name"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -26746,7 +27823,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#155/source-map",
+"@id": "amf://id#168/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -26754,7 +27831,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#155"
+"@value": "amf://id#168"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -26768,7 +27845,7 @@
 ]
 },
 {
-"@id": "amf://id#158",
+"@id": "amf://id#171",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -26781,7 +27858,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#159",
+"@id": "amf://id#172",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -26798,16 +27875,18 @@
 "@value": "etag"
 }
 ],
-"http://schema.org/name": [
+"http://a.ml/vocabularies/core#name": [
 {
 "@value": "The Etag Schema "
 }
 ],
 "http://www.w3.org/ns/shacl#defaultValue": [
 {
-"@id": "amf://id#160",
+"@id": "amf://id#173",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -26817,7 +27896,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#160/source-map",
+"@id": "amf://id#173/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -26825,7 +27904,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#160"
+"@value": "amf://id#173"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -26846,7 +27925,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#159/source-map",
+"@id": "amf://id#172/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -26854,7 +27933,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#159"
+"@value": "amf://id#172"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -26892,7 +27971,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#159"
+"@value": "amf://id#172"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -26904,7 +27983,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/name"
+"@value": "http://a.ml/vocabularies/core#name"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -26930,7 +28009,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#158/source-map",
+"@id": "amf://id#171/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -26938,7 +28017,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#158"
+"@value": "amf://id#171"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -26957,11 +28036,18 @@
 "@value": "SchemaPerson"
 }
 ],
-"http://a.ml/vocabularies/document#examples": [
+"http://a.ml/vocabularies/apiContract#examples": [
 {
-"@id": "amf://id#161",
+"@id": "amf://id#174",
 "@type": [
-"http://a.ml/vocabularies/document#Example",
+"http://a.ml/vocabularies/apiContract#NamedExamples",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/apiContract#examples": [
+{
+"@id": "amf://id#175",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Example",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/document#strict": [
@@ -26971,15 +28057,19 @@
 ],
 "http://a.ml/vocabularies/document#structuredValue": [
 {
-"@id": "amf://id#161",
+"@id": "amf://id#175",
 "@type": [
-"http://a.ml/vocabularies/data#Object"
+"http://a.ml/vocabularies/data#Object",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#birthday": [
 {
-"@id": "amf://id#162",
+"@id": "amf://id#176",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -26989,7 +28079,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#162/source-map",
+"@id": "amf://id#176/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -26997,7 +28087,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#162"
+"@value": "amf://id#176"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -27013,9 +28103,11 @@
 ],
 "http://a.ml/vocabularies/data#etag": [
 {
-"@id": "amf://id#163",
+"@id": "amf://id#177",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -27025,7 +28117,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#163/source-map",
+"@id": "amf://id#177/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -27033,7 +28125,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#163"
+"@value": "amf://id#177"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -27049,9 +28141,11 @@
 ],
 "http://a.ml/vocabularies/data#gender": [
 {
-"@id": "amf://id#164",
+"@id": "amf://id#178",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -27061,7 +28155,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#164/source-map",
+"@id": "amf://id#178/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -27069,7 +28163,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#164"
+"@value": "amf://id#178"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -27085,9 +28179,11 @@
 ],
 "http://a.ml/vocabularies/data#id": [
 {
-"@id": "amf://id#165",
+"@id": "amf://id#179",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -27097,7 +28193,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#165/source-map",
+"@id": "amf://id#179/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -27105,7 +28201,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#165"
+"@value": "amf://id#179"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -27121,15 +28217,19 @@
 ],
 "http://a.ml/vocabularies/data#image": [
 {
-"@id": "amf://id#166",
+"@id": "amf://id#180",
 "@type": [
-"http://a.ml/vocabularies/data#Object"
+"http://a.ml/vocabularies/data#Object",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#thumb": [
 {
-"@id": "amf://id#167",
+"@id": "amf://id#181",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -27139,7 +28239,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#167/source-map",
+"@id": "amf://id#181/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -27147,7 +28247,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#167"
+"@value": "amf://id#181"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -27163,9 +28263,11 @@
 ],
 "http://a.ml/vocabularies/data#url": [
 {
-"@id": "amf://id#168",
+"@id": "amf://id#182",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -27175,7 +28277,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#168/source-map",
+"@id": "amf://id#182/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -27183,7 +28285,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#168"
+"@value": "amf://id#182"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -27199,7 +28301,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#166/source-map",
+"@id": "amf://id#180/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -27207,7 +28309,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#166"
+"@value": "amf://id#180"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -27221,12 +28323,36 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#166"
+"@value": "http://a.ml/vocabularies/data#url"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(8,11)-(8,58)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#180"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
 {
 "@value": "[(7,11)-(10,3)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/data#thumb"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(9,13)-(9,66)]"
 }
 ]
 }
@@ -27237,9 +28363,11 @@
 ],
 "http://a.ml/vocabularies/data#language": [
 {
-"@id": "amf://id#169",
+"@id": "amf://id#183",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -27249,7 +28377,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#169/source-map",
+"@id": "amf://id#183/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -27257,7 +28385,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#169"
+"@value": "amf://id#183"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -27273,9 +28401,11 @@
 ],
 "http://a.ml/vocabularies/data#name": [
 {
-"@id": "amf://id#170",
+"@id": "amf://id#184",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -27285,7 +28415,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#170/source-map",
+"@id": "amf://id#184/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -27293,7 +28423,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#170"
+"@value": "amf://id#184"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -27309,9 +28439,11 @@
 ],
 "http://a.ml/vocabularies/data#tagline": [
 {
-"@id": "amf://id#171",
+"@id": "amf://id#185",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -27321,7 +28453,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#171/source-map",
+"@id": "amf://id#185/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -27329,7 +28461,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#171"
+"@value": "amf://id#185"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -27345,9 +28477,11 @@
 ],
 "http://a.ml/vocabularies/data#url": [
 {
-"@id": "amf://id#172",
+"@id": "amf://id#186",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -27357,7 +28491,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#172/source-map",
+"@id": "amf://id#186/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -27365,7 +28499,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#172"
+"@value": "amf://id#186"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -27381,7 +28515,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#161/source-map",
+"@id": "amf://id#175/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -27389,7 +28523,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#161"
+"@value": "amf://id#175"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -27403,7 +28537,19 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#161"
+"@value": "http://a.ml/vocabularies/data#image"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "url->[(8,4)-(8,11)]#thumb->[(9,4)-(9,13)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#175"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -27417,12 +28563,120 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#161"
+"@value": "http://a.ml/vocabularies/data#url"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(6,9)-(6,50)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/data#name"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(3,10)-(3,24)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/data#image"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(7,11)-(10,3)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/data#gender"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(5,12)-(5,18)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/data#birthday"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(4,14)-(4,26)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#175"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
 {
 "@value": "[(1,0)-(14,1)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/data#etag"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(13,10)-(13,36)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/data#id"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(2,8)-(2,30)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/data#language"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(12,14)-(12,21)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/data#tagline"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(11,13)-(11,34)]"
 }
 ]
 }
@@ -27433,12 +28687,12 @@
 ],
 "http://a.ml/vocabularies/document#reference-id": [
 {
-"@id": "amf://id#16"
+"@id": "amf://id#17"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#161/source-map",
+"@id": "amf://id#175/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -27460,7 +28714,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#161"
+"@value": "amf://id#175"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -27473,10 +28727,12 @@
 }
 ]
 }
+]
+}
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#128/source-map",
+"@id": "amf://id#141/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -27484,7 +28740,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#128"
+"@value": "amf://id#141"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -27498,7 +28754,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#128"
+"@value": "amf://id#141"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -27524,7 +28780,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#128"
+"@value": "amf://id#141"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -27538,7 +28794,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#128"
+"@value": "amf://id#141"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -27552,7 +28808,7 @@
 ]
 },
 {
-"@id": "amf://id#173",
+"@id": "amf://id#187",
 "@type": [
 "http://a.ml/vocabularies/shapes#UnionShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -27560,7 +28816,7 @@
 ],
 "http://a.ml/vocabularies/shapes#anyOf": [
 {
-"@id": "amf://id#174",
+"@id": "amf://id#188",
 "@type": [
 "http://www.w3.org/ns/shacl#NodeShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -27574,7 +28830,7 @@
 ],
 "http://www.w3.org/ns/shacl#property": [
 {
-"@id": "amf://id#175",
+"@id": "amf://id#189",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -27587,7 +28843,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#176",
+"@id": "amf://id#190",
 "@type": [
 "http://a.ml/vocabularies/shapes#ArrayShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -27596,7 +28852,7 @@
 ],
 "http://a.ml/vocabularies/shapes#items": [
 {
-"@id": "amf://id#177",
+"@id": "amf://id#191",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -27615,14 +28871,14 @@
 "@value": "targets"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "The possible content types to convert to."
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#176/source-map",
+"@id": "amf://id#190/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -27630,7 +28886,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#176"
+"@value": "amf://id#190"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -27644,7 +28900,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -27656,7 +28912,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#176"
+"@value": "amf://id#190"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -27682,7 +28938,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#175/source-map",
+"@id": "amf://id#189/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -27702,7 +28958,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#175"
+"@value": "amf://id#189"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -27716,7 +28972,7 @@
 ]
 },
 {
-"@id": "amf://id#178",
+"@id": "amf://id#192",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -27729,7 +28985,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#179",
+"@id": "amf://id#193",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -27746,14 +29002,14 @@
 "@value": "source"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "The imported file's content type to convert from."
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#179/source-map",
+"@id": "amf://id#193/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -27761,7 +29017,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#179"
+"@value": "amf://id#193"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -27775,7 +29031,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -27787,7 +29043,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#179"
+"@value": "amf://id#193"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -27825,7 +29081,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#178/source-map",
+"@id": "amf://id#192/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -27845,7 +29101,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#178"
+"@value": "amf://id#192"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -27866,7 +29122,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#174/source-map",
+"@id": "amf://id#188/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -27874,7 +29130,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#174"
+"@value": "amf://id#188"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -27888,7 +29144,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#174"
+"@value": "amf://id#188"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -27902,7 +29158,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#174"
+"@value": "amf://id#188"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -27916,7 +29172,7 @@
 ]
 },
 {
-"@id": "amf://id#180",
+"@id": "amf://id#194",
 "@type": [
 "http://www.w3.org/ns/shacl#NodeShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -27930,7 +29186,7 @@
 ],
 "http://www.w3.org/ns/shacl#property": [
 {
-"@id": "amf://id#42",
+"@id": "amf://id#35",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -27943,7 +29199,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#43",
+"@id": "amf://id#36",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -27960,14 +29216,14 @@
 "@value": "etag"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "ETag of this resource for caching purposes.\n__This property will be ignored when creating an object.__\n"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#43/source-map",
+"@id": "amf://id#36/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -27975,7 +29231,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#43"
+"@value": "amf://id#36"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -27989,7 +29245,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -28001,7 +29257,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#43"
+"@value": "amf://id#36"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -28039,7 +29295,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#42/source-map",
+"@id": "amf://id#35/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -28047,7 +29303,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#42"
+"@value": "amf://id#35"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -28061,7 +29317,7 @@
 ]
 },
 {
-"@id": "amf://id#121",
+"@id": "amf://id#134",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -28074,7 +29330,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#122",
+"@id": "amf://id#135",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -28091,14 +29347,14 @@
 "@value": "url"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "A URL that points to a profile picture of this user."
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#122/source-map",
+"@id": "amf://id#135/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -28106,7 +29362,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#122"
+"@value": "amf://id#135"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -28120,7 +29376,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -28132,7 +29388,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#122"
+"@value": "amf://id#135"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -28170,7 +29426,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#121/source-map",
+"@id": "amf://id#134/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -28190,7 +29446,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#121"
+"@value": "amf://id#134"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -28204,7 +29460,7 @@
 ]
 },
 {
-"@id": "amf://id#123",
+"@id": "amf://id#136",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -28217,7 +29473,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#124",
+"@id": "amf://id#137",
 "@type": [
 "http://www.w3.org/ns/shacl#NodeShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -28261,7 +29517,7 @@
 "@value": "width"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "Width of the shape.\n"
 }
@@ -28290,7 +29546,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -28392,7 +29648,7 @@
 "@value": "height"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "Height of the shape.\n"
 }
@@ -28421,7 +29677,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -28523,7 +29779,7 @@
 "@value": "unit?"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "A unit that describes the dimension. It can be, for example, `px` for\npixels, `pt` for points, `%` for percentage.\n"
 }
@@ -28532,7 +29788,9 @@
 {
 "@id": "amf://id#9",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -28629,7 +29887,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -28682,16 +29940,23 @@
 "@value": "Dimension"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "A dimmensions of an object like image.\n"
 }
 ],
-"http://a.ml/vocabularies/document#examples": [
+"http://a.ml/vocabularies/apiContract#examples": [
 {
 "@id": "amf://id#10",
 "@type": [
-"http://a.ml/vocabularies/document#Example",
+"http://a.ml/vocabularies/apiContract#NamedExamples",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/apiContract#examples": [
+{
+"@id": "amf://id#11",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Example",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/document#strict": [
@@ -28701,55 +29966,23 @@
 ],
 "http://a.ml/vocabularies/document#structuredValue": [
 {
-"@id": "amf://id#10",
+"@id": "amf://id#11",
 "@type": [
-"http://a.ml/vocabularies/data#Object"
+"http://a.ml/vocabularies/data#Object",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#height": [
 {
-"@id": "amf://id#11",
+"@id": "amf://id#12",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
 "@value": "160",
-"@type": "http://www.w3.org/2001/XMLSchema#integer"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "amf://id#11/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#11"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(24,10)-(24,13)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"http://a.ml/vocabularies/data#width": [
-{
-"@id": "amf://id#12",
-"@type": [
-"http://a.ml/vocabularies/data#Scalar"
-],
-"http://a.ml/vocabularies/data#value": [
-{
-"@value": "200",
 "@type": "http://www.w3.org/2001/XMLSchema#integer"
 }
 ],
@@ -28768,6 +30001,44 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
 {
+"@value": "[(24,10)-(24,13)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"http://a.ml/vocabularies/data#width": [
+{
+"@id": "amf://id#13",
+"@type": [
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/data#value": [
+{
+"@value": "200",
+"@type": "http://www.w3.org/2001/XMLSchema#integer"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#sources": [
+{
+"@id": "amf://id#13/source-map",
+"@type": [
+"http://a.ml/vocabularies/document-source-maps#SourceMap"
+],
+"http://a.ml/vocabularies/document-source-maps#lexical": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#13"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
 "@value": "[(23,9)-(23,12)]"
 }
 ]
@@ -28779,7 +30050,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#10/source-map",
+"@id": "amf://id#11/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -28787,12 +30058,36 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#10"
+"@value": "http://a.ml/vocabularies/data#width"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(23,9)-(23,12)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#11"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
 {
 "@value": "[(23,0)-(25,0)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/data#height"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(24,10)-(24,13)]"
 }
 ]
 }
@@ -28801,7 +30096,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#10"
+"@value": "amf://id#11"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -28822,7 +30117,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#10/source-map",
+"@id": "amf://id#11/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -28856,7 +30151,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#10"
+"@value": "amf://id#11"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -28869,10 +30164,12 @@
 }
 ]
 }
+]
+}
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#124/source-map",
+"@id": "amf://id#137/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -28880,7 +30177,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#124"
+"@value": "amf://id#137"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -28894,7 +30191,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#124"
+"@value": "amf://id#137"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -28908,7 +30205,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -28920,7 +30217,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#124"
+"@value": "amf://id#137"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -28934,7 +30231,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#124"
+"@value": "amf://id#137"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -28960,7 +30257,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#123/source-map",
+"@id": "amf://id#136/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -28968,7 +30265,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#123"
+"@value": "amf://id#136"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -28987,19 +30284,19 @@
 "@value": "Picture"
 }
 ],
-"http://schema.org/name": [
+"http://a.ml/vocabularies/core#name": [
 {
 "@value": "Pic"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "The user's profile picture."
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#180/source-map",
+"@id": "amf://id#194/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -29007,7 +30304,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#180"
+"@value": "amf://id#194"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -29021,7 +30318,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -29033,7 +30330,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#180"
+"@value": "amf://id#194"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -29045,7 +30342,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/name"
+"@value": "http://a.ml/vocabularies/core#name"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -29059,7 +30356,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#180"
+"@value": "amf://id#194"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -29080,7 +30377,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#173/source-map",
+"@id": "amf://id#187/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -29100,7 +30397,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#173"
+"@value": "amf://id#187"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -29114,7 +30411,7 @@
 ]
 },
 {
-"@id": "amf://id#181",
+"@id": "amf://id#195",
 "@type": [
 "http://www.w3.org/ns/shacl#NodeShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -29128,7 +30425,7 @@
 ],
 "http://www.w3.org/ns/shacl#property": [
 {
-"@id": "amf://id#178",
+"@id": "amf://id#192",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -29141,7 +30438,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#179",
+"@id": "amf://id#193",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -29158,14 +30455,14 @@
 "@value": "source"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "The imported file's content type to convert from."
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#179/source-map",
+"@id": "amf://id#193/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -29173,7 +30470,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#179"
+"@value": "amf://id#193"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -29187,7 +30484,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -29199,7 +30496,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#179"
+"@value": "amf://id#193"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -29237,7 +30534,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#178/source-map",
+"@id": "amf://id#192/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -29257,7 +30554,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#178"
+"@value": "amf://id#192"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -29271,7 +30568,7 @@
 ]
 },
 {
-"@id": "amf://id#175",
+"@id": "amf://id#189",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -29284,7 +30581,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#176",
+"@id": "amf://id#190",
 "@type": [
 "http://a.ml/vocabularies/shapes#ArrayShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -29293,7 +30590,7 @@
 ],
 "http://a.ml/vocabularies/shapes#items": [
 {
-"@id": "amf://id#177",
+"@id": "amf://id#191",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -29312,14 +30609,14 @@
 "@value": "targets"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "The possible content types to convert to."
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#176/source-map",
+"@id": "amf://id#190/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -29327,7 +30624,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#176"
+"@value": "amf://id#190"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -29341,7 +30638,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -29353,7 +30650,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#176"
+"@value": "amf://id#190"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -29379,7 +30676,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#175/source-map",
+"@id": "amf://id#189/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -29399,7 +30696,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#175"
+"@value": "amf://id#189"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -29420,7 +30717,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#181/source-map",
+"@id": "amf://id#195/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -29428,7 +30725,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#181"
+"@value": "amf://id#195"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -29454,7 +30751,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#181"
+"@value": "amf://id#195"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -29468,7 +30765,7 @@
 ]
 },
 {
-"@id": "amf://id#182",
+"@id": "amf://id#196",
 "@type": [
 "http://www.w3.org/ns/shacl#NodeShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -29482,7 +30779,7 @@
 ],
 "http://www.w3.org/ns/shacl#property": [
 {
-"@id": "amf://id#42",
+"@id": "amf://id#35",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -29495,7 +30792,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#43",
+"@id": "amf://id#36",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -29512,14 +30809,14 @@
 "@value": "etag"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "ETag of this resource for caching purposes.\n__This property will be ignored when creating an object.__\n"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#43/source-map",
+"@id": "amf://id#36/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -29527,7 +30824,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#43"
+"@value": "amf://id#36"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -29541,7 +30838,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -29553,7 +30850,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#43"
+"@value": "amf://id#36"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -29591,7 +30888,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#42/source-map",
+"@id": "amf://id#35/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -29599,7 +30896,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#42"
+"@value": "amf://id#35"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -29618,14 +30915,14 @@
 "@value": "Resource"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "Common properties for all resources returned by the API.\n"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#182/source-map",
+"@id": "amf://id#196/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -29633,7 +30930,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#182"
+"@value": "amf://id#196"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -29647,7 +30944,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#182"
+"@value": "amf://id#196"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -29661,7 +30958,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -29673,7 +30970,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#182"
+"@value": "amf://id#196"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -29687,7 +30984,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#182"
+"@value": "amf://id#196"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -29701,7 +30998,7 @@
 ]
 },
 {
-"@id": "amf://id#124",
+"@id": "amf://id#137",
 "@type": [
 "http://www.w3.org/ns/shacl#NodeShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -29745,7 +31042,7 @@
 "@value": "width"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "Width of the shape.\n"
 }
@@ -29774,7 +31071,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -29876,7 +31173,7 @@
 "@value": "height"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "Height of the shape.\n"
 }
@@ -29905,7 +31202,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -30007,7 +31304,7 @@
 "@value": "unit?"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "A unit that describes the dimension. It can be, for example, `px` for\npixels, `pt` for points, `%` for percentage.\n"
 }
@@ -30016,7 +31313,9 @@
 {
 "@id": "amf://id#9",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -30113,7 +31412,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -30166,16 +31465,23 @@
 "@value": "Dimension"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "A dimmensions of an object like image.\n"
 }
 ],
-"http://a.ml/vocabularies/document#examples": [
+"http://a.ml/vocabularies/apiContract#examples": [
 {
 "@id": "amf://id#10",
 "@type": [
-"http://a.ml/vocabularies/document#Example",
+"http://a.ml/vocabularies/apiContract#NamedExamples",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/apiContract#examples": [
+{
+"@id": "amf://id#11",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Example",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/document#strict": [
@@ -30185,55 +31491,23 @@
 ],
 "http://a.ml/vocabularies/document#structuredValue": [
 {
-"@id": "amf://id#10",
+"@id": "amf://id#11",
 "@type": [
-"http://a.ml/vocabularies/data#Object"
+"http://a.ml/vocabularies/data#Object",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#height": [
 {
-"@id": "amf://id#11",
+"@id": "amf://id#12",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
 "@value": "160",
-"@type": "http://www.w3.org/2001/XMLSchema#integer"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "amf://id#11/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#11"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(24,10)-(24,13)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"http://a.ml/vocabularies/data#width": [
-{
-"@id": "amf://id#12",
-"@type": [
-"http://a.ml/vocabularies/data#Scalar"
-],
-"http://a.ml/vocabularies/data#value": [
-{
-"@value": "200",
 "@type": "http://www.w3.org/2001/XMLSchema#integer"
 }
 ],
@@ -30252,6 +31526,44 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
 {
+"@value": "[(24,10)-(24,13)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"http://a.ml/vocabularies/data#width": [
+{
+"@id": "amf://id#13",
+"@type": [
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/data#value": [
+{
+"@value": "200",
+"@type": "http://www.w3.org/2001/XMLSchema#integer"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#sources": [
+{
+"@id": "amf://id#13/source-map",
+"@type": [
+"http://a.ml/vocabularies/document-source-maps#SourceMap"
+],
+"http://a.ml/vocabularies/document-source-maps#lexical": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#13"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
 "@value": "[(23,9)-(23,12)]"
 }
 ]
@@ -30263,7 +31575,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#10/source-map",
+"@id": "amf://id#11/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -30271,12 +31583,36 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#10"
+"@value": "http://a.ml/vocabularies/data#width"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(23,9)-(23,12)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#11"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
 {
 "@value": "[(23,0)-(25,0)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/data#height"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(24,10)-(24,13)]"
 }
 ]
 }
@@ -30285,7 +31621,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#10"
+"@value": "amf://id#11"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -30306,7 +31642,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#10/source-map",
+"@id": "amf://id#11/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -30340,7 +31676,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#10"
+"@value": "amf://id#11"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -30353,10 +31689,12 @@
 }
 ]
 }
+]
+}
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#124/source-map",
+"@id": "amf://id#137/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -30364,7 +31702,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#124"
+"@value": "amf://id#137"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -30378,7 +31716,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#124"
+"@value": "amf://id#137"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -30392,7 +31730,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -30404,7 +31742,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#124"
+"@value": "amf://id#137"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -30418,7 +31756,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#124"
+"@value": "amf://id#137"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -30432,7 +31770,7 @@
 ]
 },
 {
-"@id": "amf://id#183",
+"@id": "amf://id#197",
 "@type": [
 "http://www.w3.org/ns/shacl#NodeShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -30446,7 +31784,7 @@
 ],
 "http://www.w3.org/ns/shacl#property": [
 {
-"@id": "amf://id#94",
+"@id": "amf://id#101",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -30459,7 +31797,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#95",
+"@id": "amf://id#102",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -30481,16 +31819,23 @@
 "@value": "upc"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "The Universal Produc Code. It consists of 12 numerical digits. However, because of the\ninteger precision limitation in JavaScript it is represented as a string.\n"
 }
 ],
-"http://a.ml/vocabularies/document#examples": [
+"http://a.ml/vocabularies/apiContract#examples": [
 {
-"@id": "amf://id#96",
+"@id": "amf://id#103",
 "@type": [
-"http://a.ml/vocabularies/document#Example",
+"http://a.ml/vocabularies/apiContract#NamedExamples",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/apiContract#examples": [
+{
+"@id": "amf://id#104",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Example",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/document#strict": [
@@ -30500,9 +31845,11 @@
 ],
 "http://a.ml/vocabularies/document#structuredValue": [
 {
-"@id": "amf://id#96",
+"@id": "amf://id#104",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -30512,7 +31859,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#96/source-map",
+"@id": "amf://id#104/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -30520,7 +31867,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#96"
+"@value": "amf://id#104"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -30541,7 +31888,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#96/source-map",
+"@id": "amf://id#104/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -30575,7 +31922,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#96"
+"@value": "amf://id#104"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -30588,10 +31935,12 @@
 }
 ]
 }
+]
+}
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#95/source-map",
+"@id": "amf://id#102/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -30599,7 +31948,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#95"
+"@value": "amf://id#102"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -30613,7 +31962,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -30637,7 +31986,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#95"
+"@value": "amf://id#102"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -30675,7 +32024,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#94/source-map",
+"@id": "amf://id#101/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -30695,7 +32044,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#94"
+"@value": "amf://id#101"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -30709,7 +32058,7 @@
 ]
 },
 {
-"@id": "amf://id#42",
+"@id": "amf://id#35",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -30722,7 +32071,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#43",
+"@id": "amf://id#36",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -30739,14 +32088,14 @@
 "@value": "etag"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "ETag of this resource for caching purposes.\n__This property will be ignored when creating an object.__\n"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#43/source-map",
+"@id": "amf://id#36/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -30754,7 +32103,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#43"
+"@value": "amf://id#36"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -30768,7 +32117,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -30780,7 +32129,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#43"
+"@value": "amf://id#36"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -30818,7 +32167,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#42/source-map",
+"@id": "amf://id#35/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -30826,7 +32175,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#42"
+"@value": "amf://id#35"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -30840,7 +32189,7 @@
 ]
 },
 {
-"@id": "amf://id#97",
+"@id": "amf://id#105",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -30853,7 +32202,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#98",
+"@id": "amf://id#106",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -30870,16 +32219,23 @@
 "@value": "name"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "Product name"
 }
 ],
-"http://a.ml/vocabularies/document#examples": [
+"http://a.ml/vocabularies/apiContract#examples": [
 {
-"@id": "amf://id#99",
+"@id": "amf://id#107",
 "@type": [
-"http://a.ml/vocabularies/document#Example",
+"http://a.ml/vocabularies/apiContract#NamedExamples",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/apiContract#examples": [
+{
+"@id": "amf://id#108",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Example",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/document#strict": [
@@ -30889,9 +32245,11 @@
 ],
 "http://a.ml/vocabularies/document#structuredValue": [
 {
-"@id": "amf://id#99",
+"@id": "amf://id#108",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -30901,7 +32259,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#99/source-map",
+"@id": "amf://id#108/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -30909,7 +32267,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#99"
+"@value": "amf://id#108"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -30930,7 +32288,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#99/source-map",
+"@id": "amf://id#108/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -30964,7 +32322,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#99"
+"@value": "amf://id#108"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -30977,10 +32335,12 @@
 }
 ]
 }
+]
+}
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#98/source-map",
+"@id": "amf://id#106/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -30988,7 +32348,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#98"
+"@value": "amf://id#106"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -31002,7 +32362,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -31014,7 +32374,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#98"
+"@value": "amf://id#106"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -31052,7 +32412,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#97/source-map",
+"@id": "amf://id#105/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -31072,7 +32432,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#97"
+"@value": "amf://id#105"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -31086,7 +32446,7 @@
 ]
 },
 {
-"@id": "amf://id#100",
+"@id": "amf://id#109",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -31099,7 +32459,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#101",
+"@id": "amf://id#110",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -31121,14 +32481,14 @@
 "@value": "id"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "Product id. It is a UUID of the database record.\n__This property will be ignored when creating an object.__\nIt will be available when the product is stored in the datastore.\n"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#101/source-map",
+"@id": "amf://id#110/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -31136,7 +32496,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -31148,7 +32508,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#101"
+"@value": "amf://id#110"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -31186,7 +32546,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#100/source-map",
+"@id": "amf://id#109/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -31194,7 +32554,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#100"
+"@value": "amf://id#109"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -31208,7 +32568,7 @@
 ]
 },
 {
-"@id": "amf://id#102",
+"@id": "amf://id#111",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -31221,7 +32581,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#103",
+"@id": "amf://id#112",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -31238,16 +32598,23 @@
 "@value": "unit"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "The unit of measuremet for the quantity property."
 }
 ],
-"http://a.ml/vocabularies/document#examples": [
+"http://a.ml/vocabularies/apiContract#examples": [
 {
-"@id": "amf://id#104",
+"@id": "amf://id#113",
 "@type": [
-"http://a.ml/vocabularies/document#Example",
+"http://a.ml/vocabularies/apiContract#NamedExamples",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/apiContract#examples": [
+{
+"@id": "amf://id#114",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Example",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/document#strict": [
@@ -31257,9 +32624,11 @@
 ],
 "http://a.ml/vocabularies/document#structuredValue": [
 {
-"@id": "amf://id#104",
+"@id": "amf://id#114",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -31269,7 +32638,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#104/source-map",
+"@id": "amf://id#114/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -31277,7 +32646,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#104"
+"@value": "amf://id#114"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -31298,7 +32667,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#104/source-map",
+"@id": "amf://id#114/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -31332,7 +32701,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#104"
+"@value": "amf://id#114"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -31345,10 +32714,12 @@
 }
 ]
 }
+]
+}
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#103/source-map",
+"@id": "amf://id#112/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -31356,7 +32727,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#103"
+"@value": "amf://id#112"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -31370,7 +32741,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -31382,7 +32753,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#103"
+"@value": "amf://id#112"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -31420,7 +32791,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#102/source-map",
+"@id": "amf://id#111/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -31440,7 +32811,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#102"
+"@value": "amf://id#111"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -31454,7 +32825,7 @@
 ]
 },
 {
-"@id": "amf://id#105",
+"@id": "amf://id#115",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -31467,7 +32838,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#106",
+"@id": "amf://id#116",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -31484,16 +32855,23 @@
 "@value": "available"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "Product current availability in the store.\nProduct may be not available but the users still can order it with later delivery date.\n"
 }
 ],
-"http://a.ml/vocabularies/document#examples": [
+"http://a.ml/vocabularies/apiContract#examples": [
 {
-"@id": "amf://id#107",
+"@id": "amf://id#117",
 "@type": [
-"http://a.ml/vocabularies/document#Example",
+"http://a.ml/vocabularies/apiContract#NamedExamples",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/apiContract#examples": [
+{
+"@id": "amf://id#118",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Example",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/document#strict": [
@@ -31503,9 +32881,11 @@
 ],
 "http://a.ml/vocabularies/document#structuredValue": [
 {
-"@id": "amf://id#107",
+"@id": "amf://id#118",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -31515,7 +32895,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#107/source-map",
+"@id": "amf://id#118/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -31523,7 +32903,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#107"
+"@value": "amf://id#118"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -31544,7 +32924,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#107/source-map",
+"@id": "amf://id#118/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -31578,7 +32958,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#107"
+"@value": "amf://id#118"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -31591,10 +32971,12 @@
 }
 ]
 }
+]
+}
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#106/source-map",
+"@id": "amf://id#116/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -31602,7 +32984,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#106"
+"@value": "amf://id#116"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -31616,7 +32998,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -31628,7 +33010,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#106"
+"@value": "amf://id#116"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -31666,7 +33048,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#105/source-map",
+"@id": "amf://id#115/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -31686,7 +33068,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#105"
+"@value": "amf://id#115"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -31700,7 +33082,7 @@
 ]
 },
 {
-"@id": "amf://id#108",
+"@id": "amf://id#119",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -31713,7 +33095,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#109",
+"@id": "amf://id#120",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -31730,16 +33112,23 @@
 "@value": "quantity"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "The quantity of the product in the one unit of measurement.\nSee `unit` property for more information.\n"
 }
 ],
-"http://a.ml/vocabularies/document#examples": [
+"http://a.ml/vocabularies/apiContract#examples": [
 {
-"@id": "amf://id#110",
+"@id": "amf://id#121",
 "@type": [
-"http://a.ml/vocabularies/document#Example",
+"http://a.ml/vocabularies/apiContract#NamedExamples",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/apiContract#examples": [
+{
+"@id": "amf://id#122",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Example",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/document#strict": [
@@ -31749,9 +33138,11 @@
 ],
 "http://a.ml/vocabularies/document#structuredValue": [
 {
-"@id": "amf://id#110",
+"@id": "amf://id#122",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -31761,7 +33152,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#110/source-map",
+"@id": "amf://id#122/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -31769,7 +33160,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#110"
+"@value": "amf://id#122"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -31790,7 +33181,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#110/source-map",
+"@id": "amf://id#122/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -31824,7 +33215,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#110"
+"@value": "amf://id#122"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -31837,10 +33228,12 @@
 }
 ]
 }
+]
+}
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#109/source-map",
+"@id": "amf://id#120/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -31848,7 +33241,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#109"
+"@value": "amf://id#120"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -31862,7 +33255,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -31874,7 +33267,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#109"
+"@value": "amf://id#120"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -31912,7 +33305,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#108/source-map",
+"@id": "amf://id#119/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -31932,7 +33325,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#108"
+"@value": "amf://id#119"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -31951,21 +33344,28 @@
 "@value": "Product"
 }
 ],
-"http://schema.org/name": [
+"http://a.ml/vocabularies/core#name": [
 {
 "@value": "A product resource"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "A single product representing an item in the store."
 }
 ],
-"http://a.ml/vocabularies/document#examples": [
+"http://a.ml/vocabularies/apiContract#examples": [
 {
-"@id": "amf://id#111",
+"@id": "amf://id#123",
 "@type": [
-"http://a.ml/vocabularies/document#Example",
+"http://a.ml/vocabularies/apiContract#NamedExamples",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/apiContract#examples": [
+{
+"@id": "amf://id#124",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Example",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/document#strict": [
@@ -31975,15 +33375,19 @@
 ],
 "http://a.ml/vocabularies/document#structuredValue": [
 {
-"@id": "amf://id#111",
+"@id": "amf://id#124",
 "@type": [
-"http://a.ml/vocabularies/data#Object"
+"http://a.ml/vocabularies/data#Object",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#available": [
 {
-"@id": "amf://id#112",
+"@id": "amf://id#125",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -31993,7 +33397,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#112/source-map",
+"@id": "amf://id#125/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -32001,7 +33405,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#112"
+"@value": "amf://id#125"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -32017,9 +33421,11 @@
 ],
 "http://a.ml/vocabularies/data#etag": [
 {
-"@id": "amf://id#113",
+"@id": "amf://id#126",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -32029,7 +33435,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#113/source-map",
+"@id": "amf://id#126/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -32037,7 +33443,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#113"
+"@value": "amf://id#126"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -32053,9 +33459,11 @@
 ],
 "http://a.ml/vocabularies/data#id": [
 {
-"@id": "amf://id#114",
+"@id": "amf://id#127",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -32065,7 +33473,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#114/source-map",
+"@id": "amf://id#127/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -32073,7 +33481,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#114"
+"@value": "amf://id#127"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -32089,9 +33497,11 @@
 ],
 "http://a.ml/vocabularies/data#name": [
 {
-"@id": "amf://id#115",
+"@id": "amf://id#128",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -32101,7 +33511,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#115/source-map",
+"@id": "amf://id#128/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -32109,7 +33519,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#115"
+"@value": "amf://id#128"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -32125,9 +33535,11 @@
 ],
 "http://a.ml/vocabularies/data#quantity": [
 {
-"@id": "amf://id#116",
+"@id": "amf://id#129",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -32137,7 +33549,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#116/source-map",
+"@id": "amf://id#129/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -32145,7 +33557,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#116"
+"@value": "amf://id#129"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -32161,9 +33573,11 @@
 ],
 "http://a.ml/vocabularies/data#unit": [
 {
-"@id": "amf://id#117",
+"@id": "amf://id#130",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -32173,7 +33587,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#117/source-map",
+"@id": "amf://id#130/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -32181,7 +33595,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#117"
+"@value": "amf://id#130"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -32197,9 +33611,11 @@
 ],
 "http://a.ml/vocabularies/data#upc": [
 {
-"@id": "amf://id#118",
+"@id": "amf://id#131",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -32209,7 +33625,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#118/source-map",
+"@id": "amf://id#131/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -32217,7 +33633,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#118"
+"@value": "amf://id#131"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -32233,7 +33649,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#111/source-map",
+"@id": "amf://id#124/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -32241,12 +33657,96 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#111"
+"@value": "http://a.ml/vocabularies/data#upc"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(50,7)-(50,21)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/data#quantity"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(48,12)-(48,15)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/data#id"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(46,6)-(46,34)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/data#available"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(51,13)-(51,17)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#124"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
 {
 "@value": "[(46,0)-(53,0)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/data#etag"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(52,8)-(52,28)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/data#name"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(47,8)-(47,20)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/data#unit"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(49,8)-(49,10)]"
 }
 ]
 }
@@ -32255,7 +33755,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#111"
+"@value": "amf://id#124"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -32276,7 +33776,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#111/source-map",
+"@id": "amf://id#124/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -32310,7 +33810,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#111"
+"@value": "amf://id#124"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -32323,10 +33823,12 @@
 }
 ]
 }
+]
+}
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#183/source-map",
+"@id": "amf://id#197/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -32334,7 +33836,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#183"
+"@value": "amf://id#197"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -32348,7 +33850,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#183"
+"@value": "amf://id#197"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -32362,7 +33864,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -32374,7 +33876,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#183"
+"@value": "amf://id#197"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -32386,7 +33888,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/name"
+"@value": "http://a.ml/vocabularies/core#name"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -32400,7 +33902,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#183"
+"@value": "amf://id#197"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -32414,7 +33916,7 @@
 ]
 },
 {
-"@id": "amf://id#184",
+"@id": "amf://id#198",
 "@type": [
 "http://www.w3.org/ns/shacl#NodeShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -32428,7 +33930,7 @@
 ],
 "http://www.w3.org/ns/shacl#property": [
 {
-"@id": "amf://id#19",
+"@id": "amf://id#20",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -32441,7 +33943,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#20",
+"@id": "amf://id#21",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -32458,14 +33960,14 @@
 "@value": "url"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "The URL of the image.\nTo resize the image and crop it to a square, append the query string **?sz=x**, where x is the dimension in pixels of each side.\n"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#20/source-map",
+"@id": "amf://id#21/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -32473,7 +33975,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#20"
+"@value": "amf://id#21"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -32487,7 +33989,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -32499,7 +34001,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#20"
+"@value": "amf://id#21"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -32537,7 +34039,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#19/source-map",
+"@id": "amf://id#20/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -32545,7 +34047,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#19"
+"@value": "amf://id#20"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -32559,7 +34061,7 @@
 ]
 },
 {
-"@id": "amf://id#21",
+"@id": "amf://id#22",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -32572,7 +34074,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#22",
+"@id": "amf://id#23",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -32589,19 +34091,19 @@
 "@value": "thumb"
 }
 ],
-"http://schema.org/name": [
+"http://a.ml/vocabularies/core#name": [
 {
 "@value": "Thumbnail"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "An URL to the thumbnail of the image. Thumbnails are 60x60px cropped images of the original image.\n"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#22/source-map",
+"@id": "amf://id#23/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -32609,7 +34111,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#22"
+"@value": "amf://id#23"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -32623,7 +34125,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -32647,7 +34149,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#22"
+"@value": "amf://id#23"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -32659,7 +34161,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/name"
+"@value": "http://a.ml/vocabularies/core#name"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -32685,7 +34187,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#21/source-map",
+"@id": "amf://id#22/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -32693,7 +34195,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#21"
+"@value": "amf://id#22"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -32712,16 +34214,23 @@
 "@value": "Image"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "An image object representing an image object strored in the file store.\nThe image can be only included in the response. It has no effect if the Image appear in the\nrequest. Endpoint handles image creation on it's own and clients can't process images\nexcept of sending image data.\n"
 }
 ],
-"http://a.ml/vocabularies/document#examples": [
+"http://a.ml/vocabularies/apiContract#examples": [
 {
-"@id": "amf://id#23",
+"@id": "amf://id#24",
 "@type": [
-"http://a.ml/vocabularies/document#Example",
+"http://a.ml/vocabularies/apiContract#NamedExamples",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/apiContract#examples": [
+{
+"@id": "amf://id#25",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Example",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/document#strict": [
@@ -32731,15 +34240,19 @@
 ],
 "http://a.ml/vocabularies/document#structuredValue": [
 {
-"@id": "amf://id#23",
+"@id": "amf://id#25",
 "@type": [
-"http://a.ml/vocabularies/data#Object"
+"http://a.ml/vocabularies/data#Object",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#thumb": [
 {
-"@id": "amf://id#24",
+"@id": "amf://id#26",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -32749,7 +34262,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#24/source-map",
+"@id": "amf://id#26/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -32757,7 +34270,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#24"
+"@value": "amf://id#26"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -32773,9 +34286,11 @@
 ],
 "http://a.ml/vocabularies/data#url": [
 {
-"@id": "amf://id#25",
+"@id": "amf://id#27",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -32785,7 +34300,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#25/source-map",
+"@id": "amf://id#27/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -32793,7 +34308,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#25"
+"@value": "amf://id#27"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -32809,7 +34324,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#23/source-map",
+"@id": "amf://id#25/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -32817,12 +34332,36 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#23"
+"@value": "http://a.ml/vocabularies/data#url"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(22,7)-(22,52)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#25"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
 {
 "@value": "[(22,0)-(24,0)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/data#thumb"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(23,9)-(23,60)]"
 }
 ]
 }
@@ -32831,7 +34370,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#23"
+"@value": "amf://id#25"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -32852,7 +34391,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#23/source-map",
+"@id": "amf://id#25/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -32886,7 +34425,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#23"
+"@value": "amf://id#25"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -32899,10 +34438,12 @@
 }
 ]
 }
+]
+}
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#184/source-map",
+"@id": "amf://id#198/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -32910,7 +34451,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#184"
+"@value": "amf://id#198"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -32924,7 +34465,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#184"
+"@value": "amf://id#198"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -32938,7 +34479,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -32950,7 +34491,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#184"
+"@value": "amf://id#198"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -32964,7 +34505,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#184"
+"@value": "amf://id#198"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -32978,7 +34519,7 @@
 ]
 },
 {
-"@id": "amf://id#120",
+"@id": "amf://id#133",
 "@type": [
 "http://www.w3.org/ns/shacl#NodeShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -32992,7 +34533,7 @@
 ],
 "http://www.w3.org/ns/shacl#property": [
 {
-"@id": "amf://id#42",
+"@id": "amf://id#35",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -33005,7 +34546,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#43",
+"@id": "amf://id#36",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -33022,14 +34563,14 @@
 "@value": "etag"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "ETag of this resource for caching purposes.\n__This property will be ignored when creating an object.__\n"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#43/source-map",
+"@id": "amf://id#36/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -33037,7 +34578,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#43"
+"@value": "amf://id#36"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -33051,7 +34592,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -33063,7 +34604,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#43"
+"@value": "amf://id#36"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -33101,7 +34642,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#42/source-map",
+"@id": "amf://id#35/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -33109,7 +34650,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#42"
+"@value": "amf://id#35"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -33123,7 +34664,7 @@
 ]
 },
 {
-"@id": "amf://id#121",
+"@id": "amf://id#134",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -33136,7 +34677,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#122",
+"@id": "amf://id#135",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -33153,14 +34694,14 @@
 "@value": "url"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "A URL that points to a profile picture of this user."
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#122/source-map",
+"@id": "amf://id#135/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -33168,7 +34709,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#122"
+"@value": "amf://id#135"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -33182,7 +34723,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -33194,7 +34735,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#122"
+"@value": "amf://id#135"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -33232,7 +34773,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#121/source-map",
+"@id": "amf://id#134/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -33252,7 +34793,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#121"
+"@value": "amf://id#134"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -33266,7 +34807,7 @@
 ]
 },
 {
-"@id": "amf://id#123",
+"@id": "amf://id#136",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -33279,7 +34820,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#124",
+"@id": "amf://id#137",
 "@type": [
 "http://www.w3.org/ns/shacl#NodeShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -33323,7 +34864,7 @@
 "@value": "width"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "Width of the shape.\n"
 }
@@ -33352,7 +34893,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -33454,7 +34995,7 @@
 "@value": "height"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "Height of the shape.\n"
 }
@@ -33483,7 +35024,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -33585,7 +35126,7 @@
 "@value": "unit?"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "A unit that describes the dimension. It can be, for example, `px` for\npixels, `pt` for points, `%` for percentage.\n"
 }
@@ -33594,7 +35135,9 @@
 {
 "@id": "amf://id#9",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -33691,7 +35234,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -33744,16 +35287,23 @@
 "@value": "Dimension"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "A dimmensions of an object like image.\n"
 }
 ],
-"http://a.ml/vocabularies/document#examples": [
+"http://a.ml/vocabularies/apiContract#examples": [
 {
 "@id": "amf://id#10",
 "@type": [
-"http://a.ml/vocabularies/document#Example",
+"http://a.ml/vocabularies/apiContract#NamedExamples",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/apiContract#examples": [
+{
+"@id": "amf://id#11",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Example",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/document#strict": [
@@ -33763,55 +35313,23 @@
 ],
 "http://a.ml/vocabularies/document#structuredValue": [
 {
-"@id": "amf://id#10",
+"@id": "amf://id#11",
 "@type": [
-"http://a.ml/vocabularies/data#Object"
+"http://a.ml/vocabularies/data#Object",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#height": [
 {
-"@id": "amf://id#11",
+"@id": "amf://id#12",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
 "@value": "160",
-"@type": "http://www.w3.org/2001/XMLSchema#integer"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#sources": [
-{
-"@id": "amf://id#11/source-map",
-"@type": [
-"http://a.ml/vocabularies/document-source-maps#SourceMap"
-],
-"http://a.ml/vocabularies/document-source-maps#lexical": [
-{
-"http://a.ml/vocabularies/document-source-maps#element": [
-{
-"@value": "amf://id#11"
-}
-],
-"http://a.ml/vocabularies/document-source-maps#value": [
-{
-"@value": "[(24,10)-(24,13)]"
-}
-]
-}
-]
-}
-]
-}
-],
-"http://a.ml/vocabularies/data#width": [
-{
-"@id": "amf://id#12",
-"@type": [
-"http://a.ml/vocabularies/data#Scalar"
-],
-"http://a.ml/vocabularies/data#value": [
-{
-"@value": "200",
 "@type": "http://www.w3.org/2001/XMLSchema#integer"
 }
 ],
@@ -33830,6 +35348,44 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
 {
+"@value": "[(24,10)-(24,13)]"
+}
+]
+}
+]
+}
+]
+}
+],
+"http://a.ml/vocabularies/data#width": [
+{
+"@id": "amf://id#13",
+"@type": [
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/data#value": [
+{
+"@value": "200",
+"@type": "http://www.w3.org/2001/XMLSchema#integer"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#sources": [
+{
+"@id": "amf://id#13/source-map",
+"@type": [
+"http://a.ml/vocabularies/document-source-maps#SourceMap"
+],
+"http://a.ml/vocabularies/document-source-maps#lexical": [
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#13"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
 "@value": "[(23,9)-(23,12)]"
 }
 ]
@@ -33841,7 +35397,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#10/source-map",
+"@id": "amf://id#11/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -33849,12 +35405,36 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#10"
+"@value": "http://a.ml/vocabularies/data#width"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(23,9)-(23,12)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#11"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
 {
 "@value": "[(23,0)-(25,0)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/data#height"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(24,10)-(24,13)]"
 }
 ]
 }
@@ -33863,7 +35443,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#10"
+"@value": "amf://id#11"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -33884,7 +35464,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#10/source-map",
+"@id": "amf://id#11/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -33918,7 +35498,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#10"
+"@value": "amf://id#11"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -33931,10 +35511,12 @@
 }
 ]
 }
+]
+}
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#124/source-map",
+"@id": "amf://id#137/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -33942,7 +35524,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#124"
+"@value": "amf://id#137"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -33956,7 +35538,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#124"
+"@value": "amf://id#137"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -33970,7 +35552,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -33982,7 +35564,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#124"
+"@value": "amf://id#137"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -33996,7 +35578,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#124"
+"@value": "amf://id#137"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -34022,7 +35604,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#123/source-map",
+"@id": "amf://id#136/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -34030,7 +35612,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#123"
+"@value": "amf://id#136"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -34049,19 +35631,19 @@
 "@value": "Picture"
 }
 ],
-"http://schema.org/name": [
+"http://a.ml/vocabularies/core#name": [
 {
 "@value": "Pic"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "The user's profile picture."
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#120/source-map",
+"@id": "amf://id#133/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -34069,7 +35651,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#120"
+"@value": "amf://id#133"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -34083,7 +35665,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -34107,7 +35689,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#120"
+"@value": "amf://id#133"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -34119,7 +35701,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/name"
+"@value": "http://a.ml/vocabularies/core#name"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -34133,7 +35715,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#120"
+"@value": "amf://id#133"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -34147,7 +35729,7 @@
 ]
 },
 {
-"@id": "amf://id#185",
+"@id": "amf://id#199",
 "@type": [
 "http://www.w3.org/ns/shacl#NodeShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -34161,7 +35743,7 @@
 ],
 "http://www.w3.org/ns/shacl#property": [
 {
-"@id": "amf://id#186",
+"@id": "amf://id#200",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -34174,7 +35756,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#187",
+"@id": "amf://id#201",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -34191,16 +35773,18 @@
 "@value": "kind"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "This is always drive#property."
 }
 ],
 "http://www.w3.org/ns/shacl#defaultValue": [
 {
-"@id": "amf://id#188",
+"@id": "amf://id#202",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -34210,7 +35794,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#188/source-map",
+"@id": "amf://id#202/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -34218,7 +35802,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#188"
+"@value": "amf://id#202"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -34234,13 +35818,15 @@
 ],
 "http://www.w3.org/ns/shacl#in": [
 {
-"@id": "amf://id#187/list",
+"@id": "amf://id#201/list",
 "@type": "http://www.w3.org/2000/01/rdf-schema#Seq",
 "http://www.w3.org/2000/01/rdf-schema#_1": [
 {
-"@id": "amf://id#189",
+"@id": "amf://id#203",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -34250,7 +35836,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#189/source-map",
+"@id": "amf://id#203/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -34258,7 +35844,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#189"
+"@value": "amf://id#203"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -34281,7 +35867,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#187/source-map",
+"@id": "amf://id#201/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -34289,7 +35875,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#187"
+"@value": "amf://id#201"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -34315,7 +35901,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -34327,7 +35913,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#187"
+"@value": "amf://id#201"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -34377,7 +35963,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#186/source-map",
+"@id": "amf://id#200/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -34385,7 +35971,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#186"
+"@value": "amf://id#200"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -34399,7 +35985,7 @@
 ]
 },
 {
-"@id": "amf://id#190",
+"@id": "amf://id#204",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -34412,7 +35998,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#191",
+"@id": "amf://id#205",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -34429,14 +36015,14 @@
 "@value": "etag"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "ETag of the property."
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#191/source-map",
+"@id": "amf://id#205/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -34444,7 +36030,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#191"
+"@value": "amf://id#205"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -34458,7 +36044,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -34470,7 +36056,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#191"
+"@value": "amf://id#205"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -34508,7 +36094,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#190/source-map",
+"@id": "amf://id#204/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -34516,7 +36102,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#190"
+"@value": "amf://id#204"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -34530,7 +36116,7 @@
 ]
 },
 {
-"@id": "amf://id#192",
+"@id": "amf://id#206",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -34543,7 +36129,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#193",
+"@id": "amf://id#207",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -34560,14 +36146,14 @@
 "@value": "selfLink"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "The link back to this property."
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#193/source-map",
+"@id": "amf://id#207/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -34575,7 +36161,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#193"
+"@value": "amf://id#207"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -34589,7 +36175,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -34601,7 +36187,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#193"
+"@value": "amf://id#207"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -34639,7 +36225,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#192/source-map",
+"@id": "amf://id#206/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -34647,7 +36233,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#192"
+"@value": "amf://id#206"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -34661,7 +36247,7 @@
 ]
 },
 {
-"@id": "amf://id#194",
+"@id": "amf://id#208",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -34674,7 +36260,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#195",
+"@id": "amf://id#209",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -34691,14 +36277,14 @@
 "@value": "key"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "The key of this property."
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#195/source-map",
+"@id": "amf://id#209/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -34706,7 +36292,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#195"
+"@value": "amf://id#209"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -34720,7 +36306,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -34732,7 +36318,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#195"
+"@value": "amf://id#209"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -34770,7 +36356,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#194/source-map",
+"@id": "amf://id#208/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -34778,7 +36364,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#194"
+"@value": "amf://id#208"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -34792,7 +36378,7 @@
 ]
 },
 {
-"@id": "amf://id#196",
+"@id": "amf://id#210",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -34805,7 +36391,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#197",
+"@id": "amf://id#211",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -34822,14 +36408,14 @@
 "@value": "visibility"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "The visibility of this property."
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#197/source-map",
+"@id": "amf://id#211/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -34837,7 +36423,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#197"
+"@value": "amf://id#211"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -34851,7 +36437,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -34863,7 +36449,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#197"
+"@value": "amf://id#211"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -34901,7 +36487,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#196/source-map",
+"@id": "amf://id#210/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -34909,7 +36495,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#196"
+"@value": "amf://id#210"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -34923,7 +36509,7 @@
 ]
 },
 {
-"@id": "amf://id#198",
+"@id": "amf://id#212",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -34936,7 +36522,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#199",
+"@id": "amf://id#213",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -34953,14 +36539,14 @@
 "@value": "value"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "The value of this property."
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#199/source-map",
+"@id": "amf://id#213/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -34968,7 +36554,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#199"
+"@value": "amf://id#213"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -34982,7 +36568,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -34994,7 +36580,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#199"
+"@value": "amf://id#213"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -35032,7 +36618,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#198/source-map",
+"@id": "amf://id#212/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -35040,7 +36626,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#198"
+"@value": "amf://id#212"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -35061,7 +36647,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#185/source-map",
+"@id": "amf://id#199/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -35069,7 +36655,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#185"
+"@value": "amf://id#199"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -35095,7 +36681,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#185"
+"@value": "amf://id#199"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -35109,7 +36695,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#185"
+"@value": "amf://id#199"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -35123,12 +36709,12 @@
 ]
 },
 {
-"@id": "amf://id#200",
+"@id": "amf://id#214",
 "@type": [
 "http://a.ml/vocabularies/security#SecurityScheme",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://a.ml/vocabularies/security#name": [
+"http://a.ml/vocabularies/core#name": [
 {
 "@value": "basic"
 }
@@ -35138,14 +36724,14 @@
 "@value": "Basic Authentication"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "Test basic auth method\n"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#200/source-map",
+"@id": "amf://id#214/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -35153,7 +36739,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#200"
+"@value": "amf://id#214"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -35167,7 +36753,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -35179,7 +36765,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://a.ml/vocabularies/security#name"
+"@value": "http://a.ml/vocabularies/core#name"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -35191,7 +36777,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#200"
+"@value": "amf://id#214"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -35217,12 +36803,12 @@
 ]
 },
 {
-"@id": "amf://id#201",
+"@id": "amf://id#215",
 "@type": [
 "http://a.ml/vocabularies/security#SecurityScheme",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
-"http://a.ml/vocabularies/security#name": [
+"http://a.ml/vocabularies/core#name": [
 {
 "@value": "other"
 }
@@ -35232,14 +36818,14 @@
 "@value": "Digest Authentication"
 }
 ],
-"http://schema.org/displayName": [
+"http://a.ml/vocabularies/core#displayName": [
 {
 "@value": "Digest"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#201/source-map",
+"@id": "amf://id#215/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -35247,7 +36833,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#201"
+"@value": "amf://id#215"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -35261,7 +36847,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/displayName"
+"@value": "http://a.ml/vocabularies/core#displayName"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -35273,7 +36859,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://a.ml/vocabularies/security#name"
+"@value": "http://a.ml/vocabularies/core#name"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -35285,7 +36871,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#201"
+"@value": "amf://id#215"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -35311,7 +36897,7 @@
 ]
 },
 {
-"@id": "amf://id#27",
+"@id": "amf://id#29",
 "@type": [
 "http://www.w3.org/ns/shacl#NodeShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -35325,7 +36911,7 @@
 ],
 "http://www.w3.org/ns/shacl#property": [
 {
-"@id": "amf://id#28",
+"@id": "amf://id#30",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -35338,7 +36924,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#29",
+"@id": "amf://id#31",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -35357,7 +36943,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#29/source-map",
+"@id": "amf://id#31/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -35365,7 +36951,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#29"
+"@value": "amf://id#31"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -35391,7 +36977,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#28/source-map",
+"@id": "amf://id#30/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -35399,7 +36985,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#28"
+"@value": "amf://id#30"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -35420,7 +37006,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#27/source-map",
+"@id": "amf://id#29/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -35428,7 +37014,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#27"
+"@value": "amf://id#29"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -35454,7 +37040,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#27"
+"@value": "amf://id#29"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -35468,7 +37054,7 @@
 ]
 },
 {
-"@id": "amf://id#61",
+"@id": "amf://id#68",
 "@type": [
 "http://a.ml/vocabularies/shapes#UnionShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -35476,7 +37062,7 @@
 ],
 "http://a.ml/vocabularies/shapes#anyOf": [
 {
-"@id": "amf://id#62",
+"@id": "amf://id#69",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -35490,7 +37076,7 @@
 ]
 },
 {
-"@id": "amf://id#63",
+"@id": "amf://id#70",
 "@type": [
 "http://a.ml/vocabularies/shapes#NilShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -35505,7 +37091,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#61/source-map",
+"@id": "amf://id#68/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -35513,7 +37099,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#61"
+"@value": "amf://id#68"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -35527,7 +37113,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#61"
+"@value": "amf://id#68"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -35541,7 +37127,7 @@
 ]
 },
 {
-"@id": "amf://id#18",
+"@id": "amf://id#19",
 "@type": [
 "http://www.w3.org/ns/shacl#NodeShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -35555,7 +37141,7 @@
 ],
 "http://www.w3.org/ns/shacl#property": [
 {
-"@id": "amf://id#19",
+"@id": "amf://id#20",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -35568,7 +37154,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#20",
+"@id": "amf://id#21",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -35585,14 +37171,14 @@
 "@value": "url"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "The URL of the image.\nTo resize the image and crop it to a square, append the query string **?sz=x**, where x is the dimension in pixels of each side.\n"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#20/source-map",
+"@id": "amf://id#21/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -35600,7 +37186,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#20"
+"@value": "amf://id#21"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -35614,7 +37200,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -35626,7 +37212,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#20"
+"@value": "amf://id#21"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -35664,7 +37250,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#19/source-map",
+"@id": "amf://id#20/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -35672,7 +37258,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#19"
+"@value": "amf://id#20"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -35686,7 +37272,7 @@
 ]
 },
 {
-"@id": "amf://id#21",
+"@id": "amf://id#22",
 "@type": [
 "http://www.w3.org/ns/shacl#PropertyShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -35699,7 +37285,7 @@
 ],
 "http://a.ml/vocabularies/shapes#range": [
 {
-"@id": "amf://id#22",
+"@id": "amf://id#23",
 "@type": [
 "http://a.ml/vocabularies/shapes#ScalarShape",
 "http://www.w3.org/ns/shacl#Shape",
@@ -35716,19 +37302,19 @@
 "@value": "thumb"
 }
 ],
-"http://schema.org/name": [
+"http://a.ml/vocabularies/core#name": [
 {
 "@value": "Thumbnail"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "An URL to the thumbnail of the image. Thumbnails are 60x60px cropped images of the original image.\n"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#22/source-map",
+"@id": "amf://id#23/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -35736,7 +37322,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#22"
+"@value": "amf://id#23"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -35750,7 +37336,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -35774,7 +37360,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#22"
+"@value": "amf://id#23"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -35786,7 +37372,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/name"
+"@value": "http://a.ml/vocabularies/core#name"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -35812,7 +37398,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#21/source-map",
+"@id": "amf://id#22/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -35820,7 +37406,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#21"
+"@value": "amf://id#22"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -35839,16 +37425,23 @@
 "@value": "amf_inline_type_2"
 }
 ],
-"http://schema.org/description": [
+"http://a.ml/vocabularies/core#description": [
 {
 "@value": "An image object representing an image object strored in the file store.\nThe image can be only included in the response. It has no effect if the Image appear in the\nrequest. Endpoint handles image creation on it's own and clients can't process images\nexcept of sending image data.\n"
 }
 ],
-"http://a.ml/vocabularies/document#examples": [
+"http://a.ml/vocabularies/apiContract#examples": [
 {
-"@id": "amf://id#23",
+"@id": "amf://id#24",
 "@type": [
-"http://a.ml/vocabularies/document#Example",
+"http://a.ml/vocabularies/apiContract#NamedExamples",
+"http://a.ml/vocabularies/document#DomainElement"
+],
+"http://a.ml/vocabularies/apiContract#examples": [
+{
+"@id": "amf://id#25",
+"@type": [
+"http://a.ml/vocabularies/apiContract#Example",
 "http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/document#strict": [
@@ -35858,15 +37451,19 @@
 ],
 "http://a.ml/vocabularies/document#structuredValue": [
 {
-"@id": "amf://id#23",
+"@id": "amf://id#25",
 "@type": [
-"http://a.ml/vocabularies/data#Object"
+"http://a.ml/vocabularies/data#Object",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#thumb": [
 {
-"@id": "amf://id#24",
+"@id": "amf://id#26",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -35876,7 +37473,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#24/source-map",
+"@id": "amf://id#26/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -35884,7 +37481,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#24"
+"@value": "amf://id#26"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -35900,9 +37497,11 @@
 ],
 "http://a.ml/vocabularies/data#url": [
 {
-"@id": "amf://id#25",
+"@id": "amf://id#27",
 "@type": [
-"http://a.ml/vocabularies/data#Scalar"
+"http://a.ml/vocabularies/data#Scalar",
+"http://a.ml/vocabularies/data#Node",
+"http://a.ml/vocabularies/document#DomainElement"
 ],
 "http://a.ml/vocabularies/data#value": [
 {
@@ -35912,7 +37511,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#25/source-map",
+"@id": "amf://id#27/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -35920,7 +37519,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#25"
+"@value": "amf://id#27"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -35936,7 +37535,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#23/source-map",
+"@id": "amf://id#25/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -35944,12 +37543,36 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#23"
+"@value": "http://a.ml/vocabularies/data#url"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(22,7)-(22,52)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "amf://id#25"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
 {
 "@value": "[(22,0)-(24,0)]"
+}
+]
+},
+{
+"http://a.ml/vocabularies/document-source-maps#element": [
+{
+"@value": "http://a.ml/vocabularies/data#thumb"
+}
+],
+"http://a.ml/vocabularies/document-source-maps#value": [
+{
+"@value": "[(23,9)-(23,60)]"
 }
 ]
 }
@@ -35958,7 +37581,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#23"
+"@value": "amf://id#25"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -35979,7 +37602,7 @@
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#23/source-map",
+"@id": "amf://id#25/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -36013,7 +37636,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#23"
+"@value": "amf://id#25"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -36026,10 +37649,12 @@
 }
 ]
 }
+]
+}
 ],
 "http://a.ml/vocabularies/document-source-maps#sources": [
 {
-"@id": "amf://id#18/source-map",
+"@id": "amf://id#19/source-map",
 "@type": [
 "http://a.ml/vocabularies/document-source-maps#SourceMap"
 ],
@@ -36037,7 +37662,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#18"
+"@value": "amf://id#19"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -36051,7 +37676,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#18"
+"@value": "amf://id#19"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -36065,7 +37690,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "http://schema.org/description"
+"@value": "http://a.ml/vocabularies/core#description"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -36077,7 +37702,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#18"
+"@value": "amf://id#19"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [
@@ -36091,7 +37716,7 @@
 {
 "http://a.ml/vocabularies/document-source-maps#element": [
 {
-"@value": "amf://id#18"
+"@value": "amf://id#19"
 }
 ],
 "http://a.ml/vocabularies/document-source-maps#value": [


### PR DESCRIPTION
Namespaces like schema.org and hydra have been deprecated and replaced by new aml namespaces (aml.core and aml.apiContract).

This commit updates the helpers and map the old ones to the new values.