### PR TITLE
@W-21045342 Fix: Agent codegenie icon not showing in compact AMF models

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@api-components/amf-helper-mixin",
-  "version": "4.5.35",
+  "version": "4.5.36",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@api-components/amf-helper-mixin",
-      "version": "4.5.35",
+      "version": "4.5.36",
       "license": "Apache-2.0",
       "dependencies": {
         "amf-json-ld-lib": "0.0.14"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/amf-helper-mixin",
   "description": "A mixin with common functions user by most AMF components to compute AMF values",
-  "version": "4.5.35",
+  "version": "4.5.36",
   "license": "Apache-2.0",
   "main": "index.js",
   "module": "index.js",

--- a/src/AmfHelperMixin.d.ts
+++ b/src/AmfHelperMixin.d.ts
@@ -861,6 +861,21 @@ interface AmfHelperMixin {
   _computeTopicValue(topicObj: Object, key: string): Array<any>|undefined;
 
   /**
+   * Gets normalized root model targets for searching in compact models
+   * @param excludeNode Optional node to exclude from search
+   * @returns Array of target nodes to search
+   */
+  _getRootModelTargets(excludeNode?: DomainElement): DomainElement[];
+
+  /**
+   * Searches for a property by multiple possible keys in target nodes
+   * @param targets Array of nodes to search in
+   * @param possibleKeys Array of keys to try
+   * @returns The found property, or undefined
+   */
+  _findPropertyByKeys(targets: DomainElement[], possibleKeys: string[]): Object|undefined;
+
+  /**
    * Resolves a custom domain property by ID, handling both # and amf://id# formats
    * @param node The AMF node to search in
    * @param propId The property ID to resolve (e.g., "#106" or "amf://id#106")
@@ -870,6 +885,8 @@ interface AmfHelperMixin {
 
   /**
    * Finds a custom domain property by searching for a specific key
+   * Recursively navigates through intermediate nodes that may have their own
+   * customDomainProperties pointing to other nodes, as required for Agent Topic metadata.
    * @param node The AMF node to search in
    * @param key The property key to find (e.g., agent key)
    * @returns The found property object, or undefined if not found


### PR DESCRIPTION
Enhance AmfHelperMixin with new utility methods for model target retrieval and property searching

- Added `_getRootModelTargets` method to normalize root model targets for searching in compact models.
- Introduced `_findPropertyByKeys` method to search for properties by multiple keys in target nodes.
- Updated TypeScript definitions to include the new methods and improved documentation for existing methods.


## Problem
The agent codegenie icon was not displaying for operations in `api-summary` component when loading compact AMF specifications. This occurred because `AmfHelperMixin` methods (`_computeAgents`, `_computeNodeAgent`) were not correctly resolving custom domain properties in compact models where:

1. Custom domain properties are stored in the root AMF model, not in the operation node
2. Intermediate nodes may have their own `customDomainProperties` pointing to other nodes (as explained by AMF developers)
3. Property references use IDs like `#10` but are stored under keys like `amf://id#10`

## Solution
Enhanced `AmfHelperMixin` to properly handle compact models by:

### 1. Recursive Navigation (`_findCustomDomainPropertyByKey`)
- Added recursive navigation through intermediate nodes that may have their own `customDomainProperties`
- Implemented cycle detection using visited IDs to prevent infinite loops
- Searches both in the provided node and in the root AMF model

### 2. Root Model Resolution (`_resolveCustomDomainProperty`)
- Enhanced to search in root model when property is not found in the provided node
- Handles both array and single-object root models (compact format)

### 3. Code Refactoring
- Created `_getRootModelTargets()` helper method to normalize root model access
- Created `_findPropertyByKeys()` helper method to search properties by multiple key formats
- Reduced code duplication and improved maintainability

## Changes
- `src/AmfHelperMixin.js`: Enhanced custom domain property resolution methods
- `src/AmfHelperMixin.d.ts`: Updated type definitions

## Testing
- ✅ Works with both expanded and compact AMF models
- ✅ Handles intermediate nodes with nested `customDomainProperties`
- ✅ Prevents infinite loops in recursive navigation
- ✅ Maintains backward compatibility

<img width="1152" height="626" alt="Screenshot 2026-01-28 at 12 35 02 AM" src="https://github.com/user-attachments/assets/9413b804-30dc-423e-b772-106f2af936cf" />

## Related
Fixes issue where agent codegenie icon was not displayed in `api-summary` component for compact specs.