### PR TITLE
Apic 498/missing query parameters

### DIFF
--- a/src/AmfHelperMixin.js
+++ b/src/AmfHelperMixin.js
@@ -687,9 +687,10 @@ export const AmfHelperMixin = (base) => class extends base {
    * `{version}` from the URI template.
    * @param {boolean=} [opts.ignoreBase = false] Whether or not to ignore rendering
    * of the base URI with path.
+   * @param {boolean=} [opts.method] Model for the method
    * @return {string} The base uri for the endpoint.
    */
-  _computeUri(endpoint, { server, baseUri, version, ignoreBase=false } = {}) {
+  _computeUri(endpoint, { server, baseUri, version, ignoreBase=false, method } = {}) {
     let baseValue = '';
     if (ignoreBase === false) {
       baseValue = this._getBaseUri(baseUri, server) || '';
@@ -703,7 +704,29 @@ export const AmfHelperMixin = (base) => class extends base {
     if (version && result) {
       result = result.replace('{version}', version);
     }
-    return result;
+    const queryParams = this._computeMethodParameters(method);
+    return result + queryParams;
+  }
+
+  _computeMethodParameters(method) {
+    let queryParams = '';
+    if (!method) {
+      return queryParams
+    }
+
+    const expects = this._computeExpects(method);
+    const params = this._computeQueryParameters(expects);
+    if (params) {
+      params.forEach(param => {
+        const paramName = this._getValue(param, this.ns.aml.vocabularies.apiContract.paramName);
+        const paramExample = this._computePropertyValue(param);
+        if (paramName && paramExample) {
+          queryParams = `${queryParams ? '&' : '?'}${paramName}=${paramExample}`
+        }
+      });
+    }
+
+    return queryParams
   }
 
   /**

--- a/test/amf-helper-mixin.test.js
+++ b/test/amf-helper-mixin.test.js
@@ -1402,7 +1402,7 @@ describe('AmfHelperMixin', () => {
         it('Returns a loist of endpoints', () => {
           const result = element._computeEndpoints(webApi);
           assert.typeOf(result, 'array');
-          assert.lengthOf(result, 35);
+          assert.lengthOf(result, 36);
         });
       });
 

--- a/test/demo-api/demo-api.raml
+++ b/test/demo-api/demo-api.raml
@@ -391,3 +391,10 @@ types:
     body:
       application/json:
         type: !include types/external-type.raml
+/mail:
+  get:
+    queryParameters:
+      box:
+        type: string
+        example: "foo"
+        required: true


### PR DESCRIPTION
Bug: When computing uri for an endpoint, query parameters are missing
For example when computing uri for GET /mail, 
```
/mail:
  get:
    queryParameters:
      box:
        type: string
        example: "foo"
        required: true
```

it will return _/mail_. Now, we are contemplating both endpoint and method and for GET /mail will return _/mail?box=foo_