### PR TITLE
Add more namespace keys

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/amf-helper-mixin",
   "description": "A mixin with common functions user by most AMF components to compyte AMF values",
-  "version": "4.1.5",
+  "version": "4.1.6",
   "license": "Apache-2.0",
   "main": "index.js",
   "module": "index.js",

--- a/src/Namespace.d.ts
+++ b/src/Namespace.d.ts
@@ -154,6 +154,7 @@ interface Shapes {
   xmlName: string;
   xmlAttribute: string;
   xmlWrapped: string;
+  readOnly: string;
 }
 
 interface Data {
@@ -270,6 +271,9 @@ interface Shacl {
   raw: string;
   datatype: string;
   minCount: string;
+  xone: string;
+  not: string;
+  or: string;
 }
 
 interface W3 {

--- a/src/Namespace.js
+++ b/src/Namespace.js
@@ -257,6 +257,7 @@ ns.w3.shacl.name = n2shaclName + 'name';
 ns.w3.shacl.raw = n2shaclName + 'raw';
 ns.w3.shacl.datatype = n2shaclName + 'datatype';
 ns.w3.shacl.minCount = n2shaclName + 'minCount';
+ns.w3.shacl.xone = n2shaclName + 'xone'
 // Hydra shortcuts
 ns.w3.hydra.supportedOperation = contractKey + 'supportedOperation';
 // Schema org namespace

--- a/src/Namespace.js
+++ b/src/Namespace.js
@@ -258,8 +258,8 @@ ns.w3.shacl.raw = n2shaclName + 'raw';
 ns.w3.shacl.datatype = n2shaclName + 'datatype';
 ns.w3.shacl.minCount = n2shaclName + 'minCount';
 ns.w3.shacl.xone = n2shaclName + 'xone'
-ns.w3.shacl.xone = n2shaclName + 'not'
-ns.w3.shacl.xone = n2shaclName + 'or'
+ns.w3.shacl.not = n2shaclName + 'not'
+ns.w3.shacl.or = n2shaclName + 'or'
 // Hydra shortcuts
 ns.w3.hydra.supportedOperation = contractKey + 'supportedOperation';
 // Schema org namespace

--- a/src/Namespace.js
+++ b/src/Namespace.js
@@ -259,6 +259,7 @@ ns.w3.shacl.datatype = n2shaclName + 'datatype';
 ns.w3.shacl.minCount = n2shaclName + 'minCount';
 ns.w3.shacl.xone = n2shaclName + 'xone'
 ns.w3.shacl.xone = n2shaclName + 'not'
+ns.w3.shacl.xone = n2shaclName + 'or'
 // Hydra shortcuts
 ns.w3.hydra.supportedOperation = contractKey + 'supportedOperation';
 // Schema org namespace

--- a/src/Namespace.js
+++ b/src/Namespace.js
@@ -258,6 +258,7 @@ ns.w3.shacl.raw = n2shaclName + 'raw';
 ns.w3.shacl.datatype = n2shaclName + 'datatype';
 ns.w3.shacl.minCount = n2shaclName + 'minCount';
 ns.w3.shacl.xone = n2shaclName + 'xone'
+ns.w3.shacl.xone = n2shaclName + 'not'
 // Hydra shortcuts
 ns.w3.hydra.supportedOperation = contractKey + 'supportedOperation';
 // Schema org namespace

--- a/src/Namespace.js
+++ b/src/Namespace.js
@@ -165,6 +165,7 @@ ns.aml.vocabularies.shapes.xmlSerialization = shapesKey + 'xmlSerialization';
 ns.aml.vocabularies.shapes.xmlName = shapesKey + 'xmlName';
 ns.aml.vocabularies.shapes.xmlAttribute = shapesKey + 'xmlAttribute';
 ns.aml.vocabularies.shapes.xmlWrapped = shapesKey + 'xmlWrapped';
+ns.aml.vocabularies.shapes.readOnly = shapesKey + 'readOnly';
 ns.aml.vocabularies.data = {};
 const dataKey = ns.aml.vocabularies.data.key = ns.aml.vocabularies.key + 'data#';
 ns.aml.vocabularies.data.toString = () => dataKey;

--- a/test/amf-helper-mixin.test.js
+++ b/test/amf-helper-mixin.test.js
@@ -258,7 +258,10 @@ describe('AmfHelperMixin', function() {
             'Shape',
             'NodeShape',
             'SchemaShape',
-            'PropertyShape'
+            'PropertyShape',
+            'xone',
+            'not',
+            'or',
           ].forEach((name) => {
             assert.equal(s[name], key + name, name + ' is set');
           });
@@ -492,6 +495,7 @@ describe('AmfHelperMixin', function() {
           ['xmlName', key + 'xmlName'],
           ['xmlAttribute', key + 'xmlAttribute'],
           ['xmlWrapped', key + 'xmlWrapped'],
+          ['readOnly', key + 'readOnly'],
         ].forEach(([property, value]) => {
           it(`has value for ${property}`, () => {
             const result = element.ns.aml.vocabularies.shapes[property];


### PR DESCRIPTION
- `readOnly`
  - Add `readOnly` key to `ns.aml.vocabularies.shapes` for [properties in OAS 3 types that are defined as read only](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#fixed-fields-20)
- `xone`
  - Add `xone` key to `ns.w3.shacl` for types in OAS 3 defined with `oneOf`
- `not`
  - Add `not` key to `ns.w3.shacl` for types in OAS 3 defined with `not`
- `or`
  - Add `or` key to `ns.w3.shacl` for types in OAS 3 defined with `anyOf`