### PR TITLE
feat(servers): add support for partial model when getting servers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/amf-helper-mixin",
   "description": "A mixin with common functions user by most AMF components to compyte AMF values",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "license": "Apache-2.0",
   "main": "index.js",
   "module": "index.js",

--- a/src/AmfHelperMixin.js
+++ b/src/AmfHelperMixin.js
@@ -510,6 +510,17 @@ export const AmfHelperMixin = (base) => class extends base {
     const srv = this._ensureArray(api[key]);
     return srv ? srv[0] : undefined;
   }
+
+  /**
+   * Determines whether a partial model is valid for reading servers from
+   * Current valid values:
+   * - Operation
+   * - Endpoint
+   * @param {Object} model The partial model to evaluate
+   * @return {boolean} Whether the model's type is part of the array of valid node types from which
+   * to read servers
+   * @private
+   */
   _isValidServerPartial(model) {
     if (!model) {
       return false;
@@ -525,6 +536,7 @@ export const AmfHelperMixin = (base) => class extends base {
     }
     return false;
   }
+
   /**
    * @param {Object} options
    * @param {string=} options.endpointId Optional endpoint to look for the servers in

--- a/test/amf-helper-mixin.test.js
+++ b/test/amf-helper-mixin.test.js
@@ -1,4 +1,4 @@
-import { fixture, assert, html } from '@open-wc/testing';
+import { assert, fixture, html } from '@open-wc/testing';
 import * as sinon from 'sinon';
 import { AmfLoader } from './amf-loader.js';
 import './test-element.js';
@@ -1243,12 +1243,13 @@ describe('AmfHelperMixin', function() {
         });
 
         describe('OAS', () => {
-          const methodId = `${compact ? '' : 'amf://id'}#23`;
+          let methodId;
           // TODO uncomment this once AMF model has resolved servers on all levels
           // const endpointId = `${compact ? '' : 'amf://id'}#22`;
 
           before(async () => {
             model = await AmfLoader.load(compact, 'multiple-servers');
+            methodId = AmfLoader.lookupOperation(model, '/pets', 'get')['@id'];
           });
 
           after(async () => {
@@ -1282,6 +1283,15 @@ describe('AmfHelperMixin', function() {
             it('Returns undefined if no model', async () => {
               element = await modelFixture();
               assert.isUndefined(element._getServers({}));
+            });
+
+            it('Returns all method servers for partial model', () => {
+              const operation = { ...AmfLoader.lookupOperation(model, '/pets', 'get') };
+              operation['@context'] = (model[0] || model)['@context'];
+              element.amf = operation;
+              const servers = element._getServers({ methodId });
+              assert.typeOf(servers, 'array');
+              assert.lengthOf(servers, 2);
             });
           });
         });


### PR DESCRIPTION
When computing the servers for the model, take into account that it may be a partial model.

Currently supporting:
- Endpoints
- Operations

Also fix a test by removing a hardcoded id value.