### PR TITLE
Account for models that are wrapped in an array

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,5 @@ coverage
 # AMF models
 /test/*.json
 !test/apis.json
+
+.idea/

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -19,7 +19,7 @@ module.exports = (config) => {
 
       client: {
         mocha: {
-          timeout: 15000
+          timeout: 20000
         }
       },
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/amf-helper-mixin",
   "description": "A mixin with common functions user by most AMF components to compyte AMF values",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "license": "Apache-2.0",
   "main": "index.js",
   "module": "index.js",

--- a/src/AmfHelperMixin.js
+++ b/src/AmfHelperMixin.js
@@ -522,6 +522,9 @@ export const AmfHelperMixin = (base) => class extends base {
    * @private
    */
   _isValidServerPartial(model) {
+    if (Array.isArray(model)) {
+      model = model[0];
+    }
     if (!model) {
       return false;
     }

--- a/test/amf-helper-mixin.test.js
+++ b/test/amf-helper-mixin.test.js
@@ -2103,6 +2103,65 @@ describe('AmfHelperMixin', function() {
           assert.deepEqual(result, { '@id': '1'});
         });
       });
+
+			describe('_isValidServerPartial()', () => {
+				describe('with mock objects', () => {
+					describe('not in arrays', () =>{
+						it('should return true for endpoint type', () => {
+							const endpointKey = element._getAmfKey(element.ns.aml.vocabularies.apiContract.EndPoint);
+							const model = { '@type': [endpointKey] }
+							assert.isTrue(element._isValidServerPartial(model));
+						});
+
+						it('should return true for method type', () => {
+							const methodKey = element._getAmfKey(element.ns.aml.vocabularies.apiContract.Operation);
+							const model = { '@type': [methodKey] }
+							assert.isTrue(element._isValidServerPartial(model));
+						});
+
+						it('should return false for any other type', () => {
+							const otherKey = element._getAmfKey(element.ns.aml.vocabularies.apiContract.WebAPI);
+							const model = { '@type': [otherKey] }
+							assert.isFalse(element._isValidServerPartial(model));
+						});
+					});
+					describe('in arrays', () =>{
+						it('should return true for endpoint type', () => {
+							const endpointKey = element._getAmfKey(element.ns.aml.vocabularies.apiContract.EndPoint);
+							const model = { '@type': [endpointKey] }
+							assert.isTrue(element._isValidServerPartial([model]));
+						});
+
+						it('should return true for method type', () => {
+							const methodKey = element._getAmfKey(element.ns.aml.vocabularies.apiContract.Operation);
+							const model = { '@type': [methodKey] }
+							assert.isTrue(element._isValidServerPartial([model]));
+						});
+
+						it('should return false for any other type', () => {
+							const otherKey = element._getAmfKey(element.ns.aml.vocabularies.apiContract.WebAPI);
+							const model = { '@type': [otherKey] }
+							assert.isFalse(element._isValidServerPartial([model]));
+						});
+					})
+				});
+
+				describe('with real nodes', () => {
+					it('should return true for endpoint type', () => {
+						const endpoint = AmfLoader.lookupEndpoint(model, '/files');
+						assert.isTrue(element._isValidServerPartial(endpoint));
+					});
+
+					it('should return true for method type', () => {
+						const method = AmfLoader.lookupOperation(model, '/files', 'get');
+						assert.isTrue(element._isValidServerPartial(method));
+					});
+
+					it('should return false for any other type', () => {
+						assert.isFalse(element._isValidServerPartial(model));
+					});
+				})
+			});
       // Keys caching is only enabled for compact model that requires additional
       // computations.
       (compact ? describe : describe.skip)('keys computation caching', () => {


### PR DESCRIPTION
Many times JsonLD nodes are wrapped in arrays in our model.

`_isValidServerPartial` now takes this into account and checks if is array before computing.

Add tests for this method as well, both with mocked nodes and actual nodes.