### PR TITLE
Add `_computeAllExpects()` method

### DIFF
--- a/apis/apis.json
+++ b/apis/apis.json
@@ -10,6 +10,7 @@
   "secured-api/secured-api.raml": { "type": "RAML 1.0", "mime": "application/yaml" },
   "petstore/petstore.yaml":  { "type": "OAS 3.0", "mime": "application/yaml" },
   "APIC-483/APIC-483.raml":  { "type": "RAML 1.0" },
+  "multiple-messages/multiple-messages.yaml":  "ASYNC 2.0",
   "src": "apis",
   "dest": "apis"
 }

--- a/apis/multiple-messages/multiple-messages.yaml
+++ b/apis/multiple-messages/multiple-messages.yaml
@@ -1,0 +1,51 @@
+asyncapi: '2.0.0'
+info:
+  title: Multiple messages API
+  description: API with multiple messages
+  version: '1.0.0'
+  
+channels:
+  default-channel:
+    description: Default channel
+    publish:
+      description: Publish operation for default channel
+      message:
+          oneOf:
+            - $ref: '#/components/messages/MessageA'
+            - $ref: '#/components/messages/MessageB'
+
+components:
+
+  messages:
+    MessageA:
+      contentType: application/json
+      headers:
+        type: object
+        description: Message header
+        properties:
+          messageId:
+            description: Message ID field
+            type: string
+      payload:
+        type: object
+        description: Message payload
+        properties:
+          data1:
+            description: Data 1 field
+            type: string
+    MessageB:
+      contentType: application/json
+      headers:
+        type: object
+        description: Message header
+        properties:
+          messageId:
+            description: Message ID field
+            type: string
+      payload:
+        type: object
+        description: Message payload
+        properties:
+          data2:
+            description: Data 2 field
+            type: string

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@api-components/amf-helper-mixin",
-  "version": "4.5.19",
+  "version": "4.5.20",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/amf-helper-mixin",
   "description": "A mixin with common functions user by most AMF components to compute AMF values",
-  "version": "4.5.19",
+  "version": "4.5.20",
   "license": "Apache-2.0",
   "main": "index.js",
   "module": "index.js",

--- a/src/AmfHelperMixin.d.ts
+++ b/src/AmfHelperMixin.d.ts
@@ -444,6 +444,13 @@ interface AmfHelperMixin {
   _computeExpects(method: Operation): Request|undefined;
 
   /**
+   * Computes all values for the `expects` property.
+   *
+   * @param method AMF `supportedOperation` model
+   */
+  _computeAllExpects(method: Operation): Request[]|undefined;
+
+  /**
    * Tries to find an example value (whether it's default value or from an
    * example) to put it into snippet's values.
    *

--- a/src/AmfHelperMixin.js
+++ b/src/AmfHelperMixin.js
@@ -991,6 +991,25 @@ export const AmfHelperMixin = (base) => class extends base {
   }
 
   /**
+   * Computes all values for the `expects` property.
+   *
+   * @param {Operation} method AMF `supportedOperation` model
+   * @returns {Request[]}
+   */
+  _computeAllExpects(method) {
+    const operationKey = this.ns.aml.vocabularies.apiContract.Operation;
+    const expectsKey = this.ns.aml.vocabularies.apiContract.expects;
+    if (this._hasType(method, operationKey)) {
+      const key = this._getAmfKey(expectsKey);
+      const expects = this._ensureArray(method[key]);
+      if (expects) {
+        return Array.isArray(expects) ? expects : [expects];
+      }
+    }
+    return undefined;
+  }
+
+  /**
    * Finds an example value (whether it's default value or from an
    * example) to put it into snippet's values.
    *

--- a/test/helper/amf-helper-mixin.test.js
+++ b/test/helper/amf-helper-mixin.test.js
@@ -2175,17 +2175,11 @@ describe('AmfHelperMixin', () => {
         });
 
         describe('_computeAllExpects()', () => {
-          
-
           it('should return two items', () => {
             const expects = element._computeAllExpects(operation)
             assert.lengthOf(expects, 2);
           });
         });
-
-        it('should return two items when _compuetAllExpects() is called', () => {
-
-        })
       });
     });
   });

--- a/test/helper/amf-helper-mixin.test.js
+++ b/test/helper/amf-helper-mixin.test.js
@@ -2154,6 +2154,39 @@ describe('AmfHelperMixin', () => {
           assert.deepEqual(element.amf, expandedElement.amf)
         });
       });
+
+      describe('Multiple messages Async API', () => {
+        const multipleMessagesApi = 'multiple-messages';
+        let multipleMessagesModel;
+        let operation;
+
+        before(async () => {
+          multipleMessagesModel = await AmfLoader.load(compact, multipleMessagesApi);
+          
+        })
+
+        beforeEach(async () => {
+          element = await modelFixture(multipleMessagesModel);
+          const webApi = element._computeApi(multipleMessagesModel);
+          const endpoint = element._computeEndpointByPath(webApi, 'default-channel');
+          const key = element._getAmfKey(element.ns.aml.vocabularies.apiContract.supportedOperation);
+          // eslint-disable-next-line prefer-destructuring
+          operation = endpoint[key][0];
+        });
+
+        describe('_computeAllExpects()', () => {
+          
+
+          it('should return two items', () => {
+            const expects = element._computeAllExpects(operation)
+            assert.lengthOf(expects, 2);
+          });
+        });
+
+        it('should return two items when _compuetAllExpects() is called', () => {
+
+        })
+      });
     });
   });
 });


### PR DESCRIPTION
Async APIs can have multiple expects per operation, so we need to be able to support this.