### PR TITLE
Fix/compute api backwards compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@api-components/amf-helper-mixin",
-  "version": "4.3.4",
+  "version": "4.3.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/amf-helper-mixin",
   "description": "A mixin with common functions user by most AMF components to compute AMF values",
-  "version": "4.3.4",
+  "version": "4.3.5",
   "license": "Apache-2.0",
   "main": "index.js",
   "module": "index.js",
@@ -25,7 +25,6 @@
     "url": "https://github.com/advanced-rest-client/amf-helper-mixin/issues",
     "email": "arc@mulesoft.com"
   },
-  "dependencies": {},
   "devDependencies": {
     "@api-components/api-model-generator": "^0.2.8",
     "@open-wc/eslint-config": "^4.2.0",

--- a/src/AmfHelperMixin.js
+++ b/src/AmfHelperMixin.js
@@ -558,7 +558,7 @@ export const AmfHelperMixin = (base) => class extends base {
     if (!enc) {
       return undefined;
     }
-    if (this._hasType(enc, this.ns.aml.vocabularies.apiContract.API)) {
+    if (this._isAPI(model) || this._isWebAPI(model) || this._isAsyncAPI(model)) {
       return enc;
     }
     return undefined;

--- a/test/amf-helper-mixin.test.js
+++ b/test/amf-helper-mixin.test.js
@@ -1241,6 +1241,16 @@ describe('AmfHelperMixin', () => {
             const result = element._computeApi(asyncModel);
             assert.typeOf(result, 'object');
           });
+
+          it('should return encodes if API type is missing but WebAPI type is present', () => {
+            const key = element._getAmfKey(element.ns.aml.vocabularies.document.encodes);
+            const webApiKey = element._getAmfKey(element.ns.aml.vocabularies.apiContract.WebAPI);
+            const amfModel = {};
+            amfModel[key] = {
+              '@type': [webApiKey]
+            };
+            assert.typeOf(element._computeApi(amfModel), 'object');
+          });
         });
 
         describe('AsyncAPI', () => {
@@ -1251,6 +1261,16 @@ describe('AmfHelperMixin', () => {
           it('should return encodes node from AMF model', () => {
             const result = element._computeApi(asyncModel);
             assert.typeOf(result, 'object');
+          });
+
+          it('should return encodes if API type is missing but WebAPI type is present', () => {
+            const key = element._getAmfKey(element.ns.aml.vocabularies.document.encodes);
+            const asyncApiKey = element._getAmfKey(element.ns.aml.vocabularies.apiContract.AsyncAPI);
+            const amfModel = {};
+            amfModel[key] = {
+              '@type': [asyncApiKey]
+            };
+            assert.typeOf(element._computeApi(amfModel), 'object');
           });
         });
       });
@@ -1680,9 +1700,7 @@ describe('AmfHelperMixin', () => {
 
         it('Returns type in references (library)', () => {
           const dKey = element._getAmfKey(element.ns.aml.vocabularies.document.declares);
-          const library = references.find((unit) => {
-            return unit['@type'].find((t) => t.indexOf('Module') !== -1);
-          });
+          const library = references.find((unit) => unit['@type'].find((t) => t.indexOf('Module') !== -1));
           // let ref = references[4][dKey][0];
           let ref = library[dKey][0];
           if (ref instanceof Array) {
@@ -1698,9 +1716,7 @@ describe('AmfHelperMixin', () => {
 
         it('Returns type in references (library) when no declarations', () => {
           const dKey = element._getAmfKey(element.ns.aml.vocabularies.document.declares);
-          const library = references.find((unit) => {
-            return unit['@type'].find((t) => t.indexOf('Module') !== -1);
-          });
+          const library = references.find((unit) => unit['@type'].find((t) => t.indexOf('Module') !== -1));
           let ref = library[dKey][0];
           if (ref instanceof Array) {
             // eslint-disable-next-line prefer-destructuring
@@ -1756,9 +1772,7 @@ describe('AmfHelperMixin', () => {
         before(async () => {
           element = await modelFixture(model);
           const refs = element._computeReferences(model);
-          const ref = refs.find((unit) => {
-            return (unit['@type'] || []).find((t) => t.indexOf('ExternalFragment') !== -1);
-          });
+          const ref = refs.find((unit) => (unit['@type'] || []).find((t) => t.indexOf('ExternalFragment') !== -1));
           const enc = element._computeEncodes(ref);
           refId = enc['@id'];
         });


### PR DESCRIPTION
- `_computeApi` also accounts for WebAPI type and AsyncAPI type for backwards compatibility of AMF model