### PR TITLE
Upgrade amf-json-ld-lib

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2654,9 +2654,9 @@
       }
     },
     "amf-json-ld-lib": {
-      "version": "0.0.13",
-      "resolved": "https://registry.npmjs.org/amf-json-ld-lib/-/amf-json-ld-lib-0.0.13.tgz",
-      "integrity": "sha512-jv+jCh8kUb1+Ln9tKx7HvxlktxicBe2Pvxxmvoh/BN1ESFQnY3Xsm0X2I6CqcaVPdoDlyyRj7JM58YFXti+7vQ=="
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/amf-json-ld-lib/-/amf-json-ld-lib-0.0.14.tgz",
+      "integrity": "sha512-Gz5GIJum35HD1GCsr89nWIIbYsPH1khB8FZGPEJdKXXIi3ReG4ODKY9jlxd5Bb4Lu+f0J4KV2aIyVJ9GWiTQZg=="
     },
     "amf-shacl-node": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@api-components/amf-helper-mixin",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -87,6 +87,6 @@
     ]
   },
   "dependencies": {
-    "amf-json-ld-lib": "0.0.13"
+    "amf-json-ld-lib": "0.0.14"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/amf-helper-mixin",
   "description": "A mixin with common functions user by most AMF components to compute AMF values",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "license": "Apache-2.0",
   "main": "index.js",
   "module": "index.js",


### PR DESCRIPTION
Upgrading `amf-json-ld-lib` because of an error with using newer versions of node. Fixes #43 